### PR TITLE
Orcs should not have fist skill racial

### DIFF
--- a/sim/core/racials.go
+++ b/sim/core/racials.go
@@ -91,7 +91,7 @@ func applyRaceEffects(agent Agent) {
 		})
 
 		// Axe specialization
-		character.ApplyWeaponSpecialization(5, proto.WeaponType_WeaponTypeAxe, proto.WeaponType_WeaponTypeFist)
+		character.ApplyWeaponSpecialization(5, proto.WeaponType_WeaponTypeAxe)
 	case proto.Race_RaceTauren:
 		character.PseudoStats.ReducedNatureHitTakenChance += 0.02
 		character.AddStat(stats.Health, character.GetBaseStats()[stats.Health]*0.05)


### PR DESCRIPTION
[Reference](https://www.wowhead.com/classic/spell=20574/axe-specialization) as opposed to the [future version](https://www.wowhead.com/wotlk/spell=20574/axe-specialization) which does.