### PR TITLE
Add level to character stats panel

### DIFF
--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -1,26 +1,27 @@
-import { simLaunchStatuses } from './launched_sims';
-import { Player, PlayerConfig, registerSpecConfig as registerPlayerConfig } from './player';
-import { SimSettingCategories } from './sim';
-import { SimUI, SimWarning } from './sim_ui';
-import { EventID, TypedEvent } from './typed_event';
-
 import { CharacterStats, StatMods } from './components/character_stats';
 import { ContentBlock } from './components/content_block';
 import { EmbeddedDetailedResults } from './components/detailed_results';
 import { EncounterPickerConfig } from './components/encounter_picker';
+import * as Exporters from './components/exporters';
+import * as IconInputs from './components/icon_inputs';
+import * as Importers from './components/importers';
+import { BulkTab } from './components/individual_sim_ui/bulk_tab';
+import { GearTab } from './components/individual_sim_ui/gear_tab';
+import { RotationTab } from './components/individual_sim_ui/rotation_tab';
+import { SettingsTab } from './components/individual_sim_ui/settings_tab';
+import { TalentsTab } from './components/individual_sim_ui/talents_tab';
+import * as InputHelpers from './components/input_helpers';
 import { ItemSwapConfig } from './components/item_swap_picker';
 import { addRaidSimAction, RaidSimResultsManager } from './components/raid_sim_action';
 import { SavedDataConfig } from './components/saved_data_manager';
 import { addStatWeightsAction } from './components/stat_weights_action';
-
-import { BulkTab } from './components/individual_sim_ui/bulk_tab';
-import { GearTab } from './components/individual_sim_ui/gear_tab';
-import { SettingsTab } from './components/individual_sim_ui/settings_tab';
-import { RotationTab } from './components/individual_sim_ui/rotation_tab';
-import { TalentsTab } from './components/individual_sim_ui/talents_tab';
-
 import { LEVEL_THRESHOLDS } from './constants/other';
