### PR TITLE
Warrior stuff

### DIFF
--- a/proto/rogue.proto
+++ b/proto/rogue.proto
@@ -3,8 +3,6 @@ package proto;
 
 option go_package = "./proto";
 
-import "common.proto";
-
 message RogueTalents {
 	// Assassination
 	int32 improved_eviscerate = 1;
@@ -87,7 +85,7 @@ enum RogueRune {
 }
 
 message RogueOptions {
-	
+
 }
 
 message Rogue {

--- a/sim/core/rage.go
+++ b/sim/core/rage.go
@@ -66,7 +66,6 @@ func (unit *Unit) EnableRageBar(options RageBarOptions) {
 				damage = result.PreOutcomeDamage
 			}
 
-			// generatedRage is capped for very low damage swings
 			generatedRage := damage * 7.5 / rageConversion
 
 			generatedRage *= options.RageMultiplier

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"fmt"
-	"math"
-
 	"github.com/wowsims/sod/sim/core/stats"
 )
 
@@ -156,7 +154,7 @@ func (spell *Spell) SpellChanceToMiss(attackTable *AttackTable) float64 {
 	}
 
 	// Always a 1% chance to miss in classic
-	return math.Max(0.01, missChance)
+	return max(0.01, missChance)
 }
 func (spell *Spell) MagicHitCheck(sim *Simulation, attackTable *AttackTable) bool {
 	return sim.Proc(1.0-spell.SpellChanceToMiss(attackTable), "Magical Hit Roll")

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.30714
+  weights: 2.74582
   weights: 0
-  weights: 0.85805
+  weights: 0.85801
   weights: 0
-  weights: 0.28307
-  weights: 0
-  weights: 0
-  weights: 0.57498
+  weights: 0.28191
   weights: 0
   weights: 0
-  weights: 10.53157
-  weights: 4.00966
+  weights: 0.57609
+  weights: 0
+  weights: 0
+  weights: 9.26224
+  weights: 3.97031
   weights: 0
   weights: 0
   weights: 0
@@ -379,92 +379,92 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 416.09739
-  tps: 413.82673
+  dps: 413.16295
+  tps: 410.80129
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 465.67212
-  tps: 464.41873
+  dps: 461.52651
+  tps: 460.33455
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 416.09739
-  tps: 413.82673
+  dps: 413.16295
+  tps: 410.80129
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 274.58944
-  tps: 253.38092
+  dps: 270.2608
+  tps: 248.73729
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 287.5554
-  tps: 263.10302
+  dps: 279.91153
+  tps: 255.21919
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 285.3591
-  tps: 263.9849
+  dps: 281.31775
+  tps: 260.10654
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 292.13559
-  tps: 267.95387
+  dps: 289.86931
+  tps: 265.54596
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 256.29106
-  tps: 233.88825
+  dps: 252.44568
+  tps: 230.29302
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 289.84683
-  tps: 266.463
+  dps: 285.55777
+  tps: 261.91677
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 308.44656
-  tps: 283.48788
+  dps: 306.79321
+  tps: 281.69106
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 197.74262
-  tps: 172.42243
+  dps: 200.53281
+  tps: 175.58945
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 452.39484
-  tps: 450.71219
+  dps: 453.7313
+  tps: 452.25334
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Average-Default"
  value: {
-  dps: 623.55073
-  tps: 530.7667
+  dps: 622.06199
+  tps: 529.58697
  }
 }
 dps_results: {
@@ -512,49 +512,49 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 763.72946
-  tps: 1194.4286
+  dps: 759.51904
+  tps: 1193.10719
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 620.73424
-  tps: 530.0457
+  dps: 622.75515
+  tps: 531.91981
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 721.64925
-  tps: 628.28394
+  tps: 628.69169
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 409.37976
-  tps: 761.67789
+  dps: 408.2715
+  tps: 763.66437
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 337.55366
-  tps: 290.76794
+  dps: 336.76011
+  tps: 291.3258
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 478.14366
-  tps: 420.0814
+  tps: 420.53765
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 620.73424
-  tps: 530.0457
+  dps: 622.75515
+  tps: 531.91981
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -463,92 +463,92 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 297.83293
-  tps: 335.96689
+  dps: 297.70669
+  tps: 335.71162
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
   dps: 294.23305
-  tps: 333.73776
+  tps: 333.7735
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 294.50153
-  tps: 332.62187
+  dps: 294.37803
+  tps: 332.36933
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 250.32961
-  tps: 255.03145
+  dps: 245.90155
+  tps: 250.91653
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 242.61998
-  tps: 243.92418
+  dps: 239.99476
+  tps: 242.03984
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 237.30802
-  tps: 239.62329
+  dps: 232.85537
+  tps: 235.62454
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 239.75456
-  tps: 241.62291
+  dps: 238.53625
+  tps: 240.0725
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 242.20521
-  tps: 243.51008
+  dps: 239.42825
+  tps: 240.88757
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 238.32722
-  tps: 239.08522
+  dps: 234.30773
+  tps: 237.39381
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 244.82868
-  tps: 246.0087
+  dps: 243.54362
+  tps: 244.37944
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 150.40535
-  tps: 148.05149
+  dps: 149.16491
+  tps: 145.66504
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
   dps: 292.94669
-  tps: 332.28062
+  tps: 332.43959
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
   dps: 430.65848
-  tps: 470.72581
+  tps: 470.94795
  }
 }
 dps_results: {
@@ -639,90 +639,90 @@ dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
   dps: 417.97171
-  tps: 471.36265
+  tps: 471.25101
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 409.65649
-  tps: 462.94586
+  tps: 462.76821
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 437.47637
-  tps: 491.6123
+  tps: 491.82499
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
   dps: 264.65351
-  tps: 306.23531
+  tps: 306.53532
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 255.18185
-  tps: 295.98841
+  tps: 295.89422
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 262.42403
-  tps: 303.05028
+  tps: 302.78769
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
   dps: 417.97171
-  tps: 470.97145
+  tps: 471.24292
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 409.65649
-  tps: 462.3738
+  tps: 462.69875
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 437.47637
-  tps: 491.07114
+  tps: 491.46399
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
   dps: 264.65351
-  tps: 306.66502
+  tps: 306.50351
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 255.18185
-  tps: 295.75907
+  tps: 295.76088
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 262.42403
-  tps: 302.83146
+  tps: 302.82761
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 397.98745
-  tps: 438.94236
+  tps: 439.09687
  }
 }

