### PR TITLE
Warlock updates

### DIFF
--- a/proto/warlock.proto
+++ b/proto/warlock.proto
@@ -77,6 +77,14 @@ enum WarlockRune {
 	RuneLegsDemonicPact       	  = 425464;
 	RuneLegsEverlastingAffliction = 412689;
 	RuneLegsIncinerate			  = 412758;
+
+	RuneBeltInvocation			  = 426243;
+	RuneBeltGrimoireOfSynergy	  = 426301;
+	RuneBeltShadowAndFlame		  = 426316;
+
+	RuneBootsDemonicKnowledge	  = 412732;
+	RuneBootsDanceOfTheWicked	  = 412798;
+	RuneBootsShadowflame		  = 426320;
 }
 
 message WarlockRotation {

--- a/sim/core/aura_helpers.go
+++ b/sim/core/aura_helpers.go
@@ -172,6 +172,10 @@ func MakeStackingAura(character *Character, config StackingStatAura) *Aura {
 
 // Returns the same Aura for chaining.
 func MakePermanent(aura *Aura) *Aura {
+	if aura == nil {
+		return nil
+	}
+
 	aura.Duration = NeverExpires
 	if aura.OnReset == nil {
 		aura.OnReset = func(aura *Aura, sim *Simulation) {

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -23,11 +23,11 @@ func applyDebuffEffects(target *Unit, targetIdx int, debuffs *proto.Debuffs, rai
 	}
 
 	if debuffs.CurseOfElements {
-		MakePermanent(CurseOfElementsAura(target))
+		MakePermanent(CurseOfElementsAura(target, level))
 	}
 
 	if debuffs.CurseOfShadow {
-		MakePermanent(CurseOfShadowAura(target))
+		MakePermanent(CurseOfShadowAura(target, level))
 	}
 
 	if debuffs.ImprovedScorch && targetIdx == 0 {
@@ -242,39 +242,80 @@ func JudgementOfLightAura(target *Unit) *Aura {
 	})
 }
 
-func CurseOfElementsAura(target *Unit) *Aura {
+func CurseOfElementsAura(target *Unit, playerLevel int32) *Aura {
+	if playerLevel < 40 {
+		return nil
+	}
+
+	spellID := map[int32]int32{
+		40: 1490,
+		50: 11721,
+		60: 11722,
+	}[playerLevel]
+
+	resistance := map[int32]float64{
+		40: 45,
+		50: 60,
+		60: 75,
+	}[playerLevel]
+
+	dmgMod := map[int32]float64{
+		40: 1.06,
+		50: 1.08,
+		60: 1.10,
+	}[playerLevel]
+
 	aura := target.GetOrRegisterAura(Aura{
 		Label:    "Curse of Elements",
-		ActionID: ActionID{SpellID: 47865},
+		ActionID: ActionID{SpellID: spellID},
 		Duration: time.Minute * 5,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.FireResistance: -75, stats.FrostResistance: -75})
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFire] *= 1.1
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFrost] *= 1.1
+			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.FireResistance: -resistance, stats.FrostResistance: -resistance})
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFire] *= dmgMod
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFrost] *= dmgMod
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.FireResistance: 75, stats.FrostResistance: 75})
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFire] /= 1.1
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFrost] /= 1.1
+			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.FireResistance: resistance, stats.FrostResistance: resistance})
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFire] /= dmgMod
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexFrost] /= dmgMod
 		},
 	})
 	return aura
 }
 
-func CurseOfShadowAura(target *Unit) *Aura {
+func CurseOfShadowAura(target *Unit, playerLevel int32) *Aura {
+	if playerLevel < 50 {
+		return nil
+	}
+
+	spellID := map[int32]int32{
+		50: 17862,
+		60: 17937,
+	}[playerLevel]
+
+	resistance := map[int32]float64{
+		50: 60,
+		60: 75,
+	}[playerLevel]
+
+	dmgMod := map[int32]float64{
+		50: 1.08,
+		60: 1.10,
+	}[playerLevel]
+
 	aura := target.GetOrRegisterAura(Aura{
 		Label:    "Curse of Shadow",
-		ActionID: ActionID{SpellID: 17937},
+		ActionID: ActionID{SpellID: spellID},
 		Duration: time.Minute * 5,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.ArcaneResistance: -75, stats.ShadowResistance: -75})
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexArcane] *= 1.1
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexShadow] *= 1.1
+			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.ArcaneResistance: -resistance, stats.ShadowResistance: -resistance})
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexArcane] *= dmgMod
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexShadow] *= dmgMod
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.ArcaneResistance: 75, stats.ShadowResistance: 75})
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexArcane] /= 1.1
-			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexShadow] /= 1.1
+			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.ArcaneResistance: resistance, stats.ShadowResistance: resistance})
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexArcane] /= dmgMod
+			aura.Unit.PseudoStats.SchoolDamageTakenMultiplier[stats.SchoolIndexShadow] /= dmgMod
 		},
 	})
 	return aura

