### PR TITLE
Shaman stuff

### DIFF
--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.42992
+  weights: -0.24219
   weights: 0
-  weights: 0.82502
-  weights: 0
-  weights: 0
+  weights: 0.76095
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 7.319
-  weights: 4.38145
+  weights: 0
+  weights: 0
+  weights: 6.90069
+  weights: 3.80073
   weights: 0
   weights: 0
   weights: 0
@@ -407,8 +407,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 128.99257
-  tps: 134.74162
+  dps: 128.30277
+  tps: 134.05181
  }
 }
 dps_results: {
@@ -421,29 +421,29 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-Average-Default"
  value: {
-  dps: 561.29658
-  tps: 570.59972
+  dps: 519.10958
+  tps: 528.41272
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 558.9036
-  tps: 745.02582
+  dps: 517.12279
+  tps: 703.24502
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 558.9036
-  tps: 568.20971
+  dps: 517.12279
+  tps: 526.42891
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 584.73723
-  tps: 596.85504
+  dps: 550.05766
+  tps: 562.17547
  }
 }
 dps_results: {
@@ -470,22 +470,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 561.02719
-  tps: 747.53442
+  dps: 518.82093
+  tps: 705.32815
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 561.02719
-  tps: 570.35256
+  dps: 518.82093
+  tps: 528.14629
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 584.73723
-  tps: 596.85504
+  dps: 550.05766
+  tps: 562.17547
  }
 }
 dps_results: {
@@ -512,7 +512,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 561.02719
-  tps: 570.35256
+  dps: 518.82093
+  tps: 528.14629
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -148,16 +148,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.45134
-  weights: 0.22824
+  weights: 0.44882
+  weights: 0.21452
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.31737
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.28298
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.20515
   weights: 0
-  weights: 2.74341
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.20401
+  weights: 0
+  weights: 2.56113
   weights: 0
   weights: 0
   weights: 0
@@ -463,266 +463,266 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 344.36482
-  tps: 382.01795
+  dps: 293.04675
+  tps: 329.76133
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 340.27517
-  tps: 378.41066
+  dps: 289.45313
+  tps: 327.27318
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 340.78987
-  tps: 378.43332
+  dps: 289.70404
+  tps: 326.40661
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 303.54233
-  tps: 311.86421
+  dps: 244.81455
+  tps: 249.44098
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 298.41197
-  tps: 303.91091
+  dps: 239.0641
+  tps: 240.41003
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 285.89396
-  tps: 292.35167
+  dps: 231.77367
+  tps: 235.21327
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 295.07969
-  tps: 299.31122
+  dps: 238.08538
+  tps: 240.03634
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 297.61361
-  tps: 301.81777
+  dps: 237.85709
+  tps: 238.74313
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 290.30089
-  tps: 294.77725
+  dps: 234.04218
+  tps: 235.67339
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 298.36466
-  tps: 303.04467
+  dps: 240.70215
+  tps: 242.09774
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 194.81281
-  tps: 193.6612
+  dps: 146.6271
+  tps: 144.88947
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 338.76123
-  tps: 376.89581
+  dps: 288.17694
+  tps: 325.88483
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
-  dps: 456.84071
-  tps: 495.83051
+  dps: 424.18896
+  tps: 462.90898
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 412.9288
-  tps: 464.99288
+  dps: 403.77611
+  tps: 458.40136
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 431.82413
-  tps: 485.30719
+  dps: 394.76754
+  tps: 447.14035
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 446.92775
-  tps: 501.06579
+  dps: 421.84485
+  tps: 476.01115
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 258.81978
-  tps: 295.5301
+  dps: 257.33591
+  tps: 300.23948
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 263.77014
-  tps: 301.7787
+  dps: 247.24381
+  tps: 288.51086
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 264.74636
-  tps: 302.82223
+  dps: 254.2548
+  tps: 295.94765
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 412.9288
-  tps: 463.96453
+  dps: 403.77611
+  tps: 457.46245
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 431.82413
-  tps: 483.19106
+  dps: 394.76754
+  tps: 446.65103
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 446.92775
-  tps: 499.6993
+  dps: 421.84485
+  tps: 474.69141
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 258.81978
-  tps: 295.43071
+  dps: 257.33591
+  tps: 300.14923
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 263.77014
-  tps: 301.68213
+  dps: 247.24381
+  tps: 288.28998
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 264.74636
-  tps: 302.7057
+  dps: 254.2548
+  tps: 295.72574
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 410.52061
-  tps: 464.63829
+  dps: 400.59529
+  tps: 454.12905
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 428.1369
-  tps: 484.79961
+  dps: 391.59434
+  tps: 446.2399
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 443.49104
-  tps: 499.67816
+  dps: 410.29819
+  tps: 466.23895
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 257.00681
-  tps: 294.09135
+  dps: 254.91765
+  tps: 296.8
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 260.47855
-  tps: 299.64116
+  dps: 244.65827
+  tps: 286.87313
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 261.49165
-  tps: 300.6304
+  dps: 247.82785
+  tps: 290.4886
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 410.52061
-  tps: 463.62391
+  dps: 400.59529
+  tps: 453.67652
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 428.1369
-  tps: 482.80488
+  dps: 391.59434
+  tps: 445.83463
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 443.49104
-  tps: 498.37708
+  dps: 410.29819
+  tps: 465.54855
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 257.00681
-  tps: 294.52898
+  dps: 254.91765
+  tps: 297.31327
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 260.47855
-  tps: 299.55322
+  dps: 244.65827
+  tps: 286.66088
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 261.49165
-  tps: 300.53806
+  dps: 247.82785
+  tps: 290.39618
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 421.52646
-  tps: 460.15575
+  dps: 391.02468
+  tps: 430.57059
  }
 }