-
+import * as Tooltips from './constants/tooltips';
+import { simLaunchStatuses } from './launched_sims';
+import { Player, PlayerConfig, registerSpecConfig as registerPlayerConfig } from './player';
+import { PresetGear, PresetRotation } from './preset_utils';
+import { StatWeightsResult } from './proto/api';
+import { APLRotation_Type as APLRotationType } from './proto/apl';
 import {
 	Consumes,
 	Debuffs,
@@ -38,10 +39,7 @@ import {
 	Spec,
 	Stat,
 } from './proto/common';
-
 import { IndividualSimSettings, SavedTalents } from './proto/ui';
-import { StatWeightsResult } from './proto/api';
-import { APLRotation_Type as APLRotationType } from './proto/apl';
 import { ItemSwapGear } from './proto_utils/gear';
 import { professionNames } from './proto_utils/names';
 import { Stats } from './proto_utils/stats';
@@ -54,128 +52,127 @@ import {
 	specToEligibleRaces,
 	specToLocalStorageKey,
 } from './proto_utils/utils';
-
-import {PresetGear, PresetRotation} from './preset_utils';
-
-import * as Exporters from './components/exporters';
-import * as Importers from './components/importers';
-import * as IconInputs from './components/icon_inputs';
-import * as InputHelpers from './components/input_helpers';
-import * as Tooltips from './constants/tooltips';
+import { SimSettingCategories } from './sim';
+import { SimUI, SimWarning } from './sim_ui';
+import { EventID, TypedEvent } from './typed_event';
 
 const SAVED_GEAR_STORAGE_KEY = '__savedGear__';
 const SAVED_ROTATION_STORAGE_KEY = '__savedRotation__';
 const SAVED_SETTINGS_STORAGE_KEY = '__savedSettings__';
 const SAVED_TALENTS_STORAGE_KEY = '__savedTalents__';
 
-export type InputConfig<ModObject> = (
-	InputHelpers.TypedBooleanPickerConfig<ModObject> |
-	InputHelpers.TypedNumberPickerConfig<ModObject> |
-	InputHelpers.TypedEnumPickerConfig<ModObject>
-);
+export type InputConfig<ModObject> =
+	| InputHelpers.TypedBooleanPickerConfig<ModObject>
+	| InputHelpers.TypedNumberPickerConfig<ModObject>
+	| InputHelpers.TypedEnumPickerConfig<ModObject>;
 
 export interface InputSection {
-	tooltip?: string,
-	inputs: Array<InputConfig<Player<any>>>,
+	tooltip?: string;
+	inputs: Array<InputConfig<Player<any>>>;
 }
 
 export interface OtherDefaults {
-	profession1?: Profession,
-	profession2?: Profession,
-	distanceFromTarget?: number,
-	channelClipDelay?: number,
+	profession1?: Profession;
+	profession2?: Profession;
+	distanceFromTarget?: number;
+	channelClipDelay?: number;
 }
 
 export interface RaidSimPreset<SpecType extends Spec> {
-	spec: Spec,
-	talents: SavedTalents,
-	specOptions: SpecOptions<SpecType>,
-	consumes: Consumes,
+	spec: Spec;
+	talents: SavedTalents;
+	specOptions: SpecOptions<SpecType>;
+	consumes: Consumes;
 
-	defaultName: string,
-	defaultFactionRaces: Record<Faction, Race>,
-	defaultGear: Record<Faction, Record<number, EquipmentSpec>>,
-	otherDefaults?: OtherDefaults,
+	defaultName: string;
+	defaultFactionRaces: Record<Faction, Race>;
+	defaultGear: Record<Faction, Record<number, EquipmentSpec>>;
+	otherDefaults?: OtherDefaults;
 
-	tooltip: string,
-	iconUrl: string,
+	tooltip: string;
+	iconUrl: string;
 }
 
 export interface IndividualSimUIConfig<SpecType extends Spec> extends PlayerConfig<SpecType> {
 	// Additional css class to add to the root element.
-	cssClass: string,
+	cssClass: string;
 	// Used to generate schemed components. E.g. 'shaman', 'druid', 'raid'
-	cssScheme: string,
+	cssScheme: string;
 
 	knownIssues?: Array<string>;
-	warnings?: Array<(simUI: IndividualSimUI<SpecType>) => SimWarning>,
+	warnings?: Array<(simUI: IndividualSimUI<SpecType>) => SimWarning>;
 
 	epStats: Array<Stat>;
 	epPseudoStats?: Array<PseudoStat>;
 	epReferenceStat: Stat;
 	displayStats: Array<Stat>;
-	modifyDisplayStats?: (player: Player<SpecType>) => StatMods,
+	modifyDisplayStats?: (player: Player<SpecType>) => StatMods;
 
 	defaults: {
-		race?: Race
-		gear: EquipmentSpec,
-		epWeights: Stats,
-		consumes: Consumes,
+		race?: Race;
+		gear: EquipmentSpec;
+		epWeights: Stats;
+		consumes: Consumes;
 
-		rotationType?: APLRotationType,
-		simpleRotation?: SpecRotation<SpecType>,
+		rotationType?: APLRotationType;
+		simpleRotation?: SpecRotation<SpecType>;
 
-		talents: SavedTalents,
-		specOptions: SpecOptions<SpecType>,
+		talents: SavedTalents;
+		specOptions: SpecOptions<SpecType>;
 
-		raidBuffs: RaidBuffs,
-		partyBuffs: PartyBuffs,
-		individualBuffs: IndividualBuffs,
+		raidBuffs: RaidBuffs;
+		partyBuffs: PartyBuffs;
+		individualBuffs: IndividualBuffs;
 
-		debuffs: Debuffs,
+		debuffs: Debuffs;
 
-		other?: OtherDefaults,
-	},
+		other?: OtherDefaults;
+	};
 
-	playerInputs?: InputSection,
-	playerIconInputs: Array<IconInputs.IconInputConfig<Player<SpecType>, any>>,
-	petConsumeInputs?: Array<IconInputs.IconInputConfig<Player<SpecType>, any>>,
+	playerInputs?: InputSection;
+	playerIconInputs: Array<IconInputs.IconInputConfig<Player<SpecType>, any>>;
+	petConsumeInputs?: Array<IconInputs.IconInputConfig<Player<SpecType>, any>>;
 	rotationInputs?: InputSection;
 	rotationIconInputs?: Array<IconInputs.IconInputConfig<Player<any>, any>>;
-	includeBuffDebuffInputs: Array<any>,
-	excludeBuffDebuffInputs: Array<any>,
+	includeBuffDebuffInputs: Array<any>;
+	excludeBuffDebuffInputs: Array<any>;
 	otherInputs: InputSection;
 	// Currently, many classes don't support item swapping, and only in certain slots.
 	// So enable it only where it is supported.
-	itemSwapConfig?: ItemSwapConfig,
+	itemSwapConfig?: ItemSwapConfig;
 
 	// For when extra sections are needed (e.g. Shaman totems)
-	customSections?: Array<(parentElem: HTMLElement, simUI: IndividualSimUI<SpecType>) => ContentBlock>,
+	customSections?: Array<
+		(parentElem: HTMLElement, simUI: IndividualSimUI<SpecType>) => ContentBlock
+	>;
 
-	encounterPicker: EncounterPickerConfig,
+	encounterPicker: EncounterPickerConfig;
 
 	presets: {
-		gear: Array<PresetGear>,
-		talents: Array<SavedDataConfig<Player<any>, SavedTalents>>,
-		rotations: Array<PresetRotation>,
-	},
+		gear: Array<PresetGear>;
+		talents: Array<SavedDataConfig<Player<any>, SavedTalents>>;
+		rotations: Array<PresetRotation>;
+	};
 