--- a/sim/hunter/pet_abilities.go
+++ b/sim/hunter/pet_abilities.go
@@ -84,7 +84,7 @@ func (hp *HunterPet) newClaw() *core.Spell {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   hp.MeleeCritMultiplier(1, 0),
+		CritMultiplier:   hp.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -141,7 +141,7 @@ func (hp *HunterPet) newBite() *core.Spell {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   hp.MeleeCritMultiplier(1, 0),
+		CritMultiplier:   hp.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -193,7 +193,7 @@ func (hp *HunterPet) newLightningBreath() *core.Spell {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   hp.SpellCritMultiplier(1, 0),
+		CritMultiplier:   hp.DefaultSpellCritMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -54,18 +54,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0172
+  weights: 0.0178
   weights: 0
-  weights: 0.1175
-  weights: 0
-  weights: 0
+  weights: 0.11115
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.56387
-  weights: 0.26415
+  weights: 0
+  weights: 0
+  weights: 0.52631
+  weights: 0.25623
   weights: 0
   weights: 0
   weights: 0
@@ -101,64 +101,64 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 31.96529
-  tps: 31.96529
+  dps: 29.8897
+  tps: 29.8897
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 37.26375
-  tps: 37.26375
+  dps: 34.93739
+  tps: 34.93739
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 31.96529
-  tps: 31.96529
+  dps: 29.8897
+  tps: 29.8897
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StormshroudArmor"
  value: {
-  dps: 16.67222
-  tps: 16.67222
+  dps: 15.99758
+  tps: 15.99758
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 36.58624
-  tps: 36.58624
+  dps: 34.31395
+  tps: 34.31395
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 37.80008
-  tps: 33.75453
+  dps: 35.42004
+  tps: 31.59462
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-25-phase_1-Adaptive-phase_1-FullBuffs-LongMultiTarget"
  value: {
-  dps: 38.58011
-  tps: 34.73165
+  dps: 36.13213
+  tps: 32.48865
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-25-phase_1-Adaptive-phase_1-FullBuffs-LongSingleTarget"
  value: {
-  dps: 38.58011
-  tps: 34.73165
+  dps: 36.13213
+  tps: 32.48865
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-25-phase_1-Adaptive-phase_1-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 50.27069
-  tps: 44.26652
+  dps: 47.47092
+  tps: 41.71303
  }
 }
 dps_results: {
@@ -185,22 +185,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-25-phase_1-Adaptive-phase_1-FullBuffs-LongMultiTarget"
  value: {
-  dps: 38.13649
-  tps: 34.36437
+  dps: 35.71118
+  tps: 32.13922
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-25-phase_1-Adaptive-phase_1-FullBuffs-LongSingleTarget"
  value: {
-  dps: 38.13649
-  tps: 34.36437
+  dps: 35.71118
+  tps: 32.13922
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-25-phase_1-Adaptive-phase_1-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 50.27069
-  tps: 44.26652
+  dps: 47.47092
+  tps: 41.71303
  }
 }
 dps_results: {
@@ -227,7 +227,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 38.13649
-  tps: 34.36437
+  dps: 35.71118
+  tps: 32.13922
  }
 }

--- a/sim/warlock/_curses.go
+++ b/sim/warlock/_curses.go
@@ -6,39 +6,6 @@ import (
 	"github.com/wowsims/sod/sim/core"
 )
 
-func (warlock *Warlock) registerCurseOfElementsSpell() {
-	warlock.CurseOfElementsAuras = warlock.NewEnemyAuraArray(core.CurseOfElementsAura)
-
-	warlock.CurseOfElements = warlock.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 47865},
-		SpellSchool: core.SpellSchoolShadow,
-		ProcMask:    core.ProcMaskEmpty,
-		Flags:       core.SpellFlagAPL,
-
-		ManaCost: core.ManaCostOptions{
-			BaseCost:   0.1,
-			Multiplier: 1 - 0.02*float64(warlock.Talents.Suppression),
-		},
-		Cast: core.CastConfig{
-			DefaultCast: core.Cast{
-				GCD: core.GCDDefault - core.TernaryDuration(warlock.Talents.AmplifyCurse, 1, 0)*500*time.Millisecond,
-			},
-		},
-
-		ThreatMultiplier: 1 - 0.1*float64(warlock.Talents.ImprovedDrainSoul),
-		FlatThreatBonus:  156,
-
-		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
-			if result.Landed() {
-				warlock.CurseOfElementsAuras.Get(target).Activate(sim)
-			}
-		},
-
-		RelatedAuras: []core.AuraArray{warlock.CurseOfElementsAuras},
-	})
-}
-
 func (warlock *Warlock) registerCurseOfWeaknessSpell() {
 	warlock.CurseOfWeaknessAuras = warlock.NewEnemyAuraArray(func(target *core.Unit) *core.Aura {
 		return core.CurseOfWeaknessAura(target, warlock.Talents.ImprovedCurseOfWeakness)
@@ -113,62 +80,6 @@ func (warlock *Warlock) registerCurseOfTonguesSpell() {
 		},
 
 		RelatedAuras: []core.AuraArray{warlock.CurseOfTonguesAuras},
-	})
-}
-
-func (warlock *Warlock) registerCurseOfAgonySpell() {
-	numberOfTicks := 12
-	baseTickDmg := 145.0
-
-	warlock.CurseOfAgony = warlock.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 47864},
-		SpellSchool: core.SpellSchoolShadow,
-		Flags:       core.SpellFlagHauntSE | core.SpellFlagAPL,
-		ProcMask:    core.ProcMaskSpellDamage,
-
-		ManaCost: core.ManaCostOptions{
-			BaseCost:   0.1,
-			Multiplier: 1 - 0.02*float64(warlock.Talents.Suppression),
-		},
-		Cast: core.CastConfig{
-			DefaultCast: core.Cast{
-				GCD: core.GCDDefault - core.TernaryDuration(warlock.Talents.AmplifyCurse, 1, 0)*500*time.Millisecond,
-			},
-		},
-
-		DamageMultiplierAdditive: 1 +
-			0.03*float64(warlock.Talents.ShadowMastery) +
-			0.01*float64(warlock.Talents.Contagion) +
-			0.05*float64(warlock.Talents.ImprovedCurseOfAgony),
-		ThreatMultiplier: 1 - 0.1*float64(warlock.Talents.ImprovedDrainSoul),
-		FlatThreatBonus:  0,
-
-		Dot: core.DotConfig{
-			Aura: core.Aura{
-				Label: "CurseofAgony",
-			},
-			NumberOfTicks: numberOfTicks,
-			TickLength:    time.Second * 2,
-			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
-				dot.SnapshotBaseDamage = 0.5*baseTickDmg + 0.1*dot.Spell.SpellPower()
-				dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(dot.Spell.Unit.AttackTables[target.UnitIndex])
-			},
-			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickCounted)
-				if dot.TickCount%4 == 0 { // CoA ramp up
-					dot.SnapshotBaseDamage += 0.5 * baseTickDmg
-				}
-			},
-		},
-
-		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
-			if result.Landed() {
-				spell.SpellMetrics[target.UnitIndex].Hits--
-				warlock.CurseOfDoom.Dot(target).Cancel(sim)
-				spell.Dot(target).Apply(sim)
-			}
-		},
 	})
 }
 