--- a/sim/warlock/dark_pact.go
+++ b/sim/warlock/dark_pact.go
@@ -1,8 +1,6 @@
 package warlock
 
 import (
-	"math"
-
 	"github.com/wowsims/sod/sim/core"
 )
 
@@ -33,7 +31,7 @@ func (warlock *Warlock) getDarkPactConfig(rank int) core.SpellConfig {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			maxDrain := manaRestore
-			actualDrain := math.Min(maxDrain, warlock.Pet.CurrentMana())
+			actualDrain := min(maxDrain, warlock.Pet.CurrentMana())
 
 			warlock.Pet.SpendMana(sim, actualDrain, petManaMetrics)
 			warlock.AddMana(sim, actualDrain, manaMetrics)

--- a/sim/warrior/deep_wounds.go
+++ b/sim/warrior/deep_wounds.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/wowsims/sod/sim/core"
 	"github.com/wowsims/sod/sim/core/proto"
-	"github.com/wowsims/sod/sim/core/stats"
 )
 
 func (warrior *Warrior) applyDeepWounds() {
@@ -36,7 +35,8 @@ func (warrior *Warrior) applyDeepWounds() {
 			TickLength:    time.Second * 3,
 
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				dot.SnapshotAttackerMultiplier = target.PseudoStats.PeriodicPhysicalDamageTakenMultiplier * warrior.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical]
+				attackTable := warrior.AttackTables[target.UnitIndex][proto.CastType_CastTypeMainHand]
+				dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable)
 				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTick)
 			},
 		},
