### PR TITLE
Add starsurge lunar eclipse crit bonus

### DIFF
--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -161,6 +161,300 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_1-Default-phase_2-FullBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 33.0604
+  tps: 43.6655
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_1-Default-phase_2-FullBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 33.0604
+  tps: 33.59065
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_1-Default-phase_2-FullBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 33.03235
+  tps: 35.16801
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_1-Default-phase_2-NoBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 32.13696
+  tps: 32.13696
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_1-Default-phase_2-NoBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 32.13696
+  tps: 32.13696
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_1-Default-phase_2-NoBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 32.82904
+  tps: 32.82904
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_1-FullBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 102.88453
+  tps: 124.19733
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_1-FullBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 102.88453
+  tps: 103.95017
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_1-FullBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 106.7322
+  tps: 111.69948
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_1-NoBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 100.36065
+  tps: 100.36065
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_1-NoBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 100.36065
+  tps: 100.36065
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_1-NoBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 106.98319
+  tps: 106.98319
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_2-FullBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 62.15304
+  tps: 69.90224
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_2-FullBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 62.15304
+  tps: 62.5405
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_2-FullBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 62.05179
+  tps: 63.86563
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_2-NoBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 61.67812
+  tps: 61.67812
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_2-NoBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 61.67812
+  tps: 61.67812
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-25-phase_2-Default-phase_2-NoBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 61.38657
+  tps: 61.38657
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_1-FullBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 115.70634
+  tps: 235.34579
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_1-FullBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 115.70634
+  tps: 121.68832
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_1-FullBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 114.2282
+  tps: 124.22293
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_1-NoBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 102.91597
+  tps: 102.91597
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_1-NoBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 102.91597
+  tps: 102.91597
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_1-NoBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 113.87893
+  tps: 113.87893
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_2-FullBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 124.55498
+  tps: 232.04758
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_2-FullBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 124.55498
+  tps: 129.92961
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_2-FullBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 117.73747
+  tps: 127.91979
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_2-NoBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 125.81317
+  tps: 125.81317
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_2-NoBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 125.81317
+  tps: 125.81317
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_1-Default-phase_2-NoBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 117.20238
+  tps: 117.20238
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_1-FullBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 181.31128
+  tps: 300.36622
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_1-FullBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 181.31128
+  tps: 187.26402
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_1-FullBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 190.41167
+  tps: 199.37695
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_1-NoBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 168.50212
+  tps: 168.50212
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_1-NoBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 168.50212
+  tps: 168.50212
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_1-NoBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 188.74505
+  tps: 188.74505
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_2-FullBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 223.52802
+  tps: 349.48962
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_2-FullBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 223.52802
+  tps: 229.8261
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_2-FullBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 231.44896
+  tps: 243.05316
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_2-NoBuffs-Full Consumes-LongMultiTarget"
+ value: {
+  dps: 206.02085
+  tps: 206.02085
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_2-NoBuffs-Full Consumes-LongSingleTarget"
+ value: {
+  dps: 206.02085
+  tps: 206.02085
+ }
+}
+dps_results: {
+ key: "TestBalance-Settings-Tauren-40-phase_2-Default-phase_2-NoBuffs-Full Consumes-ShortSingleTarget"
+ value: {
+  dps: 230.77126
+  tps: 230.77126
+ }
+}
+dps_results: {
  key: "TestBalance-SwitchInFrontOfTarget-Default"
  value: {
   dps: 60.91753

--- a/sim/druid/balance/balance_test.go
+++ b/sim/druid/balance/balance_test.go
@@ -14,21 +14,30 @@ func init() {
 
 func TestBalance(t *testing.T) {
 	core.RunTestSuite(t, t.Name(), core.FullCharacterTestSuiteGenerator(core.CharacterSuiteConfig{
-		Class: proto.Class_ClassDruid,
-		Race:  proto.Race_RaceTauren,
+		Class:       proto.Class_ClassDruid,
+		Race:        proto.Race_RaceTauren,
+		Level:       25,
+		OtherLevels: []int32{40},
 
-		GearSet:       core.GetGearSet("../../../ui/balance_druid/gear_sets", "phase_1"),
-		OtherGearSets: []core.GearSetCombo{},
-		Talents:       StandardTalents,
-		Consumes:      FullConsumes,
-		SpecOptions:   core.SpecOptionsCombo{Label: "Default", SpecOptions: PlayerOptionsAdaptive},
-		Rotation:      core.GetAplRotation("../../../ui/balance_druid/apls", "phase_1"),
+		GearSet: core.GetGearSet("../../../ui/balance_druid/gear_sets", "phase_1"),
+		OtherGearSets: []core.GearSetCombo{
+			core.GetGearSet("../../../ui/balance_druid/gear_sets", "phase_2"),
+		},
+
+		Talents:     phase2Talents,
+		Consumes:    FullConsumes,
+		SpecOptions: core.SpecOptionsCombo{Label: "Default", SpecOptions: PlayerOptionsAdaptive},
+		Rotation:    core.GetAplRotation("../../../ui/balance_druid/apls", "phase_1"),
+		OtherRotations: []core.RotationCombo{
+			core.GetAplRotation("../../../ui/balance_druid/apls", "phase_2"),
+		},
 
 		ItemFilter: ItemFilter,
 	}))
 }
 
-var StandardTalents = "5000500302541051"
+var phase1Talents = "50005003021"
+var phase2Talents = "5000500302541051"
 
 var FullConsumes = core.ConsumesCombo{
 	Label: "Full Consumes",

--- a/sim/druid/runes.go
+++ b/sim/druid/runes.go
@@ -4,7 +4,6 @@ import (
 	"slices"
 	"time"
 
-	item_sets "github.com/wowsims/sod/sim/common/sod/items_sets"
 	"github.com/wowsims/sod/sim/core"
 	"github.com/wowsims/sod/sim/core/proto"
 )
@@ -93,11 +92,13 @@ func (druid *Druid) applyEclipse() {
 			core.Each(affectedLunarSpells, func(spell *DruidSpell) {
 				spell.DefaultCast.CastTime -= lunarCastTimeReduction
 			})
+			druid.Starsurge.BonusCritRating += 30.0
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			core.Each(affectedLunarSpells, func(spell *DruidSpell) {
 				spell.DefaultCast.CastTime += lunarCastTimeReduction
 			})
+			druid.Starsurge.BonusCritRating -= 30.0
 		},
 		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
 			if spell.SpellCode != SpellCode_DruidStarfire {
@@ -195,59 +196,6 @@ func (druid *Druid) applySunfire() {
 			if result.Landed() {
 				spell.Dot(target).Apply(sim)
 			}
-		},
-	})
-}
-
-func (druid *Druid) applyStarsurge() {
-	if !druid.HasRune(proto.DruidRune_RuneLegsStarsurge) {
-		return
-	}
-
-	level := float64(druid.GetCharacter().Level)
-	baseCalc := (9.183105 + 0.616405*level + 0.028608*level*level)
-	baseLowDamage := baseCalc * 3.81
-	baseHighDamage := baseCalc * 4.67
-
-	druid.Starsurge = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 417157},
-		SpellCode:   SpellCode_DruidStarsurge,
-		SpellSchool: core.SpellSchoolArcane,
-		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       core.SpellFlagAPL | core.SpellFlagResetAttackSwing,
-
-		MissileSpeed: 24,
-
-		ManaCost: core.ManaCostOptions{
-			BaseCost: 0.01 * (1 - 0.03*float64(druid.Talents.Moonglow)),
-		},
-		Cast: core.CastConfig{
-			DefaultCast: core.Cast{
-				GCD:      core.GCDDefault,
-				CastTime: 0,
-			},
-			CD: core.Cooldown{
-				Timer:    druid.NewTimer(),
-				Duration: time.Second * 6,
-			},
-		},
-
-		DamageMultiplier: 1,
-		CritMultiplier:   druid.VengeanceCritMultiplier(),
-		BonusCritRating:  core.TernaryFloat64(druid.HasSetBonus(item_sets.ItemSetInsulatedSorcerorLeather, 3), 2, 0) * core.CritRatingPerCritChance,
-		ThreatMultiplier: 1,
-
-		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := sim.Roll(baseLowDamage, baseHighDamage)*druid.MoonfuryDamageMultiplier() + spell.SpellDamage()
-			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
-
-			if result.DidCrit() && druid.NaturesGraceProcAura != nil {
-				druid.NaturesGraceProcAura.Activate(sim)
-			}
-
-			spell.WaitTravelTime(sim, func(sim *core.Simulation) {
-				spell.DealDamage(sim, result)
-			})
 		},
 	})
 }