--- a/sim/warlock/corruption.go
+++ b/sim/warlock/corruption.go
@@ -34,8 +34,10 @@ func (warlock *Warlock) getCorruptionConfig(rank int) core.SpellConfig {
 			},
 		},
 
-		BonusHitRating:   float64(warlock.Talents.Suppression) * 2 * core.CritRatingPerCritChance,
-		BonusCritRating:  0,
+		BonusHitRating:  float64(warlock.Talents.Suppression) * 2 * core.CritRatingPerCritChance,
+		BonusCritRating: 0,
+		DamageMultiplierAdditive: 1 +
+			0.02*float64(warlock.Talents.ShadowMastery),
 		DamageMultiplier: 1,
 		CritMultiplier:   1,
 		ThreatMultiplier: 1,

--- a/sim/warlock/curses.go
+++ b/sim/warlock/curses.go
@@ -31,8 +31,10 @@ func (warlock *Warlock) getCurseOfAgonyBaseConfig(rank int) core.SpellConfig {
 			},
 		},
 
-		BonusHitRating:   2 * float64(warlock.Talents.Suppression) * core.CritRatingPerCritChance,
-		DamageMultiplier: 1 + 0.02*float64(warlock.Talents.ImprovedCurseOfWeakness),
+		BonusHitRating: 2 * float64(warlock.Talents.Suppression) * core.CritRatingPerCritChance,
+		DamageMultiplier: 1 *
+			(1 + 0.02*float64(warlock.Talents.ImprovedCurseOfWeakness)) *
+			(1 + 0.02*float64(warlock.Talents.ShadowMastery)),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  0,
 
@@ -81,6 +83,153 @@ func (warlock *Warlock) registerCurseOfAgonySpell() {
 			warlock.CurseOfAgony = warlock.GetOrRegisterSpell(config)
 		}
 	}
