### PR TITLE
Enable Phase 2 + level-based auto rotations

### DIFF
--- a/ui/balance_druid/presets.ts
+++ b/ui/balance_druid/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Debuffs,
@@ -28,25 +29,72 @@ import Phase1APL from './apls/phase_1.apl.json';
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const BlankPresetGear = PresetUtils.makePresetGear('Blank', BlankGear);
-export const Phase1PresetGear = PresetUtils.makePresetGear('Phase 1', Phase1Gear);
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
-export const DefaultGear = Phase1PresetGear;
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+export const GearPhase1 = PresetUtils.makePresetGear('Phase 1', Phase1Gear);
 
-export const APLBalancePhase1 = PresetUtils.makePresetAPLRotation('Phase 1', Phase1APL);
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
 
-export const DEFAULT_APL = APLBalancePhase1
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const APLPhase1 = PresetUtils.makePresetAPLRotation('Phase 1', Phase1APL);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
-export const Phase1PresetTalents = {
+
+export const TalentsPhase1 = {
 	name: 'Phase 1',
 	data: SavedTalents.create({
 		talentsString: '50005003021',
 	}),
 };
 
-export const DefaultTalents = Phase1PresetTalents;
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalents = TalentPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = BalanceDruidOptions.create({
 	innervateTarget: UnitReference.create(),

--- a/ui/balance_druid/sim.ts
+++ b/ui/balance_druid/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Faction,
@@ -5,9 +6,6 @@ import {
 	Spec,
 	Stat,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { getSpecIcon, specNames } from '../core/proto_utils/utils.js';
 import { Player } from '../core/player.js';
@@ -112,20 +110,23 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.Phase1PresetTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		rotations: [
-			Presets.DEFAULT_APL,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.BlankPresetGear,
-			Presets.Phase1PresetGear,
+			Presets.GearBlank,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (): APLRotation => {
-		return Presets.DEFAULT_APL.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -147,10 +148,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/core/constants/mechanics.ts
+++ b/ui/core/constants/mechanics.ts
@@ -1,8 +1,8 @@
-import { LEVEL_THRESHOLDS, Phase } from "./other";
+import { CURRENT_PHASE, LEVEL_THRESHOLDS, Phase } from "./other";
 
 export const MAX_CHARACTER_LEVEL = LEVEL_THRESHOLDS[Phase.Phase5];
 export const MAX_TALENT_POINTS = MAX_CHARACTER_LEVEL - 9;
-export const CURRENT_LEVEL_CAP = 25;
+export const CURRENT_LEVEL_CAP = LEVEL_THRESHOLDS[CURRENT_PHASE];
 export const BOSS_LEVEL = MAX_CHARACTER_LEVEL + 3;
 
 export const EXPERTISE_PER_QUARTER_PERCENT_REDUCTION = 32.79 / 4;

--- a/ui/core/constants/other.ts
+++ b/ui/core/constants/other.ts
@@ -14,7 +14,7 @@ export const LEVEL_THRESHOLDS: Record<Phase, number> = {
   [Phase.Phase5]: 60,
 };
 
-export const CURRENT_PHASE = Phase.Phase1;
+export const CURRENT_PHASE = Phase.Phase2;
 
 // Github pages serves our site under the /sod directory (because the repo name is wotlk)
 export const REPO_NAME = 'sod';

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -118,8 +118,10 @@ export interface IndividualSimUIConfig<SpecType extends Spec> extends PlayerConf
 		gear: EquipmentSpec,
 		epWeights: Stats,
 		consumes: Consumes,
+
 		rotationType?: APLRotationType,
 		simpleRotation?: SpecRotation<SpecType>,
+
 		talents: SavedTalents,
 		specOptions: SpecOptions<SpecType>,
 

--- a/ui/elemental_shaman/presets.ts
+++ b/ui/elemental_shaman/presets.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
   Consumes,
   Debuffs,
@@ -34,20 +35,55 @@ import Phase2APL from './apls/phase_2.apl.json';
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
+
 export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
 export const GearPhase1 = PresetUtils.makePresetGear('Phase 1', Phase1Gear);
 export const GearPhase2 = PresetUtils.makePresetGear('Phase 2', Phase2Gear);
 
-export const DefaultGear = GearPhase1;
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearPhase1,
+  ],
+  [Phase.Phase2]: [
+    GearPhase2,
+  ]
+};
+
+export const DefaultGear = GearPresets[CURRENT_PHASE][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
 
 export const APLPhase1 = PresetUtils.makePresetAPLRotation('Phase 1', Phase1APL);
 export const APLPhase1AG = PresetUtils.makePresetAPLRotation('Phase 1 (AG)', Phase1AGAPL);
 export const APLPhase2 = PresetUtils.makePresetAPLRotation('Phase 2', Phase2APL);
 
-export const DefaultAPL = APLPhase1;
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLPhase1,
+    APLPhase1AG,
+  ],
+  [Phase.Phase2]: [
+    APLPhase2,
+  ]
+};
+
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase2][0],
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
+
 export const TalentsPhase1 = {
   name: 'Phase 1',
   data: SavedTalents.create({
@@ -62,7 +98,20 @@ export const TalentsPhase2 = {
   }),
 };
 
-export const DefaultTalents = TalentsPhase1;
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsPhase1,
+  ],
+  [Phase.Phase2]: [
+    TalentsPhase2,
+  ]
+};
+
+export const DefaultTalents = TalentPresets[CURRENT_PHASE][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = ElementalShamanOptions.create({
   shield: ShamanShield.LightningShield,

--- a/ui/elemental_shaman/sim.ts
+++ b/ui/elemental_shaman/sim.ts
@@ -1,4 +1,5 @@
 import { ShamanShieldInput } from '../core/components/inputs/shaman_shields.js';
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Faction,
@@ -8,9 +9,6 @@ import {
 	Spec,
 	Stat,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Player } from '../core/player.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { getSpecIcon, specNames } from '../core/proto_utils/utils.js';
@@ -122,25 +120,24 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecElementalShaman, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.TalentsPhase1,
-			Presets.TalentsPhase2,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.APLPhase1,
-			Presets.APLPhase1AG,
-			Presets.APLPhase2,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
 			Presets.GearBlank,
-			Presets.GearPhase1,
-			Presets.GearPhase2,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (_: Player<Spec.SpecElementalShaman>): APLRotation => {
-		return Presets.DefaultAPL.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -161,12 +158,12 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecElementalShaman, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearPhase1.gear,
-					2: Presets.GearPhase2.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
+					2: Presets.GearPresets[Phase.Phase2][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearPhase1.gear,
-					2: Presets.GearPhase2.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
+					2: Presets.GearPresets[Phase.Phase2][0].gear,
 				},
 			},
 		},

--- a/ui/enhancement_shaman/presets.ts
+++ b/ui/enhancement_shaman/presets.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Debuffs,
@@ -29,11 +30,32 @@ import Phase1APL from './apls/phase_1.apl.json';
 export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
 export const GearPhase1 = PresetUtils.makePresetGear('Phase 1', Phase1Gear);
 
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
 export const DefaultGear = GearPhase1
 
-export const Phase1PresetAPL = PresetUtils.makePresetAPLRotation('Phase 1', Phase1APL);
+export const APLPhase1 = PresetUtils.makePresetAPLRotation('Phase 1', Phase1APL);
 
-export const DefaultAPL = Phase1PresetAPL
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
@@ -51,7 +73,16 @@ export const TalentsPhase2 = {
 	}),
 };
 
-export const DefaultTalents = TalentsPhase1;
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsPhase1,
+  ],
+  [Phase.Phase2]: [
+    TalentsPhase2,
+  ]
+};
+
+export const DefaultTalents = TalentPresets[CURRENT_PHASE][0];
 
 export const DefaultOptions = EnhancementShamanOptions.create({
 	shield: ShamanShield.LightningShield,

--- a/ui/enhancement_shaman/sim.ts
+++ b/ui/enhancement_shaman/sim.ts
@@ -1,4 +1,5 @@
 import { ShamanShieldInput } from '../core/components/inputs/shaman_shields.js';
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.js';
 import { Player } from '../core/player.js';
 import { APLRotation } from '../core/proto/apl.js';
@@ -143,22 +144,24 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.TalentsPhase1,
-			Presets.TalentsPhase2,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.Phase1PresetAPL,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
 			Presets.GearBlank,
-			Presets.GearPhase1,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (_): APLRotation => {
-		return Presets.DefaultAPL.rotation.rotation!;
+	autoRotation: (player): APLRotation => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -180,10 +183,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/feral_druid/presets.ts
+++ b/ui/feral_druid/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -22,15 +23,49 @@ import * as PresetUtils from '../core/preset_utils.js';
 import BlankGear from './gear_sets/blank.gear.json';
 import Phase1Gear from './gear_sets/p1.gear.json';
 
+import DefaultApl from './apls/default.apl.json';
+
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const BlankPreset = PresetUtils.makePresetGear('Blank', BlankGear);
-export const DefaultGear = PresetUtils.makePresetGear('Phase 1', Phase1Gear);
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
-import DefaultApl from './apls/default.apl.json';
-export const APL_ROTATION_DEFAULT = PresetUtils.makePresetAPLRotation('APL Default', DefaultApl);
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+export const GearPhase1 = PresetUtils.makePresetGear('Phase 1', Phase1Gear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const APLPhase1 = PresetUtils.makePresetAPLRotation('APL Default', DefaultApl);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
 
 export const DefaultRotation = FeralDruidRotation.create({
 	maintainFaerieFire: false,
@@ -43,14 +78,34 @@ export const DefaultRotation = FeralDruidRotation.create({
 
 export const SIMPLE_ROTATION_DEFAULT = PresetUtils.makePresetSimpleRotation('Simple Default', Spec.SpecFeralDruid, DefaultRotation);
 
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
+
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
-export const StandardTalents = {
+
+export const TalentsPhase1 = {
 	name: 'Standard',
 	data: SavedTalents.create({
 		talentsString: '500005001--05',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalents = TalentPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = FeralDruidOptions.create({
 	latencyMs: 100,

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.js';
 import { Player } from '../core/player.js';
 import {
@@ -102,7 +103,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		rotationType: APLRotationType.TypeSimple,
 		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
-		talents: Presets.StandardTalents.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -173,21 +174,24 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.StandardTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		rotations: [
 			Presets.SIMPLE_ROTATION_DEFAULT,
-			Presets.APL_ROTATION_DEFAULT,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.BlankPreset,
-			Presets.DefaultGear,
+			Presets.GearBlank,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (_player: Player<Spec.SpecFeralDruid>): APLRotation => {
-		return Presets.APL_ROTATION_DEFAULT.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	simpleRotation: (player: Player<Spec.SpecFeralDruid>, simple: DruidRotation, cooldowns: Cooldowns): APLRotation => {
@@ -222,7 +226,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 			defaultName: 'Cat',
 			iconUrl: getSpecIcon(Class.ClassDruid, 3),
 
-			talents: Presets.StandardTalents.data,
+			talents: Presets.DefaultTalents.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -233,10 +237,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/feral_tank_druid/presets.ts
+++ b/ui/feral_tank_druid/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -21,7 +22,26 @@ import DefaultApl from './apls/default.apl.json';
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const DefaultGear = PresetUtils.makePresetGear('Blank', BlankGear);
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearBlank,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultRotation = DruidRotation.create({
 	maulRageThreshold: 25,
@@ -29,16 +49,50 @@ export const DefaultRotation = DruidRotation.create({
 	lacerateTime: 8.0,
 });
 
-export const ROTATION_DEFAULT = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+export const DefaultAPL = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    DefaultAPL,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
+
 export const StandardTalents = {
 	name: 'Standard',
 	data: SavedTalents.create({
 		talentsString: '-503232132322010353120300313511-20350001',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    StandardTalents,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalents = TalentPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = DruidOptions.create({
 	innervateTarget: UnitReference.create(),

--- a/ui/feral_tank_druid/sim.ts
+++ b/ui/feral_tank_druid/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Debuffs,
@@ -11,9 +12,6 @@ import {
 	Stat,
 	TristateEffect,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { getSpecIcon, specNames } from '../core/proto_utils/utils.js';
 import { Player } from '../core/player.js';
@@ -106,7 +104,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralTankDruid, {
 		// Default rotation settings.
 		simpleRotation: Presets.DefaultRotation,
 		// Default talents.
-		talents: Presets.StandardTalents.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -165,20 +163,23 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralTankDruid, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.StandardTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.ROTATION_DEFAULT,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.DefaultGear,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (): APLRotation => {
-		return Presets.ROTATION_DEFAULT.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [

--- a/ui/hunter/presets.ts
+++ b/ui/hunter/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -16,24 +17,62 @@ import {
 
 import * as PresetUtils from '../core/preset_utils.js';
 
-import Phase1Gear from './gear_sets/phase1.json';
-
-import MeleeWeaveP1 from './apls/melee.weave.25.json';
-//import MmApl from './apls/mm.apl.json';
-//import MmAdvApl from './apls/mm_advanced.apl.json';
-//import SvApl from './apls/sv.apl.json';
-//import SvAdvApl from './apls/sv_advanced.apl.json';
-//import AoeApl from './apls/aoe.apl.json';
-
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
+
+import Phase1Gear from './gear_sets/phase1.json';
 
 export const GearBeastMasteryPhase1 = PresetUtils.makePresetGear('P1 Beast Mastery', Phase1Gear, { talentTree: 0 })
 export const GearMarksmanPhase1 = PresetUtils.makePresetGear('P1 Marksmanship', Phase1Gear, { talentTree: 1 })
 export const GearSurvivalPhase1 = PresetUtils.makePresetGear('P1 Survival', Phase1Gear, { talentTree: 2 })
 
-export const GearDefault = GearBeastMasteryPhase1
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearBeastMasteryPhase1,
+		GearMarksmanPhase1,
+		GearSurvivalPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+import MeleeWeaveP1 from './apls/melee.weave.25.json';
+
+export const APLMeleeWeavePhase1 = PresetUtils.makePresetAPLRotation('Melee Weave P1', MeleeWeaveP1, { talentTree: 0 });
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLMeleeWeavePhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, Record<number, PresetUtils.PresetRotation>> = {
+  25: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][0],
+		2: APLPresets[Phase.Phase1][0],
+	},
+  40: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][0],
+		2: APLPresets[Phase.Phase1][0],
+	}
+};
 
 export const DefaultSimpleRotation = HunterRotation.create({
 	type: RotationType.SingleTarget,
@@ -41,10 +80,13 @@ export const DefaultSimpleRotation = HunterRotation.create({
 	multiDotSerpentSting: true,
 });
 
-export const ROTATION_PRESET_MELEE_WEAVE_PHASE1 = PresetUtils.makePresetAPLRotation('Melee Weave P1', MeleeWeaveP1, { talentTree: 0 });
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
+
 export const TalentsBeastMasteryPhase1 = {
 	name: 'P1 Beast Mastery',
 	data: SavedTalents.create({
@@ -66,9 +108,26 @@ export const TalentsSurvivalPhase1 = {
 	}),
 };
 
-export const TalentsBeastMasteryDefault = TalentsBeastMasteryPhase1;
-export const TalentsMarksmanDefault = TalentsMarksmanPhase1;
-export const TalentsSurvivalDefault = TalentsSurvivalPhase1;
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsBeastMasteryPhase1,
+		TalentsMarksmanPhase1,
+		TalentsSurvivalPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalentsBeastMastery = TalentPresets[Phase.Phase1][0];
+export const DefaultTalentsMarksman 		= TalentPresets[Phase.Phase1][1];
+export const DefaultTalentsSurvival 		= TalentPresets[Phase.Phase1][2];
+
+export const DefaultTalents = DefaultTalentsBeastMastery;
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = HunterOptions.create({
 	ammo: Ammo.RazorArrow,

--- a/ui/hunter/sim.ts
+++ b/ui/hunter/sim.ts
@@ -1,6 +1,6 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
-	Cooldowns,
 	Debuffs,
 	Faction,
 	IndividualBuffs,
@@ -24,7 +24,6 @@ import { getSpecIcon } from '../core/proto_utils/utils.js';
 import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.js';
 
 import {
-	Hunter_Rotation as HunterRotation,
 	Hunter_Rotation_StingType as StingType,
 	Hunter_Rotation_RotationType,
 } from '../core/proto/hunter.js';
@@ -103,7 +102,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.GearDefault.gear,
+		gear: Presets.DefaultGear.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
 			[Stat.StatStamina]: 0.5,
@@ -123,7 +122,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 		// Default rotation settings.
 		simpleRotation: Presets.DefaultSimpleRotation,
 		// Default talents.
-		talents: Presets.TalentsBeastMasteryDefault.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -180,38 +179,26 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.TalentsBeastMasteryPhase1,
-			Presets.TalentsMarksmanPhase1,
-			Presets.TalentsSurvivalPhase1,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.ROTATION_PRESET_MELEE_WEAVE_PHASE1,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.GearBeastMasteryPhase1,
-			Presets.GearMarksmanPhase1,
-			Presets.GearSurvivalPhase1,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (_player: Player<Spec.SpecHunter>): APLRotation => {
-		// const talentTree = player.getTalentTree();
-		// const numTargets = player.sim.encounter.targets.length;
-		// if (numTargets >= 4) {
-		// 	return Presets.ROTATION_PRESET_AOE.rotation.rotation!;
-		// } else if (talentTree == 0) {
-		// 	return Presets.ROTATION_PRESET_MELEE_WEAVE_PHASE1.rotation.rotation!;
-		// } else if (talentTree == 1) {
-		// 	return Presets.ROTATION_PRESET_MM.rotation.rotation!;
-		// } else {
-		// 	return Presets.ROTATION_PRESET_SV.rotation.rotation!;
-		// }
-		return Presets.ROTATION_PRESET_MELEE_WEAVE_PHASE1.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()][player.getTalentTree()].rotation.rotation!;
 	},
 
-	simpleRotation: (player: Player<Spec.SpecHunter>, simple: HunterRotation, cooldowns: Cooldowns): APLRotation => {
+	simpleRotation: (player, simple, cooldowns) => {
 		let [prepullActions, actions] = AplUtils.standardCooldownDefaults(cooldowns);
 
 		const serpentSting = APLAction.fromJsonString(`{"condition":{"cmp":{"op":"OpGt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"6s"}}}},"multidot":{"spellId":{"spellId":49001},"maxDots":${simple.multiDotSerpentSting ? 3 : 1},"maxOverlap":{"const":{"val":"0ms"}}}}`);
@@ -284,7 +271,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 			defaultName: 'Beast Mastery',
 			iconUrl: getSpecIcon(Class.ClassHunter, 0),
 
-			talents: Presets.TalentsBeastMasteryDefault.data,
+			talents: Presets.DefaultTalentsBeastMastery.data,
 			specOptions: Presets.BMDefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -295,10 +282,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearBeastMasteryPhase1.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearBeastMasteryPhase1.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},
@@ -307,7 +294,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 			tooltip: 'Marksmanship Hunter',
 			defaultName: 'Marksmanship',
 			iconUrl: getSpecIcon(Class.ClassHunter, 1),
-			talents: Presets.TalentsMarksmanPhase1.data,
+			talents: Presets.DefaultTalentsMarksman.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -318,10 +305,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearMarksmanPhase1.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearMarksmanPhase1.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 			},
 		},
@@ -331,7 +318,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 			defaultName: 'Survival',
 			iconUrl: getSpecIcon(Class.ClassHunter, 2),
 
-			talents: Presets.TalentsSurvivalDefault.data,
+			talents: Presets.DefaultTalentsSurvival.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -342,10 +329,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHunter, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearSurvivalPhase1.gear,
+					1: Presets.GearPresets[Phase.Phase1][2].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearSurvivalPhase1.gear,
+					1: Presets.GearPresets[Phase.Phase1][2].gear,
 				},
 			},
 		},

--- a/ui/mage/presets.ts
+++ b/ui/mage/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -15,24 +16,109 @@ import * as PresetUtils from '../core/preset_utils.js';
 
 import DefaultBlankGear from './gear_sets/blank.gear.json';
 
-import DefaultAPL from './apls/default.apl.json';
+import APLDefault from './apls/default.apl.json';
 
-export const GearArcaneDefault = PresetUtils.makePresetGear('Default', DefaultBlankGear, { talentTree: 0 });
-export const GearFireDefault = PresetUtils.makePresetGear('Default', DefaultBlankGear, { talentTree: 1 });
-export const GearFrostDefault = PresetUtils.makePresetGear('Default', DefaultBlankGear, { talentTree: 2 });
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
-export const ROTATION_PRESET_ARCANE = PresetUtils.makePresetAPLRotation('Default', DefaultAPL, { talentTree: 0 });
-export const ROTATION_PRESET_FIRE = PresetUtils.makePresetAPLRotation('Default', DefaultAPL, { talentTree: 1 });
-export const ROTATION_PRESET_FROST = PresetUtils.makePresetAPLRotation('Default', DefaultAPL, { talentTree: 2 });
+export const GearArcanePhase1 = PresetUtils.makePresetGear('Default', DefaultBlankGear, { talentTree: 0 });
+export const GearFirePhase1 = PresetUtils.makePresetGear('Default', DefaultBlankGear, { talentTree: 1 });
+export const GearFrostPhase1 = PresetUtils.makePresetGear('Default', DefaultBlankGear, { talentTree: 2 });
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearArcanePhase1,
+		GearFirePhase1,
+		GearFrostPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const APLArcanePhase1 = PresetUtils.makePresetAPLRotation('Default', APLDefault, { talentTree: 0 });
+export const APLFirePhase1 = PresetUtils.makePresetAPLRotation('Default', APLDefault, { talentTree: 1 });
+export const APLFrostPhase1 = PresetUtils.makePresetAPLRotation('Default', APLDefault, { talentTree: 2 });
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLArcanePhase1,
+		APLFirePhase1,
+		APLFrostPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, Record<number, PresetUtils.PresetRotation>> = {
+  25: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][1],
+		2: APLPresets[Phase.Phase1][2],
+	},
+  40: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][1],
+		2: APLPresets[Phase.Phase1][2],
+	}
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
-export const DefaultTalents = {
-	name: 'Fire',
+
+export const TalentsArcanePhase1 = {
+	name: 'Phase 1',
 	data: SavedTalents.create({
-		talentsString: '230025030002-5052000123033151-003',
+		talentsString: '50005003021',
 	}),
 };
+
+export const TalentsFirePhase1 = {
+	name: 'Phase 1',
+	data: SavedTalents.create({
+		talentsString: '50005003021',
+	}),
+};
+
+export const TalentsFrostPhase1 = {
+	name: 'Phase 1',
+	data: SavedTalents.create({
+		talentsString: '50005003021',
+	}),
+};
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsArcanePhase1,
+		TalentsFirePhase1,
+		TalentsFrostPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalentsArcane = TalentPresets[Phase.Phase1][0];
+export const DefaultTalentsFire 	= TalentPresets[Phase.Phase1][1];
+export const DefaultTalentsFrost 	= TalentPresets[Phase.Phase1][2];
+
+export const DefaultTalents = DefaultTalentsArcane;
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = MageOptions.create({
 	armor: ArmorType.MageArmor,

--- a/ui/mage/sim.ts
+++ b/ui/mage/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Debuffs,
@@ -10,7 +11,6 @@ import {
 	Stat,
 	TristateEffect
 } from '../core/proto/common.js';
-import {APLRotation} from '../core/proto/apl.js';
 import {Stats} from '../core/proto_utils/stats.js';
 import { getSpecIcon } from '../core/proto_utils/utils.js';
 import {Player} from '../core/player.js';
@@ -56,7 +56,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 	],
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.GearArcaneDefault.gear,
+		gear: Presets.DefaultGear.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
 			[Stat.StatIntellect]: 0.48,
@@ -132,20 +132,23 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 	presets: {
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.ROTATION_PRESET_ARCANE,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.DefaultTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.GearArcaneDefault,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (_player: Player<Spec.SpecMage>): APLRotation => {
-		return Presets.ROTATION_PRESET_ARCANE.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()][player.getTalentTree()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -155,7 +158,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 			defaultName: 'Arcane',
 			iconUrl: getSpecIcon(Class.ClassMage, 0),
 
-			talents: Presets.DefaultTalents.data,
+			talents: Presets.DefaultTalentsArcane.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			otherDefaults: Presets.OtherDefaults,
@@ -167,10 +170,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearArcaneDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearArcaneDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},
@@ -180,7 +183,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 			defaultName: 'Fire',
 			iconUrl: getSpecIcon(Class.ClassMage, 1),
 
-			talents: Presets.DefaultTalents.data,
+			talents: Presets.DefaultTalentsFire.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			otherDefaults: Presets.OtherDefaults,
@@ -192,10 +195,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearFireDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearFireDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 			},
 		},
@@ -205,7 +208,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 			defaultName: 'Frost',
 			iconUrl: getSpecIcon(Class.ClassMage, 2),
 
-			talents: Presets.DefaultTalents.data,
+			talents: Presets.DefaultTalentsFrost.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			otherDefaults: Presets.OtherDefaults,
@@ -217,10 +220,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMage, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearFrostDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][2].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearFrostDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][2].gear,
 				},
 			},
 		},

--- a/ui/protection_paladin/presets.ts
+++ b/ui/protection_paladin/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -13,17 +14,54 @@ import {
 
 import * as PresetUtils from '../core/preset_utils.js';
 
-import BlankGear from './gear_sets/blank.gear.json';
-
-import DefaultApl from './apls/default.apl.json';
-
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const DefaultGear = PresetUtils.makePresetGear('Blank', BlankGear);
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
-export const ROTATION_DEFAULT = PresetUtils.makePresetAPLRotation('Default (969)', DefaultApl);
+import BlankGear from './gear_sets/blank.gear.json';
+
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearBlank,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+import DefaultApl from './apls/default.apl.json';
+
+export const DefaultAPL = PresetUtils.makePresetAPLRotation('Default (969)', DefaultApl);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    DefaultAPL,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
@@ -34,6 +72,20 @@ export const GenericAoeTalents = {
 		talentsString: '-05005135200132311333312321-511302012003',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    GenericAoeTalents,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+export const DefaultTalents = TalentPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = ProtectionPaladinOptions.create({
 	aura: PaladinAura.RetributionAura,

--- a/ui/protection_paladin/sim.ts
+++ b/ui/protection_paladin/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Debuffs,
@@ -10,9 +11,6 @@ import {
 	Stat, PseudoStat,
 	TristateEffect,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { Player } from '../core/player.js';
 import { getSpecIcon } from '../core/proto_utils/utils.js';
@@ -114,7 +112,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default talents.
-		talents: Presets.GenericAoeTalents.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -182,20 +180,23 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.GenericAoeTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.ROTATION_DEFAULT,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.DefaultGear,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (): APLRotation => {
-		return Presets.ROTATION_DEFAULT.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -205,7 +206,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 			defaultName: 'Protection',
 			iconUrl: getSpecIcon(Class.ClassPaladin, 1),
 
-			talents: Presets.GenericAoeTalents.data,
+			talents: Presets.DefaultTalents.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -216,10 +217,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/protection_warrior/presets.ts
+++ b/ui/protection_warrior/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -14,21 +15,60 @@ import {
 
 import * as PresetUtils from '../core/preset_utils.js';
 
-import BlankGear from './gear_sets/blank.gear.json';
-
-import DefaultApl from './apls/default.apl.json';
-
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const DefaultGear = PresetUtils.makePresetGear('Blank', BlankGear);
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
-export const ROTATION_DEFAULT = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+import BlankGear from './gear_sets/blank.gear.json';
+
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearBlank,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+import DefaultApl from './apls/default.apl.json';
+
+export const DefaultAPL = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    DefaultAPL,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
+
 export const ROTATION_PRESET_SIMPLE = PresetUtils.makePresetSimpleRotation('Simple Cooldowns', Spec.SpecProtectionWarrior, ProtectionWarriorRotation.create());
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
+
 export const StandardTalents = {
 	name: 'Standard',
 	data: SavedTalents.create({
@@ -42,6 +82,21 @@ export const UATalents = {
 		talentsString: '35023301230051002020120002-2-05035122500000252',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    StandardTalents,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalents = TalentPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = ProtectionWarriorOptions.create({
 	shout: WarriorShout.WarriorShoutCommanding,

--- a/ui/protection_warrior/sim.ts
+++ b/ui/protection_warrior/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Debuffs,
@@ -11,10 +12,6 @@ import {
 	PseudoStat,
 	TristateEffect
 } from '../core/proto/common.js';
-
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { Player } from '../core/player.js';
 import { getSpecIcon } from '../core/proto_utils/utils.js';
@@ -111,7 +108,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default talents.
-		talents: Presets.StandardTalents.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -172,22 +169,24 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.StandardTalents,
-			Presets.UATalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.ROTATION_DEFAULT,
 			Presets.ROTATION_PRESET_SIMPLE,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.DefaultGear,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (): APLRotation => {
-		return Presets.ROTATION_DEFAULT.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -208,10 +207,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/retribution_paladin/presets.ts
+++ b/ui/retribution_paladin/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -21,12 +22,50 @@ import DefaultApl from './apls/default.apl.json';
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const DefaultGear = PresetUtils.makePresetGear('Blank', BlankGear);
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
-export const ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearBlank,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const APLPhase1 = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
+
 export const AuraMasteryTalents = {
 	name: 'Aura Mastery',
 	data: SavedTalents.create({
@@ -34,13 +73,27 @@ export const AuraMasteryTalents = {
 	}),
 };
 
-
 export const DivineSacTalents = {
 	name: 'Divine Sacrifice & Guardian',
 	data: SavedTalents.create({
 		talentsString: '03-453201002-05222051203331302133201331',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    AuraMasteryTalents,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalents = TalentPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = RetributionPaladinOptions.create({
 	aura: PaladinAura.RetributionAura,

--- a/ui/retribution_paladin/sim.ts
+++ b/ui/retribution_paladin/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Debuffs,
@@ -10,9 +11,6 @@ import {
 	Stat, PseudoStat,
 	TristateEffect,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { Player } from '../core/player.js';
 import { getSpecIcon } from '../core/proto_utils/utils.js';
@@ -96,7 +94,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default talents.
-		talents: Presets.AuraMasteryTalents.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -150,21 +148,23 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 
 	presets: {
 		rotations: [
-			Presets.ROTATION_PRESET_DEFAULT,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.AuraMasteryTalents,
-			Presets.DivineSacTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.DefaultGear,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (): APLRotation => {
-		return Presets.ROTATION_PRESET_DEFAULT.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -174,7 +174,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 			defaultName: 'Retribution',
 			iconUrl: getSpecIcon(Class.ClassPaladin, 2),
 
-			talents: Presets.AuraMasteryTalents.data,
+			talents: Presets.DefaultTalents.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -185,10 +185,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.DefaultGear.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/rogue/presets.ts
+++ b/ui/rogue/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Flask,
@@ -28,9 +29,26 @@ import RuptureMutilateExposeApl from './apls/rupture_mutilate_expose.apl.json';
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const GearAssassinationDefault = PresetUtils.makePresetGear('Blank', BlankGear, { talentTree: 0 });
-export const GearCombatDefault = PresetUtils.makePresetGear('Blank', BlankGear, { talentTree: 0 });
-export const GearSubtletyDefault = PresetUtils.makePresetGear('Blank', BlankGear, { talentTree: 0 });
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearBlank,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
 
 export const ROTATION_PRESET_MUTILATE = PresetUtils.makePresetAPLRotation('Mutilate', MutilateApl, { talentTree: 0 });
 export const ROTATION_PRESET_RUPTURE_MUTILATE = PresetUtils.makePresetAPLRotation('Rupture Mutilate', RuptureMutilateApl, { talentTree: 0 });
@@ -42,8 +60,35 @@ export const ROTATION_PRESET_COMBAT_CLEAVE_SND = PresetUtils.makePresetAPLRotati
 export const ROTATION_PRESET_COMBAT_CLEAVE_SND_EXPOSE = PresetUtils.makePresetAPLRotation('Combat Cleave SND w/ Expose', CombatCleaveSndExposeApl, { talentTree: 1 });
 export const ROTATION_PRESET_AOE = PresetUtils.makePresetAPLRotation('Fan AOE', FanAoeApl);
 
+export const APLPresets = {
+  [Phase.Phase1]: [
+    ROTATION_PRESET_MUTILATE,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, Record<number, PresetUtils.PresetRotation>> = {
+  25: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][0],
+		2: APLPresets[Phase.Phase1][0],
+	},
+  40: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][0],
+		2: APLPresets[Phase.Phase1][0],
+	}
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
+
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
+
 export const CombatHackTalents = {
 	name: 'Combat Axes/Swords',
 	data: SavedTalents.create({
@@ -92,6 +137,27 @@ export const HemoSubtletyTalents = {
 		talentsString: '30532010135--502201203032112135011503122',
 	}),
 }
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    AssassinationTalents137,
+		CombatHackTalents,
+		SubtletyTalents,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalentsAssassin = TalentPresets[Phase.Phase1][0];
+export const DefaultTalentsCombat 	= TalentPresets[Phase.Phase1][1];
+export const DefaultTalentsSubtlety = TalentPresets[Phase.Phase1][2];
+
+export const DefaultTalents = DefaultTalentsAssassin;
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = RogueOptions.create({
 	mhImbue: Poison.DeadlyPoison,

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class, 
 	Debuffs,
@@ -13,9 +14,6 @@ import {
 	TristateEffect,
 	WeaponType
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Player } from '../core/player.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { getSpecIcon } from '../core/proto_utils/utils.js';
@@ -134,7 +132,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.GearAssassinationDefault.gear,
+		gear: Presets.DefaultGear.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
 			[Stat.StatAgility]: 1.86,
@@ -208,47 +206,23 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.AssassinationTalents137,
-			Presets.AssassinationTalents182,
-			Presets.AssassinationTalentsBF,
-			Presets.CombatHackTalents,
-			Presets.CombatCQCTalents,
-			Presets.SubtletyTalents,
-			Presets.HemoSubtletyTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.ROTATION_PRESET_MUTILATE,
-			Presets.ROTATION_PRESET_MUTILATE_EXPOSE,
-			Presets.ROTATION_PRESET_RUPTURE_MUTILATE,
-			Presets.ROTATION_PRESET_RUPTURE_MUTILATE_EXPOSE,
-			Presets.ROTATION_PRESET_COMBAT,
-			Presets.ROTATION_PRESET_COMBAT_EXPOSE,
-			Presets.ROTATION_PRESET_COMBAT_CLEAVE_SND,
-			Presets.ROTATION_PRESET_COMBAT_CLEAVE_SND_EXPOSE,
-			Presets.ROTATION_PRESET_AOE,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.GearAssassinationDefault,
-			Presets.GearCombatDefault,
-			Presets.GearSubtletyDefault,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (player: Player<Spec.SpecRogue>): APLRotation => {
-		const talentTree = player.getTalentTree();
-		const numTargets = player.sim.encounter.targets.length;
-		if (numTargets >= 5) {
-			return Presets.ROTATION_PRESET_AOE.rotation.rotation!;
-		} else if (talentTree == 0) {
-			return Presets.ROTATION_PRESET_MUTILATE_EXPOSE.rotation.rotation!;
-		} else if (talentTree == 1) {
-			return Presets.ROTATION_PRESET_COMBAT_EXPOSE.rotation.rotation!;
-		} else {
-			// TODO: Need a sub rotation here
-			return Presets.ROTATION_PRESET_MUTILATE_EXPOSE.rotation.rotation!;
-		}
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()][player.getTalentTree()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -258,7 +232,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 			defaultName: 'Assassination',
 			iconUrl: getSpecIcon(Class.ClassRogue, 0),
 
-			talents: Presets.AssassinationTalents137.data,
+			talents: Presets.DefaultTalentsAssassin.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -269,10 +243,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearAssassinationDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearAssassinationDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},
@@ -282,7 +256,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 			defaultName: 'Combat',
 			iconUrl: getSpecIcon(Class.ClassRogue, 1),
 
-			talents: Presets.CombatCQCTalents.data,
+			talents: Presets.DefaultTalentsCombat.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -293,10 +267,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearCombatDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearCombatDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/shadow_priest/presets.ts
+++ b/ui/shadow_priest/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Debuffs,
@@ -26,18 +27,71 @@ import DefaultApl from './apls/default.apl.json'
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const BLANK_GEAR_PRESET = PresetUtils.makePresetGear('Blank', BlankGear);
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
-export const ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearBlank,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const APLPhase1 = PresetUtils.makePresetAPLRotation('Default', DefaultApl);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
+  25: APLPresets[Phase.Phase1][0],
+  40: APLPresets[Phase.Phase1][0],
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
+
 export const StandardTalents = {
 	name: 'Standard',
 	data: SavedTalents.create({
 		talentsString: '5042001303--5002505103501051',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    StandardTalents,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalents = TalentPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = Options.create({});
 

--- a/ui/shadow_priest/sim.ts
+++ b/ui/shadow_priest/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Faction,
@@ -6,9 +7,6 @@ import {
 	Spec,
 	Stat,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { Player } from '../core/player.js';
 import { getSpecIcon, specNames } from '../core/proto_utils/utils.js';
@@ -70,7 +68,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.BLANK_GEAR_PRESET.gear,
+		gear: Presets.DefaultGear.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
 			[Stat.StatIntellect]: 0.11,
@@ -132,19 +130,22 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.StandardTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		rotations: [
-			Presets.ROTATION_PRESET_DEFAULT,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.BLANK_GEAR_PRESET,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (_: Player<Spec.SpecShadowPriest>): APLRotation => {
-		return Presets.ROTATION_PRESET_DEFAULT.rotation.rotation!;
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -165,10 +166,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.BLANK_GEAR_PRESET.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.BLANK_GEAR_PRESET.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},

--- a/ui/tank_warlock/presets.ts
+++ b/ui/tank_warlock/presets.ts
@@ -1,6 +1,6 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	AgilityElixir,
-	Conjured,
 	Consumes,
 	Debuffs,
 	FirePowerBuff,
@@ -21,43 +21,109 @@ import {
 	WarlockOptions as WarlockOptions,
 	WarlockOptions_WeaponImbue as WarlockWeaponImbue,
 } from '../core/proto/warlock.js';
+
 import * as PresetUtils from '../core/preset_utils.js';
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
 
 import AfflictionTankGear from './gear_sets/affi.tank.gear.json';
 import DestroTankGear from './gear_sets/destro.tank.gear.json';
 
-export const GearAfflictionTankDefault = PresetUtils.makePresetGear('Affliction Tank', AfflictionTankGear);
-export const GearDestructionTankDefault = PresetUtils.makePresetGear('Destruction Tank', DestroTankGear);
+export const GearAfflictionTankPhase1 = PresetUtils.makePresetGear('Affliction Tank', AfflictionTankGear);
+export const GearDemologyTankPhase1 = PresetUtils.makePresetGear('Demonology Tank', AfflictionTankGear);
+export const GearDestructionTankPhase1 = PresetUtils.makePresetGear('Destruction Tank', DestroTankGear);
+
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearAfflictionTankPhase1,
+		GearDemologyTankPhase1,
+		GearDestructionTankPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
 
 import AfflictionTankAPL from './apls/affi.tank.apl.json';
 import DestroTankAPL from './apls/destro.tank.apl.json';
 
-export const RotationAfflictionTankDefault = PresetUtils.makePresetAPLRotation('Affliction Tank', AfflictionTankAPL);
-export const RotationDestructionTankDefault = PresetUtils.makePresetAPLRotation('Destruction Tank', DestroTankAPL);
+export const APLAfflictionTankPhase1 = PresetUtils.makePresetAPLRotation('Affliction Tank', AfflictionTankAPL);
+export const APLDemonologyTankPhase1 = PresetUtils.makePresetAPLRotation('Demonology Tank', DestroTankAPL);
+export const APLDestructionTankPhase1 = PresetUtils.makePresetAPLRotation('Destruction Tank', DestroTankAPL);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLAfflictionTankPhase1,
+		APLDemonologyTankPhase1,
+		APLDestructionTankPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, Record<number, PresetUtils.PresetRotation>> = {
+  25: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][1],
+		2: APLPresets[Phase.Phase1][2],
+	},
+  40: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][1],
+		2: APLPresets[Phase.Phase1][2],
+	}
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
 
-export const DefaultTalents = {
-	name: 'Default',
-	data: SavedTalents.create({
-		talentsString: '25002-2050300142301-52500051020001',
-	}),
-};
-
-export const AfflictionTankTalents = {
+export const TalentsAfflictionTankPhase1 = {
 	name: 'Affliction Tank',
 	data: SavedTalents.create({
 		talentsString: '050025001-003',
 	}),
 };
 
-export const DestroTalents = {
+export const TalentsDestructionTankPhase1 = {
 	name: 'Destruction',
 	data: SavedTalents.create({
 		talentsString: '-03-0550201',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsAfflictionTankPhase1,
+		TalentsDestructionTankPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalentsAffliction 	= TalentPresets[Phase.Phase1][0]
+// export const DefaultTalentsDemonology 	= TalentPresets[Phase.Phase1][1];
+export const DefaultTalentsDestruction 	= TalentPresets[Phase.Phase1][1];
+
+export const DefaultTalents = DefaultTalentsAffliction;
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = WarlockOptions.create({
 	armor: Armor.DemonArmor,

--- a/ui/tank_warlock/sim.ts
+++ b/ui/tank_warlock/sim.ts
@@ -1,4 +1,4 @@
-import { APLRotation } from '../core/proto/apl.js';
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Faction,
@@ -80,7 +80,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankWarlock, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.GearAfflictionTankDefault.gear,
+		gear: Presets.DefaultGear.gear,
 
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
@@ -98,7 +98,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankWarlock, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default talents.
-		talents: Presets.AfflictionTankTalents.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 
@@ -155,32 +155,30 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankWarlock, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.AfflictionTankTalents,
-			Presets.DestroTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.RotationAfflictionTankDefault,
-			Presets.RotationDestructionTankDefault,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.GearAfflictionTankDefault,
-			Presets.GearDestructionTankDefault,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (player: Player<Spec.SpecTankWarlock>): APLRotation => {
+	autoRotation: (player) => {
 		const hasMasterChanneler = player.getEquippedItem(ItemSlot.ItemSlotChest)?.rune?.id == WarlockRune.RuneChestMasterChanneler
-		const hasLakeOfFire = player.getEquippedItem(ItemSlot.ItemSlotChest)?.rune?.id == WarlockRune.RuneChestLakeOfFire
-		if (hasMasterChanneler) {
-			return Presets.RotationAfflictionTankDefault.rotation.rotation!;
-		} else if (hasLakeOfFire) {
-			return Presets.RotationDestructionTankDefault.rotation.rotation!;
-		} else {
-			return Presets.RotationDestructionTankDefault.rotation.rotation!;
-		}
+		// const hasLakeOfFire = player.getEquippedItem(ItemSlot.ItemSlotChest)?.rune?.id == WarlockRune.RuneChestLakeOfFire
+
+		// Affliction vs Destruction
+		const specNumber = hasMasterChanneler ? 0 : 2
+
+		return Presets.DefaultAPLs[player.getLevel()][specNumber].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -201,10 +199,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankWarlock, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearAfflictionTankDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearAfflictionTankDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 			otherDefaults: Presets.OtherDefaults,
@@ -226,10 +224,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankWarlock, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearDestructionTankDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearDestructionTankDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 			},
 			otherDefaults: Presets.OtherDefaults,

--- a/ui/warlock/presets.ts
+++ b/ui/warlock/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Debuffs,
@@ -20,16 +21,65 @@ import {
 } from '../core/proto/warlock.js';
 import * as PresetUtils from '../core/preset_utils.js';
 
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
+
 import DestructionGear from './gear_sets/destruction.gear.json';
 import DestructionAPL from './apls/destruction.apl.json';
 
-export const GearAfflictionDefault = PresetUtils.makePresetGear('Affliction', DestructionGear);
-export const GearDemonologyDefault = PresetUtils.makePresetGear('Demonology', DestructionGear);
-export const GearDestructionDefault = PresetUtils.makePresetGear('Destruction', DestructionGear);
+export const GearAfflictionPhase1 = PresetUtils.makePresetGear('Affliction', DestructionGear);
+export const GearDemonologyPhase1 = PresetUtils.makePresetGear('Demonology', DestructionGear);
+export const GearDestructionPhase1 = PresetUtils.makePresetGear('Destruction', DestructionGear);
 
-export const RotationAfflictionDefault = PresetUtils.makePresetAPLRotation('Affliction', DestructionAPL);
-export const RotationDemonologyDefault = PresetUtils.makePresetAPLRotation('Demonology', DestructionAPL);
-export const RotationDestructionDefault = PresetUtils.makePresetAPLRotation('Destruction', DestructionAPL);
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearAfflictionPhase1,
+		GearDemonologyPhase1,
+		GearDestructionPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+export const RotationAfflictionPhase1 = PresetUtils.makePresetAPLRotation('Affliction', DestructionAPL);
+export const RotationDemonologyPhase1 = PresetUtils.makePresetAPLRotation('Demonology', DestructionAPL);
+export const RotationDestructionPhase1 = PresetUtils.makePresetAPLRotation('Destruction', DestructionAPL);
+
+export const APLPresets = {
+  [Phase.Phase1]: [
+    RotationAfflictionPhase1,
+		RotationDemonologyPhase1,
+		RotationDestructionPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, Record<number, PresetUtils.PresetRotation>> = {
+  25: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][1],
+		2: APLPresets[Phase.Phase1][2],
+	},
+  40: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][1],
+		2: APLPresets[Phase.Phase1][2],
+	}
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
@@ -40,6 +90,25 @@ export const DestroTalents = {
 		talentsString: '-03-0550201',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    DestroTalents,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalentsAffliction = TalentPresets[Phase.Phase1][0];
+export const DefaultTalentsDemonology	= TalentPresets[Phase.Phase1][0];
+export const DefaultTalentsDestruction = TalentPresets[Phase.Phase1][0];
+
+export const DefaultTalents = DefaultTalentsDestruction;
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = WarlockOptions.create({
 	armor: Armor.DemonArmor,

--- a/ui/warlock/sim.ts
+++ b/ui/warlock/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Faction,
@@ -7,10 +8,6 @@ import {
 	Spec,
 	Stat,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
-
 import { Stats } from '../core/proto_utils/stats.js';
 import { Player } from '../core/player.js';
 import { getSpecIcon } from '../core/proto_utils/utils.js';
@@ -21,7 +18,6 @@ import * as ConsumablesInputs from '../core/components/inputs/consumables.js';
 import * as OtherInputs from '../core/components/other_inputs.js';
 import * as WarlockInputs from './inputs.js';
 import * as Presets from './presets.js';
-import { WarlockOptions_Summon, WarlockRune } from '../core/proto/warlock.js';
 
 const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 	cssClass: 'warlock-sim-ui',
@@ -114,7 +110,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.GearDestructionDefault.gear,
+		gear: Presets.DefaultGear.gear,
 
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
@@ -132,7 +128,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default talents.
-		talents: Presets.DestroTalents.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 
@@ -195,28 +191,24 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.DestroTalents,
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.RotationDestructionDefault,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 
 		// Preset gear configurations that the user can quickly select.
 		gear: [
-			Presets.GearDestructionDefault,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (player: Player<Spec.SpecWarlock>): APLRotation => {
-		const talentTree = player.getTalentTree();
-		if (talentTree == 0) {
-			return Presets.RotationAfflictionDefault.rotation.rotation!;
-		} else if (talentTree == 1) {
-			return Presets.RotationDemonologyDefault.rotation.rotation!;
-		} else {
-			return Presets.RotationDestructionDefault.rotation.rotation!;
-		}
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()][player.getTalentTree()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -226,7 +218,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 			defaultName: 'Affliction',
 			iconUrl: getSpecIcon(Class.ClassWarlock, 0),
 
-			talents: Presets.DestroTalents.data,
+			talents: Presets.DefaultTalentsAffliction.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -237,10 +229,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearAfflictionDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearAfflictionDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 			otherDefaults: Presets.OtherDefaults,
@@ -251,7 +243,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 			defaultName: 'Demonology',
 			iconUrl: getSpecIcon(Class.ClassWarlock, 1),
 
-			talents: Presets.DestroTalents.data,
+			talents: Presets.DefaultTalentsDemonology.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -262,10 +254,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearDemonologyDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearDemonologyDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 			},
 			otherDefaults: Presets.OtherDefaults,
@@ -276,7 +268,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 			defaultName: 'Destruction',
 			iconUrl: getSpecIcon(Class.ClassWarlock, 2),
 
-			talents: Presets.DestroTalents.data,
+			talents: Presets.DefaultTalentsDestruction.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -287,10 +279,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarlock, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearDestructionDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][2].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearDestructionDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][2].gear,
 				},
 			},
 			otherDefaults: Presets.OtherDefaults,

--- a/ui/warrior/presets.ts
+++ b/ui/warrior/presets.ts
@@ -1,3 +1,4 @@
+import { Phase } from '../core/constants/other.js';
 import {
 	Consumes,
 	Debuffs,
@@ -17,15 +18,17 @@ import {
 
 import * as PresetUtils from '../core/preset_utils.js';
 
-import BlankGear from './gear_sets/blank.gear.json';
-import Phase1Gear from './gear_sets/phase_1.gear.json';
-import Phase1DWGear from './gear_sets/phase_1_dw.gear.json';
-
-import Phase1APL from './apls/phase_1.apl.json';
-
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Gear Presets
+///////////////////////////////////////////////////////////////////////////
+
+import BlankGear from './gear_sets/blank.gear.json';
+import Phase1Gear from './gear_sets/phase_1.gear.json';
+import Phase1DWGear from './gear_sets/phase_1_dw.gear.json';
 
 export const GearBlank = PresetUtils.makePresetGear('Blank', BlankGear);
 
@@ -33,22 +36,80 @@ export const GearArmsPhase1 = PresetUtils.makePresetGear('P1 Arms 2H', Phase1Gea
 export const GearArmsDWPhase1 = PresetUtils.makePresetGear('P1 Arms DW', Phase1DWGear, { talentTree: 0 });
 export const GearFuryPhase1 = PresetUtils.makePresetGear('P1 Fury', Phase1Gear, { talentTree: 1 });
 
-export const GearArmsDefault = GearArmsPhase1;
-export const GearFuryDefault = GearFuryPhase1;
+export const GearPresets = {
+  [Phase.Phase1]: [
+    GearArmsPhase1,
+		GearFuryPhase1,
+		GearArmsDWPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultGear = GearPresets[Phase.Phase1][0];
+
+///////////////////////////////////////////////////////////////////////////
+//                                 APL Presets
+///////////////////////////////////////////////////////////////////////////
+
+import Phase1APL from './apls/phase_1.apl.json';
 
 export const APLPhase1 = PresetUtils.makePresetAPLRotation('P1 Preset', Phase1APL);
 
-export const RotationArmsDefault = APLPhase1;
-export const RotationFuryDefault = APLPhase1;
+export const APLPresets = {
+  [Phase.Phase1]: [
+    APLPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultAPLs: Record<number, Record<number, PresetUtils.PresetRotation>> = {
+  25: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][0],
+		2: APLPresets[Phase.Phase1][0],
+	},
+  40: {
+		0: APLPresets[Phase.Phase1][0],
+		1: APLPresets[Phase.Phase1][0],
+		2: APLPresets[Phase.Phase1][0],
+	}
+};
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Talent Presets
+///////////////////////////////////////////////////////////////////////////
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/classic/talent-calc and copy the numbers in the url.
-export const Talent25 = {
+
+export const TalentsPhase1 = {
 	name: 'Level 25',
 	data: SavedTalents.create({
 		talentsString: '303220203-01',
 	}),
 };
+
+export const TalentPresets = {
+  [Phase.Phase1]: [
+    TalentsPhase1,
+  ],
+  [Phase.Phase2]: [
+  ]
+};
+
+// TODO: Add Phase 2 preset and pull from map
+export const DefaultTalentsArms = TalentPresets[Phase.Phase1][0];
+export const DefaultTalentsFury = TalentPresets[Phase.Phase1][0];
+
+export const DefaultTalents = DefaultTalentsArms;
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Options Presets
+///////////////////////////////////////////////////////////////////////////
 
 export const DefaultOptions = WarriorOptions.create({
 	startingRage: 0,

--- a/ui/warrior/sim.ts
+++ b/ui/warrior/sim.ts
@@ -1,3 +1,4 @@
+import { CURRENT_PHASE, Phase } from '../core/constants/other.js';
 import {
 	Class,
 	Faction,
@@ -8,9 +9,6 @@ import {
 	Stat, PseudoStat,
 	TristateEffect,
 } from '../core/proto/common.js';
-import {
-	APLRotation,
-} from '../core/proto/apl.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { Player } from '../core/player.js';
 import { getSpecIcon } from '../core/proto_utils/utils.js';
@@ -68,7 +66,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.GearArmsDefault.gear,
+		gear: Presets.DefaultGear.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
 			[Stat.StatStrength]: 2.72,
@@ -87,7 +85,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 		// Default talents.
-		talents: Presets.Talent25.data,
+		talents: Presets.DefaultTalents.data,
 		// Default spec-specific settings.
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
@@ -127,28 +125,24 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [
-			Presets.Talent25
+			...Presets.TalentPresets[Phase.Phase1],
+			...Presets.TalentPresets[CURRENT_PHASE],
 		],
 		// Preset rotations that the user can quickly select.
 		rotations: [
-			Presets.APLPhase1,
+			...Presets.APLPresets[Phase.Phase1],
+			...Presets.APLPresets[CURRENT_PHASE],
 		],
 		// Preset gear configurations that the user can quickly select.
 		gear: [
 			Presets.GearBlank,
-			Presets.GearArmsPhase1,
-			Presets.GearArmsDWPhase1,
-			Presets.GearFuryPhase1,
+			...Presets.GearPresets[Phase.Phase1],
+			...Presets.GearPresets[CURRENT_PHASE],
 		],
 	},
 
-	autoRotation: (player: Player<Spec.SpecWarrior>): APLRotation => {
-		const talentTree = player.getTalentTree();
-		if (talentTree == 0) {
-			return Presets.RotationArmsDefault.rotation.rotation!;
-		} else {
-			return Presets.RotationFuryDefault.rotation.rotation!;
-		}
+	autoRotation: (player) => {
+		return Presets.DefaultAPLs[player.getLevel()][player.getTalentTree()].rotation.rotation!;
 	},
 
 	raidSimPresets: [
@@ -158,7 +152,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 			defaultName: 'Arms',
 			iconUrl: getSpecIcon(Class.ClassWarrior, 0),
 
-			talents: Presets.Talent25.data,
+			talents: Presets.DefaultTalentsArms.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -169,10 +163,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearArmsDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearArmsDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][0].gear,
 				},
 			},
 		},
@@ -182,7 +176,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 			defaultName: 'Fury',
 			iconUrl: getSpecIcon(Class.ClassWarrior, 1),
 
-			talents: Presets.Talent25.data,
+			talents: Presets.DefaultTalentsFury.data,
 			specOptions: Presets.DefaultOptions,
 			consumes: Presets.DefaultConsumes,
 			defaultFactionRaces: {
@@ -193,10 +187,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 			defaultGear: {
 				[Faction.Unknown]: {},
 				[Faction.Alliance]: {
-					1: Presets.GearFuryDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 				[Faction.Horde]: {
-					1: Presets.GearFuryDefault.gear,
+					1: Presets.GearPresets[Phase.Phase1][1].gear,
 				},
 			},
 		},


### PR DESCRIPTION
- Sets Phase 2 as the default throughout the system.
- Also allows auto rotations to be configured by level, so that when players switch levels with Auto Rotation selected, a rotation corresponding to the player's level bracket will be used.