--- a/sim/druid/starsurge.go
+++ b/sim/druid/starsurge.go
@@ -1,0 +1,62 @@
+package druid
+
+import (
+	"time"
+
+	item_sets "github.com/wowsims/sod/sim/common/sod/items_sets"
+	"github.com/wowsims/sod/sim/core"
+	"github.com/wowsims/sod/sim/core/proto"
+)
+
+func (druid *Druid) applyStarsurge() {
+	if !druid.HasRune(proto.DruidRune_RuneLegsStarsurge) {
+		return
+	}
+
+	level := float64(druid.GetCharacter().Level)
+	baseCalc := (9.183105 + 0.616405*level + 0.028608*level*level)
+	baseLowDamage := baseCalc * 3.81
+	baseHighDamage := baseCalc * 4.67
+
+	druid.Starsurge = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
+		ActionID:    core.ActionID{SpellID: 417157},
+		SpellCode:   SpellCode_DruidStarsurge,
+		SpellSchool: core.SpellSchoolArcane,
+		ProcMask:    core.ProcMaskSpellDamage,
+		Flags:       core.SpellFlagAPL | core.SpellFlagResetAttackSwing,
+
+		MissileSpeed: 24,
+
+		ManaCost: core.ManaCostOptions{
+			BaseCost: 0.01 * (1 - 0.03*float64(druid.Talents.Moonglow)),
+		},
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD:      core.GCDDefault,
+				CastTime: 0,
+			},
+			CD: core.Cooldown{
+				Timer:    druid.NewTimer(),
+				Duration: time.Second * 6,
+			},
+		},
+
+		DamageMultiplier: 1,
+		CritMultiplier:   druid.VengeanceCritMultiplier(),
+		BonusCritRating:  core.TernaryFloat64(druid.HasSetBonus(item_sets.ItemSetInsulatedSorcerorLeather, 3), 2, 0) * core.CritRatingPerCritChance,
+		ThreatMultiplier: 1,
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			baseDamage := sim.Roll(baseLowDamage, baseHighDamage)*druid.MoonfuryDamageMultiplier() + spell.SpellDamage()
+			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
+
+			if result.DidCrit() && druid.NaturesGraceProcAura != nil {
+				druid.NaturesGraceProcAura.Activate(sim)
+			}
+
+			spell.WaitTravelTime(sim, func(sim *core.Simulation) {
+				spell.DealDamage(sim, result)
+			})
+		},
+	})
+}


### PR DESCRIPTION
This is a bugged interaction (we assume) because lunar eclipse no longer states that it provides crit, however it's stood for a while and through the most recent balance changes