+}
+
+func (warlock *Warlock) registerCurseOfRecklessnessSpell() {
+	playerLevel := warlock.Level
+
+	warlock.CurseOfRecklessnessAuras = warlock.NewEnemyAuraArray(core.CurseOfRecklessnessAura)
+
+	spellID := map[int32]int32{
+		25: 704,
+		40: 7658,
+		50: 7659,
+		60: 11717,
+	}[playerLevel]
+
+	manaCost := map[int32]float64{
+		25: 35.0,
+		40: 60.0,
+		50: 90.0,
+		60: 115.0,
+	}[playerLevel]
+
+	warlock.CurseOfRecklessness = warlock.RegisterSpell(core.SpellConfig{
+		ActionID:    core.ActionID{SpellID: spellID},
+		SpellSchool: core.SpellSchoolShadow,
+		ProcMask:    core.ProcMaskEmpty,
+		Flags:       core.SpellFlagAPL,
+
+		ManaCost: core.ManaCostOptions{
+			FlatCost: manaCost,
+		},
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: core.GCDDefault,
+			},
+		},
+
+		BonusHitRating:   float64(warlock.Talents.Suppression) * 2 * core.CritRatingPerCritChance,
+		ThreatMultiplier: 1,
+		FlatThreatBonus:  156,
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
+			if result.Landed() {
+				warlock.CurseOfRecklessnessAuras.Get(target).Activate(sim)
+			}
+		},
+
+		RelatedAuras: []core.AuraArray{warlock.CurseOfRecklessnessAuras},
+	})
+}
+
+func (warlock *Warlock) registerCurseOfElementsSpell() {
+	playerLevel := warlock.Level
+	if playerLevel < 40 {
+		return
+	}
+
+	warlock.CurseOfElementsAuras = warlock.NewEnemyAuraArray(core.CurseOfElementsAura)
+
+	spellID := map[int32]int32{
+		40: 1490,
+		50: 11721,
+		60: 11722,
+	}[playerLevel]
+
+	manaCost := map[int32]float64{
+		40: 100.0,
+		50: 150.0,
+		60: 200.0,
+	}[playerLevel]
+
+	warlock.CurseOfElements = warlock.RegisterSpell(core.SpellConfig{
+		ActionID:    core.ActionID{SpellID: spellID},
+		SpellSchool: core.SpellSchoolShadow,
+		ProcMask:    core.ProcMaskEmpty,
+		Flags:       core.SpellFlagAPL,
+
+		ManaCost: core.ManaCostOptions{
+			FlatCost: manaCost,
+		},
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: core.GCDDefault,
+			},
+		},
+
+		BonusHitRating:   float64(warlock.Talents.Suppression) * 2 * core.CritRatingPerCritChance,
+		ThreatMultiplier: 1,
+		FlatThreatBonus:  156,
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
+			if result.Landed() {
+				warlock.CurseOfElementsAuras.Get(target).Activate(sim)
+			}
+		},
+
+		RelatedAuras: []core.AuraArray{warlock.CurseOfElementsAuras},
+	})
+}
+
+func (warlock *Warlock) registerCurseOfShadowSpell() {
+	playerLevel := warlock.Level
+	if playerLevel < 50 {
+		return
+	}
+
+	warlock.CurseOfShadowAuras = warlock.NewEnemyAuraArray(core.CurseOfShadowAura)
+
+	spellID := map[int32]int32{
+		50: 17862,
+		60: 17937,
+	}[playerLevel]
+
+	manaCost := map[int32]float64{
+		50: 150.0,
+		60: 200.0,
+	}[playerLevel]
+
+	warlock.CurseOfShadow = warlock.RegisterSpell(core.SpellConfig{
+		ActionID:    core.ActionID{SpellID: spellID},
+		SpellSchool: core.SpellSchoolShadow,
+		ProcMask:    core.ProcMaskEmpty,
+		Flags:       core.SpellFlagAPL,
+
+		ManaCost: core.ManaCostOptions{
+			FlatCost: manaCost,
+		},
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: core.GCDDefault,
+			},
+		},
+
+		BonusHitRating:   float64(warlock.Talents.Suppression) * 2 * core.CritRatingPerCritChance,
+		ThreatMultiplier: 1,
+		FlatThreatBonus:  156,
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
+			if result.Landed() {
+				warlock.CurseOfShadowAuras.Get(target).Activate(sim)
+			}
+		},
+
+		RelatedAuras: []core.AuraArray{warlock.CurseOfShadowAuras},
+	})
 }
 
 func (warlock *Warlock) registerAmplifyCurseSpell() {

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -51,31 +51,31 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 7.97382
+  dps: 7.24893
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 8.09418
+  dps: 7.35834
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-destruction-AffItemSwap--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8.06923
+  dps: 7.33566
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-destruction-AffItemSwap--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8.06923
+  dps: 7.33566
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-destruction-AffItemSwap--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11.12498
+  dps: 10.11362
  }
 }
 dps_results: {
@@ -99,19 +99,19 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-destruction-Affliction Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8.06923
+  dps: 7.33566
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-destruction-Affliction Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8.06923
+  dps: 7.33566
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-destruction-Affliction Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11.12498
+  dps: 10.11362
  }
 }
 dps_results: {
@@ -135,6 +135,6 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 8.06923
+  dps: 7.33566
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -51,31 +51,31 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 14.1562
+  dps: 12.86928
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 14.21242
+  dps: 12.92039
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destruction-Demonology Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 14.14823
+  dps: 12.86203
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destruction-Demonology Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 14.14823
+  dps: 12.86203
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destruction-Demonology Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 19.7635
+  dps: 17.96682
  }
 }
 dps_results: {
@@ -99,22 +99,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destruction-Demonology Warlock-destruction-FullBuffs-LongMultiTarget"
  value: {
-  dps: 226.56036
-  tps: 471.14116
+  dps: 205.96397
+  tps: 452.33148
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destruction-Demonology Warlock-destruction-FullBuffs-LongSingleTarget"
  value: {
-  dps: 177.01686
-  tps: 170.43545
+  dps: 160.92442
+  tps: 156.14239
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destruction-Demonology Warlock-destruction-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 211.88769
-  tps: 187.62689
+  dps: 192.62518
+  tps: 170.94523
  }
 }
 dps_results: {
@@ -141,6 +141,6 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 14.14823
+  dps: 12.86203
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -51,31 +51,31 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 14.1562
+  dps: 12.86928
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 14.21242
+  dps: 12.92039
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destruction-Destruction Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 14.14823
+  dps: 12.86203
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destruction-Destruction Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 14.14823
+  dps: 12.86203
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destruction-Destruction Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 19.7635
+  dps: 17.96682
  }
 }
 dps_results: {
@@ -99,22 +99,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destruction-Destruction Warlock-destruction-FullBuffs-LongMultiTarget"
  value: {
-  dps: 226.56036
-  tps: 471.14116
+  dps: 205.96397
+  tps: 452.33148
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destruction-Destruction Warlock-destruction-FullBuffs-LongSingleTarget"
  value: {
-  dps: 177.01686
-  tps: 170.43545
+  dps: 160.92442
+  tps: 156.14239
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destruction-Destruction Warlock-destruction-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 211.88769
-  tps: 187.62689
+  dps: 192.62518
+  tps: 170.94523
  }
 }
 dps_results: {
@@ -141,6 +141,6 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 14.14823
+  dps: 12.86203
  }
 }