@@ -69,23 +69,21 @@ func (warrior *Warrior) procDeepWounds(sim *core.Simulation, target *core.Unit, 
 
 	outstandingDamage := core.TernaryFloat64(dot.IsActive(), dot.SnapshotBaseDamage*float64(dot.NumberOfTicks-dot.TickCount), 0)
 
-	attackTableMh := warrior.AttackTables[target.UnitIndex][proto.CastType_CastTypeMainHand]
-	attackTableOh := warrior.AttackTables[target.UnitIndex][proto.CastType_CastTypeOffHand]
-
 	var awd float64
 	if isOh {
+		attackTableOh := warrior.AttackTables[target.UnitIndex][proto.CastType_CastTypeOffHand]
 		adm := warrior.AutoAttacks.OHAuto().AttackerDamageMultiplier(attackTableOh)
-		tdm := warrior.AutoAttacks.OHAuto().TargetDamageMultiplier(attackTableOh, false)
-		awd = ((warrior.AutoAttacks.OH().CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower()) * 0.5) + dot.Spell.BonusWeaponDamage()) * adm * tdm
+		awd = warrior.AutoAttacks.OH().CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower()) * 0.5 * adm
 	} else { // MH
+		attackTableMh := warrior.AttackTables[target.UnitIndex][proto.CastType_CastTypeMainHand]
 		adm := warrior.AutoAttacks.MHAuto().AttackerDamageMultiplier(attackTableMh)
-		tdm := warrior.AutoAttacks.MHAuto().TargetDamageMultiplier(attackTableMh, false)
-		awd = (warrior.AutoAttacks.MH().CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower()) + dot.Spell.BonusWeaponDamage()) * adm * tdm
+		awd = warrior.AutoAttacks.MH().CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower()) * adm
 	}
 
 	newDamage := awd * 0.2 * float64(warrior.Talents.DeepWounds)
 
 	dot.SnapshotBaseDamage = (outstandingDamage + newDamage) / float64(dot.NumberOfTicks)
 	dot.SnapshotAttackerMultiplier = 1
+
 	warrior.DeepWounds.Cast(sim, target)
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -50,7 +50,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestArms-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.06078
+  weights: 0.06067
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02512
-  weights: 0.09813
-  weights: 0.48266
+  weights: 0.02506
+  weights: 0.26739
+  weights: 0.52037
   weights: 0
   weights: 0
   weights: 0
