### PR TITLE
Seal of Righteousness benefits from weapon specialization talent

### DIFF
--- a/sim/paladin/sor.go
+++ b/sim/paladin/sor.go
@@ -104,7 +104,7 @@ func (paladin *Paladin) applySealOfRighteousnessSpellAndAuraBaseConfig(rank int)
 		Flags:         core.SpellFlagMeleeMetrics,
 		RequiredLevel: level,
 
-		DamageMultiplier: 1,
+		DamageMultiplier: 1 * paladin.getWeaponSpecializationModifier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {


### PR DESCRIPTION
Testing conclusively shows the dmg % modifier applies to both the base damage and the spellpower-scaling damage