--- a/sim/warlock/drain_life.go
+++ b/sim/warlock/drain_life.go
@@ -45,9 +45,10 @@ func (warlock *Warlock) getDrainLifeBaseConfig(rank int) core.SpellConfig {
 			},
 		},
 
-		BonusHitRating:           float64(warlock.Talents.Suppression) * 2 * core.CritRatingPerCritChance,
-		DamageMultiplierAdditive: 1,
-		DamageMultiplier:         1 + 0.02*float64(warlock.Talents.ImprovedDrainLife),
+		BonusHitRating: float64(warlock.Talents.Suppression) * 2 * core.CritRatingPerCritChance,
+		DamageMultiplierAdditive: 1 +
+			0.02*float64(warlock.Talents.ShadowMastery),
+		DamageMultiplier: 1 + 0.02*float64(warlock.Talents.ImprovedDrainLife),
 
 		Dot: core.DotConfig{
 			Aura: core.Aura{
@@ -132,7 +133,6 @@ func (warlock *Warlock) getDrainLifeBaseConfig(rank int) core.SpellConfig {
 			Timer:    warlock.NewTimer(),
 			Duration: 15 * time.Second,
 		}
-		spellConfig.Flags |= core.SpellFlagPureDot
 	} else {
 		spellConfig.Flags |= core.SpellFlagChanneled
 	}

--- a/sim/warlock/haunt.go
+++ b/sim/warlock/haunt.go
@@ -55,9 +55,10 @@ func (warlock *Warlock) registerHauntSpell() {
 			},
 		},
 
-		DamageMultiplierAdditive: 1,
-		CritMultiplier:           warlock.SpellCritMultiplier(1, 0),
-		ThreatMultiplier:         1,
+		DamageMultiplierAdditive: 1 +
+			0.02*float64(warlock.Talents.ShadowMastery),
+		CritMultiplier:   warlock.SpellCritMultiplier(1, 0),
+		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(baseLowDamage, baseHighDamage) + spellCoeff*spell.SpellPower()

--- a/sim/warlock/incinerate.go
+++ b/sim/warlock/incinerate.go
@@ -57,6 +57,7 @@ func (warlock *Warlock) registerIncinerateSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			var baseDamage = sim.Roll(baseLowDamage, baseHightDamage) + spellCoeff*spell.SpellPower()
+
 			if warlock.LakeOfFireAuras != nil && warlock.LakeOfFireAuras.Get(target).IsActive() {
 				baseDamage *= 1.4
 			}

--- a/sim/warlock/pet.go
+++ b/sim/warlock/pet.go
@@ -36,16 +36,59 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 	case proto.WarlockOptions_Imp:
 		cfg.Name = "Imp"
 		cfg.PowerModifier = 0.33 // GetUnitPowerModifier("pet")