@@ -99,189 +99,189 @@ stat_weights_results: {
 dps_results: {
  key: "TestArms-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 38.42466
-  tps: 38.82889
+  dps: 37.71823
+  tps: 38.05752
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 36.33377
-  tps: 37.17127
+  dps: 35.67168
+  tps: 36.43623
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 38.0565
-  tps: 38.54212
+  dps: 37.41205
+  tps: 37.82081
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 38.48316
-  tps: 38.87907
+  dps: 37.80722
+  tps: 38.13243
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 36.40164
-  tps: 37.22938
+  dps: 35.50069
+  tps: 36.33298
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-H.A.Z.A.R.D.Suit"
  value: {
-  dps: 38.93639
-  tps: 39.22069
+  dps: 38.06272
+  tps: 38.31916
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 36.21504
-  tps: 37.0801
+  dps: 35.31409
+  tps: 36.1837
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 36.17609
-  tps: 37.04858
+  dps: 35.48299
+  tps: 36.28895
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 39.38248
-  tps: 39.59636
+  dps: 38.732
+  tps: 38.86984
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 36.15288
-  tps: 37.03001
+  dps: 35.45978
+  tps: 36.27038
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 36.58418
-  tps: 37.37733
+  dps: 35.87515
+  tps: 36.60509
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 39.07082
-  tps: 39.34275
+  dps: 38.2074
+  tps: 38.47633
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 36.02937
-  tps: 36.92775
+  dps: 35.35256
+  tps: 36.18093
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Average-Default"
  value: {
-  dps: 48.80593
-  tps: 46.80709
+  dps: 47.58309
+  tps: 45.54877
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Human-phase_2_2h-Arms-phase_2_arms-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 62.73699
-  tps: 128.12675
+  dps: 60.38915
+  tps: 125.99356
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Human-phase_2_2h-Arms-phase_2_arms-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 48.12309
-  tps: 46.51776
+  dps: 47.03508
+  tps: 45.50254
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Human-phase_2_2h-Arms-phase_2_arms-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 70.2271
-  tps: 65.47516
+  dps: 68.6191
+  tps: 64.09898
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Human-phase_2_2h-Arms-phase_2_arms-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 32.5682
-  tps: 102.29406
+  dps: 31.26354
+  tps: 100.99328
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Human-phase_2_2h-Arms-phase_2_arms-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 24.80331
-  tps: 28.03951
+  dps: 23.6056
+  tps: 26.9864
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Human-phase_2_2h-Arms-phase_2_arms-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 35.52379
-  tps: 38.05345
+  dps: 34.0851
+  tps: 36.85493
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Orc-phase_2_2h-Arms-phase_2_arms-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 65.57894
-  tps: 130.84462
+  dps: 62.31011
+  tps: 127.66731
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Orc-phase_2_2h-Arms-phase_2_arms-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 49.48819
-  tps: 47.62445
+  dps: 48.78066
+  tps: 46.84981
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Orc-phase_2_2h-Arms-phase_2_arms-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 72.41143
-  tps: 67.4289
+  dps: 71.65025
+  tps: 66.61068
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Orc-phase_2_2h-Arms-phase_2_arms-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 33.86508
-  tps: 103.5294
+  dps: 31.70352
+  tps: 101.46468
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Orc-phase_2_2h-Arms-phase_2_arms-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 25.27833
-  tps: 28.39489
+  dps: 24.22561
+  tps: 27.38644
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Settings-Orc-phase_2_2h-Arms-phase_2_arms-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 36.14967
-  tps: 38.59386
+  dps: 35.16204
+  tps: 37.65009
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 48.70731
-  tps: 46.89116
+  dps: 48.1654
+  tps: 46.28926
  }
 }

--- a/sim/warrior/quick_strike.go
+++ b/sim/warrior/quick_strike.go
@@ -17,7 +17,7 @@ func (warrior *Warrior) registerQuickStrike() {
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | core.SpellFlagAPL | SpellFlagBloodSurge,
 
 		RageCost: core.RageCostOptions{
-			Cost:   15 - float64(warrior.Talents.ImprovedHeroicStrike) - warrior.FocusedRageDiscount,
+			Cost:   20 - float64(warrior.Talents.ImprovedHeroicStrike) - warrior.FocusedRageDiscount,
 			Refund: 0.8,
 		},
 		Cast: core.CastConfig{

--- a/sim/warrior/stances.go
+++ b/sim/warrior/stances.go
@@ -22,7 +22,7 @@ func (warrior *Warrior) StanceMatches(other Stance) bool {
 }
 
 func (warrior *Warrior) makeStanceSpell(stance Stance, aura *core.Aura, stanceCD *core.Timer) *core.Spell {
-	maxRetainedRage := 10.0 + 5*float64(warrior.Talents.TacticalMastery)
+	maxRetainedRage := 5 * float64(warrior.Talents.TacticalMastery)
 	actionID := aura.ActionID
 	rageMetrics := warrior.NewRageMetrics(actionID)
 
@@ -62,40 +62,33 @@ func (warrior *Warrior) makeStanceSpell(stance Stance, aura *core.Aura, stanceCD
 }
 
 func (warrior *Warrior) registerBattleStanceAura() {
-	const threatMult = 0.8
-
-	actionID := core.ActionID{SpellID: 2457}
-
 	warrior.BattleStanceAura = warrior.GetOrRegisterAura(core.Aura{
 		Label:    "Battle Stance",
-		ActionID: actionID,
+		ActionID: core.ActionID{SpellID: 2457},
 		Duration: core.NeverExpires,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.ThreatMultiplier *= threatMult
+			aura.Unit.PseudoStats.ThreatMultiplier *= 0.8
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.ThreatMultiplier /= threatMult
+			aura.Unit.PseudoStats.ThreatMultiplier /= 0.8
 		},
 	})
 	warrior.BattleStanceAura.NewExclusiveEffect(stanceEffectCategory, true, core.ExclusiveEffect{})
 }
 
 func (warrior *Warrior) registerDefensiveStanceAura() {
-	const threatMult = 2.0735
-
-	actionID := core.ActionID{SpellID: 71}
-
 	warrior.DefensiveStanceAura = warrior.GetOrRegisterAura(core.Aura{
 		Label:    "Defensive Stance",
-		ActionID: actionID,
+		ActionID: core.ActionID{SpellID: 71},
 		Duration: core.NeverExpires,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.DamageDealtMultiplier *= 0.90
-			aura.Unit.PseudoStats.DamageTakenMultiplier *= 0.90
-
+			aura.Unit.PseudoStats.ThreatMultiplier *= 1.3
+			aura.Unit.PseudoStats.DamageDealtMultiplier *= 0.9
+			aura.Unit.PseudoStats.DamageTakenMultiplier *= 0.9
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.DamageDealtMultiplier /= 0.90
+			aura.Unit.PseudoStats.ThreatMultiplier /= 1.3
+			aura.Unit.PseudoStats.DamageDealtMultiplier /= 0.9
 			aura.Unit.PseudoStats.DamageTakenMultiplier /= 0.9
 		},
 	})
@@ -103,20 +96,19 @@ func (warrior *Warrior) registerDefensiveStanceAura() {
 }
 
 func (warrior *Warrior) registerBerserkerStanceAura() {
-	threatMult := 0.8
-	critBonus := core.CritRatingPerCritChance * 3.0
-
 	warrior.BerserkerStanceAura = warrior.GetOrRegisterAura(core.Aura{
 		Label:    "Berserker Stance",
 		ActionID: core.ActionID{SpellID: 2458},
 		Duration: core.NeverExpires,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.ThreatMultiplier *= threatMult
-			aura.Unit.AddStatDynamic(sim, stats.MeleeCrit, critBonus)
+			aura.Unit.PseudoStats.ThreatMultiplier *= 0.8
+			aura.Unit.PseudoStats.DamageTakenMultiplier *= 1.1
+			aura.Unit.AddStatDynamic(sim, stats.MeleeCrit, core.CritRatingPerCritChance*3)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.ThreatMultiplier /= threatMult
-			aura.Unit.AddStatDynamic(sim, stats.MeleeCrit, -critBonus)
+			aura.Unit.PseudoStats.ThreatMultiplier /= 0.8
+			aura.Unit.PseudoStats.DamageTakenMultiplier *= 1.1
+			aura.Unit.AddStatDynamic(sim, stats.MeleeCrit, -core.CritRatingPerCritChance*3)
 		},
 	})
 	warrior.BerserkerStanceAura.NewExclusiveEffect(stanceEffectCategory, true, core.ExclusiveEffect{})


### PR DESCRIPTION
[warrior] fix Quick Strike's rage cost
[warrior] fix Rend not dealing damage, having the wrong number of ticks, and scaling wrongly from Improved Rend ;) [warrior] non-instant Slam now resets the swing timer
[warrior] changing stances doesn't retain 10 rage by default anymore 
[warrior] Deep Wounds doesn't double dip from "damage taken" modifiers anymore, but double dips from more "damage done" modifiers 

[general] added mana/rage/energy costs to Berserking (and clamp "berserkingPct" between 0.1 and 0.3)

I'm not sure about the Slam (reset, not just delay the swing timer) and Stance Dancing (0 rage base, not 10 rage base retained) changes.

Vanilla Deep Wounds had a _very_ weird interaction with "BonusWeaponDamage" auras, I'm pretty sure that doesn't exist anymore.
The "damage taken" handling in Deep Wounds was specifically in place for Blood Frenzy and the "no double dipping"-WotLK policy, so I removed it as well. My guess is "damage taken" modifiers don't "double dip", but that could easily be tested duelling against a warrior in Defensive Stance.