--- a/sim/shaman/flametongue_weapon.go
+++ b/sim/shaman/flametongue_weapon.go
@@ -1,8 +1,6 @@
 package shaman
 
 import (
-	"time"
-
 	"github.com/wowsims/sod/sim/core"
 )
 
@@ -33,7 +31,7 @@ func (shaman *Shaman) newFlametongueImbueSpell(weapon *core.Item) *core.Spell {
 		SpellSchool: core.SpellSchoolFire,
 		ProcMask:    core.ProcMaskWeaponProc,
 
-		DamageMultiplier: 1 + .05*float64(shaman.Talents.ElementalWeapons),
+		DamageMultiplier: []float64{1, 1.05, 1.1, 1.15}[shaman.Talents.ElementalWeapons],
 		CritMultiplier:   shaman.ElementalCritMultiplier(0),
 		ThreatMultiplier: 1,
 
@@ -77,11 +75,6 @@ func (shaman *Shaman) RegisterFlametongueImbue(procMask core.ProcMask) {
 	rank := FlametongueWeaponRankByLevel[level]
 	enchantId := FlametongueWeaponEnchantId[rank]
 
-	icd := core.Cooldown{
-		Timer:    shaman.NewTimer(),
-		Duration: time.Millisecond,
-	}
-
 	mhSpell := shaman.newFlametongueImbueSpell(shaman.MainHand())
 	ohSpell := shaman.newFlametongueImbueSpell(shaman.OffHand())
 
@@ -95,12 +88,6 @@ func (shaman *Shaman) RegisterFlametongueImbue(procMask core.ProcMask) {
 			if !result.Landed() || !spell.ProcMask.Matches(procMask) {
 				return
 			}
-
-			if !icd.IsReady(sim) {
-				return
-			}
-
-			icd.Use(sim)
 
 			if spell.IsMH() {
 				mhSpell.Cast(sim, result.Target)

--- a/sim/shaman/frostbrand_weapon.go
+++ b/sim/shaman/frostbrand_weapon.go
@@ -42,7 +42,7 @@ func (shaman *Shaman) newFrostbrandImbueSpell() *core.Spell {
 		SpellSchool: core.SpellSchoolFrost,
 		ProcMask:    core.ProcMaskWeaponProc,
 
-		DamageMultiplier: 1 + .05*float64(shaman.Talents.ElementalWeapons),
+		DamageMultiplier: []float64{1, 1.05, 1.1, 1.15}[shaman.Talents.ElementalWeapons],
 		CritMultiplier:   shaman.ElementalCritMultiplier(0),
 		ThreatMultiplier: 1,
 

--- a/sim/shaman/rockbiter_weapon.go
+++ b/sim/shaman/rockbiter_weapon.go
@@ -67,7 +67,7 @@ func (shaman *Shaman) ApplyRockbiterImbueToItem(item *core.Item) {
 	rank := RockbiterWeaponRankByLevel[level]
 	enchantId := RockbiterWeaponEnchantId[rank]
 
-	bonusAP := RockbiterWeaponBonusAP[rank] * (1 + (20.0/3/100)*float64(shaman.Talents.ElementalWeapons))
+	bonusAP := RockbiterWeaponBonusAP[rank] * []float64{1, 1.07, 1.14, 1.2}[shaman.Talents.ElementalWeapons]
 	newStats := stats.Stats{stats.AttackPower: bonusAP}
 
 	item.Stats = item.Stats.Add(newStats)

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -1,97 +1,44 @@
 package shaman
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/wowsims/sod/sim/core"
 	"github.com/wowsims/sod/sim/core/proto"
 )
 
-var StormstrikeActionID = core.ActionID{SpellID: 17364}
-
-func (shaman *Shaman) StormstrikeDebuffAura(target *core.Unit, level int32) *core.Aura {
-	duration := time.Second * 12
-
-	return target.GetOrRegisterAura(core.Aura{
-		Label:    fmt.Sprintf("Stormstrike-%s", shaman.Label),
-		ActionID: StormstrikeActionID,
-		Duration: duration,
-		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			shaman.AttackTables[aura.Unit.UnitIndex][proto.CastType_CastTypeMainHand].NatureDamageTakenMultiplier *= 1.2
-			shaman.AttackTables[aura.Unit.UnitIndex][proto.CastType_CastTypeOffHand].NatureDamageTakenMultiplier *= 1.2
-		},
-		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			shaman.AttackTables[aura.Unit.UnitIndex][proto.CastType_CastTypeMainHand].NatureDamageTakenMultiplier /= 1.2
-			shaman.AttackTables[aura.Unit.UnitIndex][proto.CastType_CastTypeOffHand].NatureDamageTakenMultiplier /= 1.2
-		},
-	})
-}
-
-func (shaman *Shaman) newStormstrikeHitSpell(isMH bool) *core.Spell {
-	var actionID core.ActionID
-	if isMH {
-		actionID = StormstrikeActionID.WithTag(1)
-	} else {
-		actionID = StormstrikeActionID.WithTag(2)
-	}
-	procMask := core.Ternary(isMH, core.ProcMaskMeleeMHSpecial, core.ProcMaskMeleeOHSpecial)
-
-	flags := core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage
-	if !isMH {
-		// Seems to be a bug with the classic implementation
-		flags |= core.SpellFlagNoOnCastComplete
-	}
-
-	return shaman.RegisterSpell(core.SpellConfig{
-		ActionID:    actionID,
-		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    procMask,
-		Flags:       flags,
-
-		ThreatMultiplier: 1,
-		DamageMultiplier: 1,
-		CritMultiplier:   shaman.DefaultMeleeCritMultiplier(),
-
-		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			var baseDamage float64
-			if isMH {
-				baseDamage = spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower()) + spell.BonusWeaponDamage()
-			} else {
-				baseDamage = (spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower()) + spell.BonusWeaponDamage()) *
-					shaman.AutoAttacks.OHConfig().DamageMultiplier
-			}
-
-			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
-		},
-	})
-}
-
 func (shaman *Shaman) registerStormstrikeSpell() {
 	if !shaman.Talents.Stormstrike {
 		return
 	}
 
-	manaCost := .063
-	cooldown := time.Second * 6
-
-	var isDualWielding = shaman.HasRune(proto.ShamanRune_RuneChestDualWieldSpec) && shaman.AutoAttacks.IsDualWielding
-
-	mhSpell := shaman.newStormstrikeHitSpell(true)
-
 	var ohSpell *core.Spell
-	if isDualWielding {
-		ohSpell = shaman.newStormstrikeHitSpell(false)
+	if shaman.HasRune(proto.ShamanRune_RuneChestDualWieldSpec) && shaman.AutoAttacks.IsDualWielding {
+		ohSpell = shaman.RegisterSpell(core.SpellConfig{
+			ActionID:    core.ActionID{SpellID: 410156},
+			SpellSchool: core.SpellSchoolPhysical,
+			ProcMask:    core.ProcMaskMeleeOHSpecial,
+			Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | core.SpellFlagNoOnCastComplete,
+
+			DamageMultiplier: shaman.AutoAttacks.OHConfig().DamageMultiplier,
+			CritMultiplier:   shaman.DefaultMeleeCritMultiplier(),
+			ThreatMultiplier: 1,
+
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				damage := spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower()) + spell.BonusWeaponDamage()
+				spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
+			},
+		})
 	}
 
 	shaman.Stormstrike = shaman.RegisterSpell(core.SpellConfig{
-		ActionID:    StormstrikeActionID,
+		ActionID:    core.ActionID{SpellID: 17364},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagAPL | core.SpellFlagIncludeTargetBonusDamage,
+		Flags:       core.SpellFlagAPL | core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
 
 		ManaCost: core.ManaCostOptions{
-			BaseCost: manaCost,
+			BaseCost: .063,
 		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
@@ -100,7 +47,7 @@ func (shaman *Shaman) registerStormstrikeSpell() {
 			IgnoreHaste: true,
 			CD: core.Cooldown{
 				Timer:    shaman.NewTimer(),
-				Duration: cooldown,
+				Duration: time.Second * 6,
 			},
 		},
 
@@ -109,18 +56,16 @@ func (shaman *Shaman) registerStormstrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialHit)
-			if result.Landed() {
-				mhSpell.Cast(sim, target)
-
-				if isDualWielding {
-					ohSpell.Cast(sim, target)
-				}
-
-				shaman.Stormstrike.SpellMetrics[target.UnitIndex].Hits--
+			// offhand always swings first
+			if ohSpell != nil {
+				ohSpell.Cast(sim, target)
 			}
 
-			spell.DealOutcome(sim, result)
+			damage := spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower()) + spell.BonusWeaponDamage()
+			result := spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
+			if result.Landed() {
+				core.StormstrikeAura(target).Activate(sim) // only MH hitso apply the aura
+			}
 		},
 	})
 }


### PR DESCRIPTION
[shaman] re-model Stormstrike (no more "outer spell", oh swings first, aura only applied on mh hits); it also applies the "Stormstrike" aura now

[common] make "Stormstrike" and "Dreamstate" become exlusive effects 

[shaman] slightly re-model Windfury Weapon (bonus AP reduced to level-correct values, bonus AP not applying after offhand penalty, and offhand profiting from Dual Wield Specialization) 

[shaman] remove Flametongue Weapons's ICD