### PR TITLE
Fixes for Innervate and Mana Tide auras

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1405,13 +1405,12 @@ func registerInnervateCD(agent Agent, numInnervates int32) {
 		return
 	}
 
-	innervateThreshold := 0.0
-	var innervateAura *Aura
-
 	character := agent.GetCharacter()
+	innervateThreshold := 0.0
+	innervateAura := InnervateAura(character, -1)
+
 	character.Env.RegisterPostFinalizeEffect(func() {
 		innervateThreshold = InnervateManaThreshold(character)
-		innervateAura = InnervateAura(character, -1)
 	})
 
 	registerExternalConsecutiveCDApproximation(
@@ -1467,14 +1466,13 @@ func registerManaTideTotemCD(agent Agent, numManaTideTotems int32) {
 		return
 	}
 
-	initialDelay := time.Duration(0)
-	var mttAura *Aura
-
 	character := agent.GetCharacter()
+	initialDelay := time.Duration(0)
+	mttAura := ManaTideTotemAura(character, -1)
+
 	character.Env.RegisterPostFinalizeEffect(func() {
 		// Use first MTT at 60s, or halfway through the fight, whichever comes first.
 		initialDelay = min(character.Env.BaseDuration/2, time.Second*60)
-		mttAura = ManaTideTotemAura(character, -1)
 	})
 
 	registerExternalConsecutiveCDApproximation(

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1506,6 +1506,13 @@ func ManaTideTotemAura(character *Character, actionTag int32) *Aura {
 		}
 	}
 
+	manaPerTick := map[int32]float64{
+		25: 0,
+		40: 170, // Rank 1
+		50: 230, // Rank 2
+		60: 290, // Rank 3
+	}[character.Level]
+
 	return character.GetOrRegisterAura(Aura{
 		Label:    "ManaTideTotem-" + actionID.String(),
 		Tag:      ManaTideTotemAuraTag,
@@ -1519,7 +1526,7 @@ func ManaTideTotemAura(character *Character, actionTag int32) *Aura {
 					for i, player := range character.Party.Players {
 						if metrics[i] != nil {
 							char := player.GetCharacter()
-							char.AddMana(sim, 0.06*char.MaxMana(), metrics[i])
+							char.AddMana(sim, manaPerTick, metrics[i])
 						}
 					}
 				},

--- a/sim/druid/innervate.go
+++ b/sim/druid/innervate.go
@@ -18,7 +18,7 @@ func (druid *Druid) registerInnervateCD() {
 
 	innervateCD := core.InnervateCD
 
-	var innervateAura *core.Aura
+	innervateAura := core.InnervateAura(innervateTargetChar, actionID.Tag)
 	var innervateManaThreshold float64
 
 	druid.RegisterResetEffect(func(sim *core.Simulation) {
@@ -34,7 +34,6 @@ func (druid *Druid) registerInnervateCD() {
 		} else {
 			innervateManaThreshold = core.InnervateManaThreshold(innervateTargetChar)
 		}
-		innervateAura = core.InnervateAura(innervateTargetChar, actionID.Tag)
 	})
 
 	innervateSpell = druid.RegisterSpell(Humanoid|Moonkin|Tree, core.SpellConfig{

--- a/ui/balance_druid/inputs.ts
+++ b/ui/balance_druid/inputs.ts
@@ -1,5 +1,28 @@
+import { Spec, UnitReference, UnitReference_Type } from '../core/proto/common.js';
+import * as InputHelpers from '../core/components/input_helpers.js';
+import { ActionId } from '../core/proto_utils/action_id.js';
+import { Player } from '../core/player.js';
+import { EventID } from '../core/typed_event.js';
+
 // Configuration for spec-specific UI elements on the settings tab.
 // These don't need to be in a separate file but it keeps things cleaner.
+
+export const SelfInnervate = InputHelpers.makeSpecOptionsBooleanIconInput<Spec.SpecBalanceDruid>({
+	fieldName: 'innervateTarget',
+	actionId: () => ActionId.fromSpellId(29166),
+	extraCssClasses: [
+		'within-raid-sim-hide',
+	],
+	getValue: (player: Player<Spec.SpecBalanceDruid>) => player.getSpecOptions().innervateTarget?.type == UnitReference_Type.Player,
+	setValue: (eventID: EventID, player: Player<Spec.SpecBalanceDruid>, newValue: boolean) => {
+		const newOptions = player.getSpecOptions();
+		newOptions.innervateTarget = UnitReference.create({
+			type: newValue ? UnitReference_Type.Player : UnitReference_Type.Unknown,
+			index: 0,
+		});
+		player.setSpecOptions(eventID, newOptions);
+	},
+});
 
 export const BalanceDruidRotationConfig = {
 	inputs: [],

--- a/ui/balance_druid/sim.ts
+++ b/ui/balance_druid/sim.ts
@@ -15,6 +15,7 @@ import * as BuffDebuffInputs from '../core/components/inputs/buffs_debuffs';
 import * as ConsumablesInputs from '../core/components/inputs/consumables.js';
 import * as OtherInputs from '../core/components/other_inputs.js';
 import * as Presets from './presets.js';
+import * as DruidInputs from './inputs.js';
 
 const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	cssClass: 'balance-druid-sim-ui',
@@ -83,6 +84,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 
 	// IconInputs to include in the 'Player' section on the settings tab.
 	playerIconInputs: [
+		DruidInputs.SelfInnervate,
 	],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
 	includeBuffDebuffInputs: [


### PR DESCRIPTION
Add self Innervate to balance UI.
Fix Innervate (and Mana Tide) auras being registered too late.
Change Mana Tide aura to use flat mana values.