-	raidSimPresets: Array<RaidSimPreset<SpecType>>,
+	raidSimPresets: Array<RaidSimPreset<SpecType>>;
 }
 
-export function registerSpecConfig<SpecType extends Spec>(spec: SpecType, config: IndividualSimUIConfig<SpecType>): IndividualSimUIConfig<SpecType> {
+export function registerSpecConfig<SpecType extends Spec>(
+	spec: SpecType,
+	config: IndividualSimUIConfig<SpecType>,
+): IndividualSimUIConfig<SpecType> {
 	registerPlayerConfig(spec, config);
 	return config;
 }
 
-export let itemSwapEnabledSpecs: Array<Spec> = [];
+export const itemSwapEnabledSpecs: Array<Spec> = [];
 
 export interface Settings {
-	raidBuffs: RaidBuffs,
-	partyBuffs: PartyBuffs,
-	individualBuffs: IndividualBuffs,
-	consumes: Consumes,
-	race: Race,
+	raidBuffs: RaidBuffs;
+	partyBuffs: PartyBuffs;
+	individualBuffs: IndividualBuffs;
+	consumes: Consumes;
+	race: Race;
 	professions?: Array<Profession>;
 }
 
@@ -195,14 +192,19 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 	readonly bt: BulkTab;
 	spec: any;
 
-	constructor(parentElem: HTMLElement, player: Player<SpecType>, config: IndividualSimUIConfig<SpecType>) {
+	constructor(
+		parentElem: HTMLElement,
+		player: Player<SpecType>,
+		config: IndividualSimUIConfig<SpecType>,
+	) {
 		super(parentElem, player.sim, {
 			cssClass: config.cssClass,
 			cssScheme: config.cssScheme,
 			spec: player.spec,
 			knownIssues: config.knownIssues,
 			simStatus: simLaunchStatuses[player.spec],
-			noticeText: 'Disclaimer: Phase 2 support is still in early development. Item and spell effects may not be implemented.',
+			noticeText:
+				'Disclaimer: Phase 2 support is still in early development. Item and spell effects may not be implemented.',
 		});
 		this.rootElem.classList.add('individual-sim-ui');
 		this.player = player;
@@ -211,23 +213,37 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 		this.prevEpIterations = 0;
 		this.prevEpSimResult = null;
 
-		if ((config.itemSwapConfig?.itemSlots || []).length > 0 && !itemSwapEnabledSpecs.includes(player.spec)) {
+		if (
+			(config.itemSwapConfig?.itemSlots || []).length > 0 &&
+			!itemSwapEnabledSpecs.includes(player.spec)
+		) {
 			itemSwapEnabledSpecs.push(player.spec);
 		}
 
 		this.addWarning({
-			updateOn: TypedEvent.onAny([this.player.gearChangeEmitter, this.player.professionChangeEmitter]),
+			updateOn: TypedEvent.onAny([
+				this.player.gearChangeEmitter,
+				this.player.professionChangeEmitter,
+			]),
 			getContent: () => {
-				const failedProfReqs = this.player.getGear().getFailedProfessionRequirements(this.player.getProfessions());
+				const failedProfReqs = this.player
+					.getGear()
+					.getFailedProfessionRequirements(this.player.getProfessions());
 				if (failedProfReqs.length == 0) {
 					return '';
 				}
 
-				return failedProfReqs.map(fpr => `${fpr.name} requires ${professionNames.get(fpr.requiredProfession)!}, but it is not selected.`);
+				return failedProfReqs.map(
+					fpr =>
+						`${fpr.name} requires ${professionNames.get(fpr.requiredProfession)!}, but it is not selected.`,
+				);
 			},
 		});
 		this.addWarning({
-			updateOn: TypedEvent.onAny([this.player.talentsChangeEmitter, this.player.levelChangeEmitter]),
+			updateOn: TypedEvent.onAny([
+				this.player.talentsChangeEmitter,
+				this.player.levelChangeEmitter,
+			]),
 			getContent: () => {
 				const talentPoints = getTalentPoints(this.player.getTalentsString());
 
@@ -244,13 +260,20 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			},
 		});
 		this.addWarning({
-			updateOn: TypedEvent.onAny([this.player.gearChangeEmitter, this.player.talentsChangeEmitter]),
+			updateOn: TypedEvent.onAny([
+				this.player.gearChangeEmitter,
+				this.player.talentsChangeEmitter,
+			]),
 			getContent: () => {
-				if (!this.player.canDualWield2H() &&
-					(this.player.getEquippedItem(ItemSlot.ItemSlotMainHand)?.item.handType == HandType.HandTypeTwoHand &&
-						this.player.getEquippedItem(ItemSlot.ItemSlotOffHand) != null ||
-						this.player.getEquippedItem(ItemSlot.ItemSlotOffHand)?.item.handType == HandType.HandTypeTwoHand)) {
-					return "Dual wielding two-handed weapon(s) without Titan's Grip spec."
+				if (
+					!this.player.canDualWield2H() &&
+					((this.player.getEquippedItem(ItemSlot.ItemSlotMainHand)?.item.handType ==
+						HandType.HandTypeTwoHand &&
+						this.player.getEquippedItem(ItemSlot.ItemSlotOffHand) != null) ||
+						this.player.getEquippedItem(ItemSlot.ItemSlotOffHand)?.item.handType ==
+							HandType.HandTypeTwoHand)
+				) {
+					return "Dual wielding two-handed weapon(s) without Titan's Grip spec.";
 				} else {
 					return '';
 				}
@@ -301,9 +324,15 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			// Loading from link needs to happen after loading saved settings, so that partial link imports
 			// (e.g. rotation only) include the previous settings for other categories.
 			try {
-				const urlParseResults = Importers.IndividualLinkImporter.tryParseUrlLocation(window.location);
+				const urlParseResults = Importers.IndividualLinkImporter.tryParseUrlLocation(
+					window.location,
+				);
 				if (urlParseResults) {
-					this.fromProto(initEventID, urlParseResults.settings, urlParseResults.categories);
+					this.fromProto(
+						initEventID,
+						urlParseResults.settings,
+						urlParseResults.categories,
+					);
 				}
 			} catch (e) {
 				console.warn('Failed to parse link settings: ' + e);
@@ -323,23 +352,29 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 	private addSidebarComponents() {
 		this.raidSimResultsManager = addRaidSimAction(this);
-		addStatWeightsAction(this, this.individualConfig.epStats, this.individualConfig.epPseudoStats, this.individualConfig.epReferenceStat);
+		addStatWeightsAction(
+			this,
+			this.individualConfig.epStats,
+			this.individualConfig.epPseudoStats,
+			this.individualConfig.epReferenceStat,
+		);
 
 		new CharacterStats(
 			this.rootElem.getElementsByClassName('sim-sidebar-footer')[0] as HTMLElement,
 			this.player,
 			this.individualConfig.displayStats,
-			this.individualConfig.modifyDisplayStats);
+			this.individualConfig.modifyDisplayStats,
+		);
 	}
 
 	private addGearTab() {
-		let gearTab = new GearTab(this.simTabContentsContainer, this);
+		const gearTab = new GearTab(this.simTabContentsContainer, this);
 		gearTab.rootElem.classList.add('active', 'show');
 	}
 
 	private addBulkTab(): BulkTab {
-		let bulkTab = new BulkTab(this.simTabContentsContainer, this);
-		bulkTab.navLink.hidden = !this.sim.getShowExperimental()
+		const bulkTab = new BulkTab(this.simTabContentsContainer, this);
+		bulkTab.navLink.hidden = !this.sim.getShowExperimental();
 		this.sim.showExperimentalChangeEmitter.on(() => {
 			bulkTab.navLink.hidden = !this.sim.getShowExperimental();
 		});
@@ -359,26 +394,54 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 	}
 
 	private addDetailedResultsTab() {
-		this.addTab('Results', 'detailed-results-tab', `
+		this.addTab(
+			'Results',
+			'detailed-results-tab',
+			`
 			<div class="detailed-results">
 			</div>
-		`);
+		`,
+		);
 
-		new EmbeddedDetailedResults(this.rootElem.getElementsByClassName('detailed-results')[0] as HTMLElement, this, this.raidSimResultsManager!);
+		new EmbeddedDetailedResults(
+			this.rootElem.getElementsByClassName('detailed-results')[0] as HTMLElement,
+			this,
+			this.raidSimResultsManager!,
+		);
 	}
 
 	private addTopbarComponents() {
 		// TODO: Classic
-		this.simHeader.addImportLink('JSON', _parent => new Importers.IndividualJsonImporter(this.rootElem, this), true);
+		this.simHeader.addImportLink(
+			'JSON',
+			_parent => new Importers.IndividualJsonImporter(this.rootElem, this),
+			true,
+		);
 		//this.simHeader.addImportLink('80U', _parent => new Importers.Individual80UImporter(this.rootElem, this), true);
 		//this.simHeader.addImportLink('WoWHead', _parent => new Importers.IndividualWowheadGearPlannerImporter(this.rootElem, this), false);
-		this.simHeader.addImportLink('Addon', _parent => new Importers.IndividualAddonImporter(this.rootElem, this), true);
+		this.simHeader.addImportLink(
+			'Addon',
+			_parent => new Importers.IndividualAddonImporter(this.rootElem, this),
+			true,
+		);
 
-		this.simHeader.addExportLink('Link', _parent => new Exporters.IndividualLinkExporter(this.rootElem, this), false);
-		this.simHeader.addExportLink('JSON', _parent => new Exporters.IndividualJsonExporter(this.rootElem, this), true);
+		this.simHeader.addExportLink(
+			'Link',
+			_parent => new Exporters.IndividualLinkExporter(this.rootElem, this),
+			false,
+		);
+		this.simHeader.addExportLink(
+			'JSON',
+			_parent => new Exporters.IndividualJsonExporter(this.rootElem, this),
+			true,
+		);
 		//this.simHeader.addExportLink('WoWHead', _parent => new Exporters.IndividualWowheadGearPlannerExporter(this.rootElem, this), false);
 		//this.simHeader.addExportLink('80U EP', _parent => new Exporters.Individual80UEPExporter(this.rootElem, this), false);
-		this.simHeader.addExportLink('Pawn EP', _parent => new Exporters.IndividualPawnEPExporter(this.rootElem, this), false);
+		this.simHeader.addExportLink(
+			'Pawn EP',
+			_parent => new Exporters.IndividualPawnEPExporter(this.rootElem, this),
+			false,
+		);
 		//this.simHeader.addExportLink("CLI", _parent => new Exporters.IndividualCLIExporter(this.rootElem, this), true);
 	}
 
@@ -389,23 +452,47 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 			//Special case for Totem of Wrath keeps buff and debuff sync'd
 			this.player.applySharedDefaults(eventID);
-			this.player.setRace(eventID, this.individualConfig.defaults.race ?? specToEligibleRaces[this.player.spec][0]);
-			this.player.setLevel(eventID, LEVEL_THRESHOLDS[simLaunchStatuses[this.player.spec].phase]);
-			this.player.setGear(eventID, this.sim.db.lookupEquipmentSpec(this.individualConfig.defaults.gear));
+			this.player.setRace(
+				eventID,
+				this.individualConfig.defaults.race ?? specToEligibleRaces[this.player.spec][0],
+			);
+			this.player.setLevel(
+				eventID,
+				LEVEL_THRESHOLDS[simLaunchStatuses[this.player.spec].phase],
+			);
+			this.player.setGear(
+				eventID,
+				this.sim.db.lookupEquipmentSpec(this.individualConfig.defaults.gear),
+			);
 			this.player.setItemSwapGear(eventID, new ItemSwapGear({}));
 			this.player.setConsumes(eventID, this.individualConfig.defaults.consumes);
-			this.player.setTalentsString(eventID, this.individualConfig.defaults.talents.talentsString);
+			this.player.setTalentsString(
+				eventID,
+				this.individualConfig.defaults.talents.talentsString,
+			);
 			this.player.setSpecOptions(eventID, this.individualConfig.defaults.specOptions);
 			this.player.setBuffs(eventID, this.individualConfig.defaults.individualBuffs);
 			this.player.getParty()!.setBuffs(eventID, this.individualConfig.defaults.partyBuffs);
 			this.player.getRaid()!.setBuffs(eventID, this.individualConfig.defaults.raidBuffs);
 			this.player.setEpWeights(eventID, this.individualConfig.defaults.epWeights);
-			const defaultRatios = this.player.getDefaultEpRatios(tankSpec, healingSpec)
+			const defaultRatios = this.player.getDefaultEpRatios(tankSpec, healingSpec);
 			this.player.setEpRatios(eventID, defaultRatios);
-			this.player.setProfession1(eventID, this.individualConfig.defaults.other?.profession1 || Profession.Engineering);
-			this.player.setProfession2(eventID, this.individualConfig.defaults.other?.profession2 || Profession.ProfessionUnknown);
-			this.player.setDistanceFromTarget(eventID, this.individualConfig.defaults.other?.distanceFromTarget || 0);
-			this.player.setChannelClipDelay(eventID, this.individualConfig.defaults.other?.channelClipDelay || 0);
+			this.player.setProfession1(
+				eventID,
+				this.individualConfig.defaults.other?.profession1 || Profession.Engineering,
+			);
+			this.player.setProfession2(
+				eventID,
+				this.individualConfig.defaults.other?.profession2 || Profession.ProfessionUnknown,
+			);
+			this.player.setDistanceFromTarget(
+				eventID,
+				this.individualConfig.defaults.other?.distanceFromTarget || 0,
+			);
+			this.player.setChannelClipDelay(
+				eventID,
+				this.individualConfig.defaults.other?.channelClipDelay || 0,
+			);
 
 			if (this.isWithinRaidSim) {
 				this.sim.raid.setTargetDummies(eventID, 0);
@@ -449,10 +536,8 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 	toProto(exportCategories?: Array<SimSettingCategories>): IndividualSimSettings {
 		const exportCategory = (cat: SimSettingCategories) =>
-				!exportCategories
-				|| exportCategories.length == 0
-				|| exportCategories.includes(cat);
-		
+			!exportCategories || exportCategories.length == 0 || exportCategories.includes(cat);
+
 		const proto = IndividualSimSettings.create({
 			player: this.player.toProto(true, false, exportCategories),
 		});
@@ -493,11 +578,13 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 		return Exporters.IndividualLinkExporter.createLink(this);
 	}
 
-	fromProto(eventID: EventID, settings: IndividualSimSettings, includeCategories?: Array<SimSettingCategories>) {
+	fromProto(
+		eventID: EventID,
+		settings: IndividualSimSettings,
+		includeCategories?: Array<SimSettingCategories>,
+	) {
 		const loadCategory = (cat: SimSettingCategories) =>
-				!includeCategories
-				|| includeCategories.length == 0
-				|| includeCategories.includes(cat);
+			!includeCategories || includeCategories.length == 0 || includeCategories.includes(cat);
 
 		const tankSpec = isTankSpec(this.player.spec);
 		const healingSpec = isHealingSpec(this.player.spec);
@@ -522,7 +609,10 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 				this.sim.raid.setTargetDummies(eventID, settings.targetDummies);
 			}
 			if (loadCategory(SimSettingCategories.Encounter)) {
-				this.sim.encounter.fromProto(eventID, settings.encounter || EncounterProto.create());
+				this.sim.encounter.fromProto(
+					eventID,
+					settings.encounter || EncounterProto.create(),
+				);
 			}
 			if (loadCategory(SimSettingCategories.UISettings)) {
 				if (settings.epWeightsStats) {
@@ -533,7 +623,9 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 				const defaultRatios = this.player.getDefaultEpRatios(tankSpec, healingSpec);
 				if (settings.epRatios) {
-					const missingRatios = new Array<number>(defaultRatios.length - settings.epRatios.length).fill(0);
+					const missingRatios = new Array<number>(
+						defaultRatios.length - settings.epRatios.length,
+					).fill(0);
 					this.player.setEpRatios(eventID, settings.epRatios.concat(missingRatios));
 				} else {
 					this.player.setEpRatios(eventID, defaultRatios);

--- a/ui/scss/core/components/_character_stats.scss
+++ b/ui/scss/core/components/_character_stats.scss
@@ -1,56 +1,57 @@
-@use "sass:map";
+@use 'sass:map';
 
 .character-stats-root {
-  width: 100%;
+	width: 100%;
 
-  .character-stats-label {
-    margin-bottom: map.get($spacers, 2);
-  }
+	.character-stats-label {
+		margin-bottom: map.get($spacers, 2);
+		display: flex;
+	}
 
-  .character-stats-table {
-    width: 100%;
+	.character-stats-table {
+		width: 100%;
 
-    .character-stats-table-row {
-      border-top: $border-default;
-      font-size: $content-font-size;
+		.character-stats-table-row {
+			border-top: $border-default;
+			font-size: $content-font-size;
 
-      .character-stats-table-label,
-      .character-stats-table-value {
-        padding-top: map.get($spacers, 2);
-        padding-bottom: map.get($spacers, 2);
-      }
+			.character-stats-table-label,
+			.character-stats-table-value {
+				padding-top: map.get($spacers, 2);
+				padding-bottom: map.get($spacers, 2);
+			}
 
-      .character-stats-table-label {
-        padding-right: map.get($spacers, 2);
-        text-align: left;
-      }
+			.character-stats-table-label {
+				padding-right: map.get($spacers, 2);
+				text-align: left;
+			}
 
-      .character-stats-table-value {
-        padding-left: map.get($spacers, 2);
-        font-weight: bold;
-        text-align: right;
-      }
-    }
-  }
+			.character-stats-table-value {
+				padding-left: map.get($spacers, 2);
+				font-weight: bold;
+				text-align: right;
+			}
+		}
+	}
 }
 
 .bonus-stats-popover {
-  .number-picker-root {
-    flex-direction: column;
+	.number-picker-root {
+		flex-direction: column;
 
-    .number-picker-input {
-      width: 8rem;
-      margin: 0 !important;
-      flex: 1;
-    }
-  }
+		.number-picker-input {
+			width: 8rem;
+			margin: 0 !important;
+			flex: 1;
+		}
+	}
 }
 
 .character-stats-tooltip-row {
 	display: flex;
 	justify-content: space-between;
 
-  span:first-child {
-    margin-right: map.get($spacers, 2);
-  }
+	span:first-child {
+		margin-right: map.get($spacers, 2);
+	}
 }


### PR DESCRIPTION
We've gotten several bug reports caused by players having level 25 selected while using items with level 40 requirements. Since level is such an important part of the SoD experience and especially our codebase for it, I think it's important that we make the player's selected level a bit more prominent and available outside of the settings tab.

<img width="1728" alt="image" src="https://github.com/wowsims/sod/assets/12898988/f825a95b-50e6-4819-b257-5de89bdd4b66">