-		cfg.Stats = stats.Stats{
-			stats.Strength:  47,
-			stats.Agility:   25,
-			stats.Stamina:   70,
-			stats.Intellect: 94,
-			stats.Spirit:    95,
-			stats.Mana:      149,
-			stats.MP5:       0,
-			stats.MeleeCrit: 3.454 * core.CritRatingPerCritChance,
-			stats.SpellCrit: 0.9075 * core.CritRatingPerCritChance,
+		switch warlock.Level {
+		case 25:
+			cfg.Stats = stats.Stats{
+				stats.Strength:  47,
+				stats.Agility:   25,
+				stats.Stamina:   49,
+				stats.Intellect: 94,
+				stats.Spirit:    95,
+				stats.Mana:      149,
+				stats.MP5:       0,
+				stats.MeleeCrit: 3.454 * core.CritRatingPerCritChance,
+				stats.SpellCrit: 0.9075 * core.CritRatingPerCritChance,
+			}
+			break
+		case 40:
+			cfg.Stats = stats.Stats{
+				stats.Strength:  70,
+				stats.Agility:   29,
+				stats.Stamina:   67,
+				stats.Intellect: 163,
+				stats.Spirit:    163,
+				stats.Mana:      149,
+				stats.MP5:       0,
+				stats.MeleeCrit: 3.454 * core.CritRatingPerCritChance,
+				stats.SpellCrit: 0.9075 * core.CritRatingPerCritChance,
+			}
+			break
+		case 50:
+			cfg.Stats = stats.Stats{
+				stats.Strength:  70,
+				stats.Agility:   29,
+				stats.Stamina:   67,
+				stats.Intellect: 163,
+				stats.Spirit:    163,
+				stats.Mana:      149,
+				stats.MP5:       0,
+				stats.MeleeCrit: 3.454 * core.CritRatingPerCritChance,
+				stats.SpellCrit: 0.9075 * core.CritRatingPerCritChance,
+			}
+			break
+		case 60:
+			cfg.Stats = stats.Stats{
+				stats.Strength:  70,
+				stats.Agility:   29,
+				stats.Stamina:   67,
+				stats.Intellect: 163,
+				stats.Spirit:    163,
+				stats.Mana:      149,
+				stats.MP5:       0,
+				stats.MeleeCrit: 3.454 * core.CritRatingPerCritChance,
+				stats.SpellCrit: 0.9075 * core.CritRatingPerCritChance,
+			}
+			break
 		}
 	case proto.WarlockOptions_Succubus:
 		cfg.Name = "Succubus"
@@ -53,9 +96,9 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 		cfg.Stats = stats.Stats{
 			stats.Strength:  50,
 			stats.Agility:   40,
-			stats.Stamina:   100,
-			stats.Intellect: 50,
-			stats.Spirit:    51,
+			stats.Stamina:   87,
+			stats.Intellect: 35,
+			stats.Spirit:    61,
 			stats.Mana:      60,
 			stats.MP5:       0,
 			stats.MeleeCrit: 3.2685 * core.CritRatingPerCritChance,
@@ -65,6 +108,29 @@ func (warlock *Warlock) NewWarlockPet() *WarlockPet {
 			MainHand: core.Weapon{
 				BaseDamageMin:  23,
 				BaseDamageMax:  38,
+				SwingSpeed:     2,
+				CritMultiplier: 2,
+			},
+			AutoSwingMelee: true,
+		}
+	case proto.WarlockOptions_Voidwalker:
+		cfg.Name = "Voidwalker"
+		cfg.PowerModifier = 0.77 // GetUnitPowerModifier("pet")
+		cfg.Stats = stats.Stats{
+			stats.Strength:  50,
+			stats.Agility:   40,
+			stats.Stamina:   87,
+			stats.Intellect: 35,
+			stats.Spirit:    61,
+			stats.Mana:      60,
+			stats.MP5:       0,
+			stats.MeleeCrit: 3.2685 * core.CritRatingPerCritChance,
+			stats.SpellCrit: 3.3355 * core.CritRatingPerCritChance,
+		}
+		cfg.AutoAttacks = core.AutoAttackOptions{
+			MainHand: core.Weapon{
+				BaseDamageMin:  2,
+				BaseDamageMax:  7,
 				SwingSpeed:     2,
 				CritMultiplier: 2,
 			},

--- a/sim/warlock/shadow_cleave.go
+++ b/sim/warlock/shadow_cleave.go
@@ -14,7 +14,7 @@ func (warlock *Warlock) getShadowCleaveBaseConfig(rank int) core.SpellConfig {
 	manaCost := [11]float64{0, 12, 20, 35, 55, 80, 105, 132, 157, 185, 190}[rank]
 	level := [11]int{0, 1, 6, 12, 20, 28, 36, 44, 52, 60, 60}[rank]
 
-	numHits := min(4, warlock.Env.GetNumTargets())
+	numHits := min(3, warlock.Env.GetNumTargets())
 	results := make([]*core.SpellResult, numHits)
 
 	return core.SpellConfig{
@@ -41,7 +41,9 @@ func (warlock *Warlock) getShadowCleaveBaseConfig(rank int) core.SpellConfig {
 			return warlock.MetamorphosisAura.IsActive()
 		},
 
-		BonusCritRating:  float64(warlock.Talents.Devastation) * core.SpellCritRatingPerCritChance,
+		BonusCritRating: float64(warlock.Talents.Devastation) * core.SpellCritRatingPerCritChance,
+		DamageMultiplierAdditive: 1 +
+			0.02*float64(warlock.Talents.ShadowMastery),
 		DamageMultiplier: 1,
 		CritMultiplier:   warlock.SpellCritMultiplier(1, core.TernaryFloat64(warlock.Talents.Ruin, 1, 0)),
 		ThreatMultiplier: 1,

--- a/sim/warlock/shadowbolt.go
+++ b/sim/warlock/shadowbolt.go
@@ -42,7 +42,9 @@ func (warlock *Warlock) getShadowBoltBaseConfig(rank int) core.SpellConfig {
 			return warlock.MetamorphosisAura == nil || !warlock.MetamorphosisAura.IsActive()
 		},
 
-		BonusCritRating:  float64(warlock.Talents.Devastation) * core.SpellCritRatingPerCritChance,
+		BonusCritRating: float64(warlock.Talents.Devastation) * core.SpellCritRatingPerCritChance,
+		DamageMultiplierAdditive: 1 +
+			0.02*float64(warlock.Talents.ShadowMastery),
 		DamageMultiplier: damageMulti,
 		CritMultiplier:   warlock.SpellCritMultiplier(1, core.TernaryFloat64(warlock.Talents.Ruin, 1, 0)),
 		ThreatMultiplier: 1,

--- a/sim/warlock/shadowburn.go
+++ b/sim/warlock/shadowburn.go
@@ -35,7 +35,9 @@ func (warlock *Warlock) registerShadowBurnBaseConfig(rank int) core.SpellConfig 
 			},
 		},
 
-		BonusCritRating:  float64(warlock.Talents.Devastation) * core.SpellCritRatingPerCritChance,
+		BonusCritRating: float64(warlock.Talents.Devastation) * core.SpellCritRatingPerCritChance,
+		DamageMultiplierAdditive: 1 +
+			0.02*float64(warlock.Talents.ShadowMastery),
 		DamageMultiplier: 1,
 		CritMultiplier:   warlock.SpellCritMultiplier(1, core.TernaryFloat64(warlock.Talents.Ruin, 1, 0)),
 		ThreatMultiplier: 1,

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -51,31 +51,31 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 7.93009
+  dps: 7.20917
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 8.12528
+  dps: 7.38661
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-AffItemSwap--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-AffItemSwap--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-AffItemSwap--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11.12136
+  dps: 10.11033
  }
 }
 dps_results: {
@@ -99,29 +99,29 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-AffItemSwap-affi.tank-FullBuffs-LongMultiTarget"
  value: {
-  dps: 113.23657
-  tps: 509.59566
+  dps: 106.21779
+  tps: 500.15483
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-AffItemSwap-affi.tank-FullBuffs-LongSingleTarget"
  value: {
-  dps: 95.17656
-  tps: 167.70815
+  dps: 89.61903
+  tps: 156.34029
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-AffItemSwap-affi.tank-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 102.16598
-  tps: 171.8724
+  dps: 95.87034
+  tps: 159.13407
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-AffItemSwap-affi.tank-NoBuffs-LongMultiTarget"
  value: {
-  dps: 68.72373
-  tps: 471.0947
+  dps: 67.04124
+  tps: 468.39727
  }
 }
 dps_results: {
@@ -141,19 +141,19 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-Affliction Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-Affliction Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-Affliction Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11.12136
+  dps: 10.11033
  }
 }
 dps_results: {
@@ -177,29 +177,29 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-Affliction Warlock-affi.tank-FullBuffs-LongMultiTarget"
  value: {
-  dps: 113.23657
-  tps: 509.59566
+  dps: 106.21779
+  tps: 500.15483
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-Affliction Warlock-affi.tank-FullBuffs-LongSingleTarget"
  value: {
-  dps: 95.17656
-  tps: 167.70815
+  dps: 89.61903
+  tps: 156.34029
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-Affliction Warlock-affi.tank-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 102.16598
-  tps: 171.8724
+  dps: 95.87034
+  tps: 159.13407
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-25-affi.tank-Affliction Warlock-affi.tank-NoBuffs-LongMultiTarget"
  value: {
-  dps: 68.72373
-  tps: 471.0947
+  dps: 67.04124
+  tps: 468.39727
  }
 }
 dps_results: {
@@ -219,6 +219,6 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -51,31 +51,31 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 7.93009
+  dps: 7.20917
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 8.12528
+  dps: 7.38661
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destro.tank-Demonology Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destro.tank-Demonology Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-25-destro.tank-Demonology Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11.12136
+  dps: 10.11033
  }
 }
 dps_results: {
@@ -99,6 +99,6 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -51,31 +51,31 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 7.93009
+  dps: 7.20917
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 8.12528
+  dps: 7.38661
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destro.tank-Destruction Warlock--FullBuffs-LongMultiTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destro.tank-Destruction Warlock--FullBuffs-LongSingleTarget"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destro.tank-Destruction Warlock--FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11.12136
+  dps: 10.11033
  }
 }
 dps_results: {
@@ -99,22 +99,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destro.tank-Destruction Warlock-destro.tank-FullBuffs-LongMultiTarget"
  value: {
-  dps: 139.566
-  tps: 594.00123
+  dps: 127.52714
+  tps: 570.8288
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destro.tank-Destruction Warlock-destro.tank-FullBuffs-LongSingleTarget"
  value: {
-  dps: 91.42183
-  tps: 209.35499
+  dps: 83.74772
+  tps: 192.77088
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-25-destro.tank-Destruction Warlock-destro.tank-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 98.14038
-  tps: 212.11032
+  dps: 89.80107
+  tps: 194.16786
  }
 }
 dps_results: {
@@ -141,6 +141,6 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 8.01928
+  dps: 7.29025
  }
 }

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -35,15 +35,19 @@ type Warlock struct {
 	DrainLife    *core.Spell
 	RainOfFire   *core.Spell
 
-	CurseOfElements      *core.Spell
-	CurseOfElementsAuras core.AuraArray
-	CurseOfWeakness      *core.Spell
-	CurseOfWeaknessAuras core.AuraArray
-	CurseOfTongues       *core.Spell
-	CurseOfTonguesAuras  core.AuraArray
-	CurseOfAgony         *core.Spell
-	CurseOfDoom          *core.Spell
-	AmplifyCurse         *core.Spell
+	CurseOfElements          *core.Spell
+	CurseOfElementsAuras     core.AuraArray
+	CurseOfShadow            *core.Spell
+	CurseOfShadowAuras       core.AuraArray
+	CurseOfRecklessness      *core.Spell
+	CurseOfRecklessnessAuras core.AuraArray
+	CurseOfWeakness          *core.Spell
+	CurseOfWeaknessAuras     core.AuraArray
+	CurseOfTongues           *core.Spell
+	CurseOfTonguesAuras      core.AuraArray
+	CurseOfAgony             *core.Spell
+	CurseOfDoom              *core.Spell
+	AmplifyCurse             *core.Spell
 
 	DemonicEmpowerment      *core.Spell
 	DemonicEmpowermentAura  *core.Aura
@@ -82,12 +86,14 @@ func (warlock *Warlock) Initialize() {
 	warlock.registerIncinerateSpell()
 	warlock.registerShadowBoltSpell()
 	warlock.registerShadowCleaveSpell()
-	// warlock.registerCurseOfElementsSpell()
-	// warlock.registerCurseOfWeaknessSpell()
-	// warlock.registerCurseOfTonguesSpell()
+
+	warlock.registerCurseOfElementsSpell()
+	warlock.registerCurseOfShadowSpell()
+	warlock.registerCurseOfRecklessnessSpell()
 	warlock.registerCurseOfAgonySpell()
 	warlock.registerAmplifyCurseSpell()
 	// warlock.registerCurseOfDoomSpell()
+
 	warlock.registerLifeTapSpell()
 	// warlock.registerSeedSpell()
 	// warlock.registerSoulFireSpell()

--- a/ui/core/components/inputs/buffs_debuffs.ts
+++ b/ui/core/components/inputs/buffs_debuffs.ts
@@ -672,6 +672,17 @@ export const CurseOfElements = withLabel(
 	'Curse of Elements',
 );
 
+export const CurseOfShadow = withLabel(
+	makeBooleanDebuffInput({
+		actionId: (player) => player.getMatchingSpellActionId([
+			{ id: 17862, 	minLevel: 44, maxLevel: 59 	},
+			{ id: 17937, 	minLevel: 60 								},
+		]),
+		fieldName: 'curseOfShadow',
+	}),
+	'Curse of Shadow',
+);
+
 export const HuntersMark = withLabel(
 	makeTristateDebuffInput({
 		actionId: (player) => player.getMatchingSpellActionId([
@@ -991,6 +1002,11 @@ export const DEBUFFS_CONFIG = [
 		config: CurseOfElements,
 		picker: IconPicker,
 		stats: [Stat.StatFirePower, Stat.StatFrostPower],
+	},
+	{
+		config: CurseOfShadow,
+		picker: IconPicker,
+		stats: [Stat.StatShadowPower, Stat.StatArcanePower],
 	},
 	{ 
 		config: AttackPowerDebuff,

--- a/ui/tank_warlock/inputs.ts
+++ b/ui/tank_warlock/inputs.ts
@@ -36,6 +36,7 @@ export const PetInput = InputHelpers.makeSpecOptionsEnumIconInput<Spec.SpecTankW
 	values: [
 		{ value: Summon.NoSummon, tooltip: 'No Pet' },
 		{ actionId: () => ActionId.fromSpellId(688), value: Summon.Imp },
+		{ actionId: () => ActionId.fromSpellId(697), value: Summon.Voidwalker },
 		{ actionId: () => ActionId.fromSpellId(712), value: Summon.Succubus },
 		{ actionId: () => ActionId.fromSpellId(691), value: Summon.Felhunter },
 	],

--- a/ui/warlock/inputs.ts
+++ b/ui/warlock/inputs.ts
@@ -26,8 +26,8 @@ export const WeaponImbueInput = InputHelpers.makeSpecOptionsEnumIconInput<Spec.S
 	values: [
 		{ value: WeaponImbue.NoWeaponImbue, tooltip: 'No Weapon Stone' },
 		// TODO: Classic warlock weapon stone id based on level
-		{ actionId: () =>  ActionId.fromItemId(13701), value: WeaponImbue.Firestone },
-		{ actionId: () =>  ActionId.fromItemId(13603), value: WeaponImbue.Spellstone },
+		{ actionId: () => ActionId.fromItemId(13701), value: WeaponImbue.Firestone },
+		{ actionId: () => ActionId.fromItemId(13603), value: WeaponImbue.Spellstone },
 	],
 });
 
@@ -35,9 +35,10 @@ export const PetInput = InputHelpers.makeSpecOptionsEnumIconInput<Spec.SpecWarlo
 	fieldName: 'summon',
 	values: [
 		{ value: Summon.NoSummon, tooltip: 'No Pet' },
-		{ actionId: () =>  ActionId.fromSpellId(688), value: Summon.Imp },
-		{ actionId: () =>  ActionId.fromSpellId(712), value: Summon.Succubus },
-		{ actionId: () =>  ActionId.fromSpellId(691), value: Summon.Felhunter },
+		{ actionId: () => ActionId.fromSpellId(688), value: Summon.Imp },
+		{ actionId: () => ActionId.fromSpellId(697), value: Summon.Voidwalker },
+		{ actionId: () => ActionId.fromSpellId(712), value: Summon.Succubus },
+		{ actionId: () => ActionId.fromSpellId(691), value: Summon.Felhunter },
 	],
 	changeEmitter: (player: Player<Spec.SpecWarlock>) => player.changeEmitter,
 });


### PR DESCRIPTION
- Added Nightfall
- Added Shadow Mastery
- Added Curse of Reck/Elements/Shadow to APL castable spells
- Fixed values for Curse of Elements/Shadow to scale with level
- Added Imp base stats for level 40 (only imp data atm)
- Added Shadow and Flame belt rune
- Fixed Succubus Lash of Pain ranks
- Fixed Thorns for tank sims