### PR TITLE
Add Electromantic Devastator's Mail set bonus

### DIFF
--- a/sim/common/sod/melee_sets.go
+++ b/sim/common/sod/melee_sets.go
@@ -130,6 +130,7 @@ var ItemSetElectromanticDevastator = core.NewItemSet(core.ItemSet{
 					c.AddMana(sim, 100, metrics)
 				},
 			})
+			procChance := 0.05
 			c.RegisterAura(core.Aura{
 				Label:    "Electromantic Devastator's Mail 3pc",
 				ActionID: core.ActionID{SpellID: 435982},
@@ -139,7 +140,6 @@ var ItemSetElectromanticDevastator = core.NewItemSet(core.ItemSet{
 				},
 				// Modeled after WotLK JoW https://github.com/wowsims/wotlk/blob/master/sim/core/debuffs.go#L202
 				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-					procChance := 0.05
 					if spell.ProcMask.Matches(core.ProcMaskEmpty | core.ProcMaskProc | core.ProcMaskWeaponProc) {
 						return // Phantom spells don't proc
 					}

--- a/sim/common/sod/melee_sets.go
+++ b/sim/common/sod/melee_sets.go
@@ -110,6 +110,46 @@ var ItemSetBlackfathomSlayerLeather = core.NewItemSet(core.ItemSet{
 	},
 })
 
+var ItemSetElectromanticDevastator = core.NewItemSet(core.ItemSet{
+	Name: "Electromantic Devastator's Mail",
+	Bonuses: map[int32]core.ApplyEffect{
+		2: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStat(stats.AttackPower, 24)
+		},
+		3: func(a core.Agent) {
+			char := a.GetCharacter()
+			if !char.HasManaBar() {
+				return
+			}
+			metrics := char.NewManaMetrics(core.ActionID{SpellID: 435982})
+			proc := char.RegisterSpell(core.SpellConfig{
+				ActionID:    core.ActionID{SpellID: 435981},
+				SpellSchool: core.SpellSchoolHoly,
+				ApplyEffects: func(sim *core.Simulation, u *core.Unit, spell *core.Spell) {
+					char.AddMana(sim, 100, metrics)
+				},
+			})
+			char.RegisterAura(core.Aura{
+				Label:    "Electromantic Devastator's Mail 3pc",
+				ActionID: core.ActionID{SpellID: 435982},
+				Duration: core.NeverExpires,
+				OnReset: func(aura *core.Aura, sim *core.Simulation) {
+					aura.Activate(sim)
+				},
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if !result.Landed() {
+						return
+					}
+					if sim.RandomFloat("Electromantic Devastator's Mail 3pc") < 0.05 {
+						proc.Cast(sim, result.Target)
+					}
+				},
+			})
+		},
+	},
+})
+
 var ItemSetInsulatedLeather = core.NewItemSet(core.ItemSet{
 	Name: "Insulated Leathers",
 	Bonuses: map[int32]core.ApplyEffect{

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -122,8 +122,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 43.71756
-  tps: 38.07916
+  dps: 40.91039
+  tps: 34.38805
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -120,6 +120,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-ElectromanticDevastator'sMail"
+ value: {
+  dps: 43.71756
+  tps: 38.07916
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-HyperconductiveMender'sMeditation"
  value: {
   dps: 43.50756

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -70,6 +70,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-ElectromanticDevastator'sMail"
+ value: {
+  dps: 12.53676
+  tps: 11.61298
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-HyperconductiveMender'sMeditation"
  value: {
   dps: 12.05599

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -72,8 +72,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 12.53676
-  tps: 11.61298
+  dps: 11.85564
+  tps: 10.12279
  }
 }
 dps_results: {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -67,6 +67,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-ElectromanticDevastator'sMail"
+ value: {
+  dps: 2.77504
+  tps: 9.15833
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-H.A.Z.A.R.D.Suit"
  value: {
   dps: 2.59731

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -67,6 +67,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-ElectromanticDevastator'sMail"
+ value: {
+  dps: 2.77504
+  tps: 9.15833
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-H.A.Z.A.R.D.Suit"
  value: {
   dps: 2.59731

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -111,6 +111,10 @@ dps_results: {
  value: {}
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-ElectromanticDevastator'sMail"
+ value: {}
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-H.A.Z.A.R.D.Suit"
  value: {}
 }


### PR DESCRIPTION
Looking for any help on verifying the `OnSpellHitDealt` aspect is correct. I modeled it after the Stormshroud proc but that one notably has a `|| !spell.ProcMask.Matches(core.ProcMaskMelee)` to fail out of the proc. The differences being Stormshroud's tooltip reads "on melee attack" where as this set reads as "on attack". Is there somewhere we can verify the interaction (item db?) before someone has the set?