### PR TITLE
Expose Armor cast by rogue modified by combo points

### DIFF
--- a/sim/rogue/expose_armor.go
+++ b/sim/rogue/expose_armor.go
@@ -7,7 +7,6 @@ import (
 )
 
 func (rogue *Rogue) registerExposeArmorSpell() {
-	// TODO: Update aura array to dynamically update armor reduction based on combo points. Currently does not and locked at 5 combos.
 	rogue.ExposeArmorAuras = rogue.NewEnemyAuraArray(func(target *core.Unit, level int32) *core.Aura {
 		return core.ExposeArmorAura(target, rogue.Talents.ImprovedExposeArmor, rogue.Level)
 	})


### PR DESCRIPTION
Update Expose Armor to correctly reduce armor based on the amount of combo points spent when cast. External use by the sim via input is unaffected.