### PR TITLE
Downgrade protobuf-ts to avoid breaking error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
             "version": "0.1.0",
             "dependencies": {
                 "@popperjs/core": "^2.11.6",
-                "@protobuf-ts/plugin": "2.9.1",
-                "@protobuf-ts/plugin-framework": "2.9.1",
-                "@protobuf-ts/protoc": "2.9.1",
-                "@protobuf-ts/runtime": "2.9.1",
                 "bootstrap": "^5.3.0",
                 "pako": "^1.0.11",
                 "tippy.js": "^6.3.7",
                 "tsx-vanilla": "^1.0.0"
             },
             "devDependencies": {
+                "@protobuf-ts/plugin": "2.9.1",
+                "@protobuf-ts/plugin-framework": "2.9.1",
+                "@protobuf-ts/protoc": "2.9.1",
+                "@protobuf-ts/runtime": "2.9.1",
                 "@types/bootstrap": "^5.2.0",
                 "@types/node": "^18.6.1",
                 "@types/pako": "^1.0.7",
@@ -624,6 +624,7 @@
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.9.1.tgz",
             "integrity": "sha512-svkFSyFgTtaLdDFPGvd6cTu8qK5Nul5RizDCTcv0xWRzcPWtMiqbuCLKCv6E9gdpnAs3MPeQTnSABB2+NhfWBg==",
+            "dev": true,
             "dependencies": {
                 "@protobuf-ts/plugin-framework": "^2.9.1",
                 "@protobuf-ts/protoc": "^2.9.1",
@@ -640,6 +641,7 @@
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.1.tgz",
             "integrity": "sha512-/4sHdsXjp6KKkbpcCLUHpMfdYsCaqqQHRAwoxVzHmltsotw06B/K9HglZtkQx0IpLO4eeF3vNr3n7qzjD3e2zA==",
+            "dev": true,
             "dependencies": {
                 "@protobuf-ts/runtime": "^2.9.1",
                 "typescript": "^3.9"
@@ -648,12 +650,14 @@
         "node_modules/@protobuf-ts/plugin-framework/node_modules/@protobuf-ts/runtime": {
             "version": "2.9.4",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
-            "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg=="
+            "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==",
+            "dev": true
         },
         "node_modules/@protobuf-ts/plugin-framework/node_modules/typescript": {
             "version": "3.9.10",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
             "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -666,6 +670,7 @@
             "version": "3.9.10",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
             "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -678,6 +683,7 @@
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.1.tgz",
             "integrity": "sha512-/q2iVDwVDijfZlFZnnm3W6ALbybNskNSww88TfYBaJH49PuQMqhcXUPRu28UouJr9sc/Lr5k6t0TB9Nff3UIsA==",
+            "dev": true,
             "bin": {
                 "protoc": "protoc.js"
             }
@@ -685,12 +691,14 @@
         "node_modules/@protobuf-ts/runtime": {
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.1.tgz",
-            "integrity": "sha512-ZTc8b+pQ6bwxZa3qg9/IO/M/brRkvr0tic9cSGgAsDByfPrtatT2300wTIRLDk8X9WTW1tT+FhyqmcrbMHTeww=="
+            "integrity": "sha512-ZTc8b+pQ6bwxZa3qg9/IO/M/brRkvr0tic9cSGgAsDByfPrtatT2300wTIRLDk8X9WTW1tT+FhyqmcrbMHTeww==",
+            "dev": true
         },
         "node_modules/@protobuf-ts/runtime-rpc": {
             "version": "2.9.4",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz",
             "integrity": "sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==",
+            "dev": true,
             "dependencies": {
                 "@protobuf-ts/runtime": "^2.9.4"
             }
@@ -698,7 +706,8 @@
         "node_modules/@protobuf-ts/runtime-rpc/node_modules/@protobuf-ts/runtime": {
             "version": "2.9.4",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
-            "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg=="
+            "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==",
+            "dev": true
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,16 @@
             "version": "0.1.0",
             "dependencies": {
                 "@popperjs/core": "^2.11.6",
+                "@protobuf-ts/plugin": "2.9.1",
+                "@protobuf-ts/plugin-framework": "2.9.1",
+                "@protobuf-ts/protoc": "2.9.1",
+                "@protobuf-ts/runtime": "2.9.1",
                 "bootstrap": "^5.3.0",
                 "pako": "^1.0.11",
                 "tippy.js": "^6.3.7",
                 "tsx-vanilla": "^1.0.0"
             },
             "devDependencies": {
-                "@protobuf-ts/plugin": "^2.0.4",
-                "@protobuf-ts/runtime": "^2.0.4",
                 "@types/bootstrap": "^5.2.0",
                 "@types/node": "^18.6.1",
                 "@types/pako": "^1.0.7",
@@ -619,15 +621,14 @@
             }
         },
         "node_modules/@protobuf-ts/plugin": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.9.4.tgz",
-            "integrity": "sha512-Db5Laq5T3mc6ERZvhIhkj1rn57/p8gbWiCKxQWbZBBl20wMuqKoHbRw4tuD7FyXi+IkwTToaNVXymv5CY3E8Rw==",
-            "dev": true,
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.9.1.tgz",
+            "integrity": "sha512-svkFSyFgTtaLdDFPGvd6cTu8qK5Nul5RizDCTcv0xWRzcPWtMiqbuCLKCv6E9gdpnAs3MPeQTnSABB2+NhfWBg==",
             "dependencies": {
-                "@protobuf-ts/plugin-framework": "^2.9.4",
-                "@protobuf-ts/protoc": "^2.9.4",
-                "@protobuf-ts/runtime": "^2.9.4",
-                "@protobuf-ts/runtime-rpc": "^2.9.4",
+                "@protobuf-ts/plugin-framework": "^2.9.1",
+                "@protobuf-ts/protoc": "^2.9.1",
+                "@protobuf-ts/runtime": "^2.9.1",
+                "@protobuf-ts/runtime-rpc": "^2.9.1",
                 "typescript": "^3.9"
             },
             "bin": {
@@ -636,20 +637,23 @@
             }
         },
         "node_modules/@protobuf-ts/plugin-framework": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.4.tgz",
-            "integrity": "sha512-9nuX1kjdMliv+Pes8dQCKyVhjKgNNfwxVHg+tx3fLXSfZZRcUHMc1PMwB9/vTvc6gBKt9QGz5ERqSqZc0++E9A==",
-            "dev": true,
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.1.tgz",
+            "integrity": "sha512-/4sHdsXjp6KKkbpcCLUHpMfdYsCaqqQHRAwoxVzHmltsotw06B/K9HglZtkQx0IpLO4eeF3vNr3n7qzjD3e2zA==",
             "dependencies": {
-                "@protobuf-ts/runtime": "^2.9.4",
+                "@protobuf-ts/runtime": "^2.9.1",
                 "typescript": "^3.9"
             }
+        },
+        "node_modules/@protobuf-ts/plugin-framework/node_modules/@protobuf-ts/runtime": {
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
+            "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg=="
         },
         "node_modules/@protobuf-ts/plugin-framework/node_modules/typescript": {
             "version": "3.9.10",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
             "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -662,7 +666,6 @@
             "version": "3.9.10",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
             "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -672,28 +675,30 @@
             }
         },
         "node_modules/@protobuf-ts/protoc": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.4.tgz",
-            "integrity": "sha512-hQX+nOhFtrA+YdAXsXEDrLoGJqXHpgv4+BueYF0S9hy/Jq0VRTVlJS1Etmf4qlMt/WdigEes5LOd/LDzui4GIQ==",
-            "dev": true,
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.1.tgz",
+            "integrity": "sha512-/q2iVDwVDijfZlFZnnm3W6ALbybNskNSww88TfYBaJH49PuQMqhcXUPRu28UouJr9sc/Lr5k6t0TB9Nff3UIsA==",
             "bin": {
                 "protoc": "protoc.js"
             }
         },
         "node_modules/@protobuf-ts/runtime": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
-            "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg==",
-            "dev": true
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.1.tgz",
+            "integrity": "sha512-ZTc8b+pQ6bwxZa3qg9/IO/M/brRkvr0tic9cSGgAsDByfPrtatT2300wTIRLDk8X9WTW1tT+FhyqmcrbMHTeww=="
         },
         "node_modules/@protobuf-ts/runtime-rpc": {
             "version": "2.9.4",
             "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz",
             "integrity": "sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==",
-            "dev": true,
             "dependencies": {
                 "@protobuf-ts/runtime": "^2.9.4"
             }
+        },
+        "node_modules/@protobuf-ts/runtime-rpc/node_modules/@protobuf-ts/runtime": {
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
+            "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg=="
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.13.0",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
     },
     "dependencies": {
         "@popperjs/core": "^2.11.6",
+        "@protobuf-ts/plugin": "2.9.1",
+        "@protobuf-ts/plugin-framework": "2.9.1",
+        "@protobuf-ts/protoc": "2.9.1",
+        "@protobuf-ts/runtime": "2.9.1",
         "bootstrap": "^5.3.0",
         "pako": "^1.0.11",
         "tippy.js": "^6.3.7",
         "tsx-vanilla": "^1.0.0"
     },
     "devDependencies": {
-        "@protobuf-ts/plugin": "^2.0.4",
-        "@protobuf-ts/runtime": "^2.0.4",
         "@types/bootstrap": "^5.2.0",
         "@types/node": "^18.6.1",
         "@types/pako": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
     },
     "dependencies": {
         "@popperjs/core": "^2.11.6",
-        "@protobuf-ts/plugin": "2.9.1",
-        "@protobuf-ts/plugin-framework": "2.9.1",
-        "@protobuf-ts/protoc": "2.9.1",
-        "@protobuf-ts/runtime": "2.9.1",
         "bootstrap": "^5.3.0",
         "pako": "^1.0.11",
         "tippy.js": "^6.3.7",
         "tsx-vanilla": "^1.0.0"
     },
     "devDependencies": {
+        "@protobuf-ts/plugin": "2.9.1",
+        "@protobuf-ts/plugin-framework": "2.9.1",
+        "@protobuf-ts/protoc": "2.9.1",
+        "@protobuf-ts/runtime": "2.9.1",
         "@types/bootstrap": "^5.2.0",
         "@types/node": "^18.6.1",
         "@types/pako": "^1.0.7",

--- a/ui/core/components/individual_sim_ui/apl_helpers.ts
+++ b/ui/core/components/individual_sim_ui/apl_helpers.ts
@@ -1,129 +1,152 @@
 import { Player, UnitMetadata } from '../../player.js';
-import { ActionID,OtherAction, UnitReference, UnitReference_Type as UnitType  } from '../../proto/common.js';
+import { ActionID, OtherAction, UnitReference, UnitReference_Type as UnitType } from '../../proto/common.js';
 import { ActionId, defaultTargetIcon, getPetIconFromName } from '../../proto_utils/action_id.js';
 import { EventID, TypedEvent } from '../../typed_event.js';
 import { bucket } from '../../utils.js';
 import { BooleanPicker } from '../boolean_picker.js';
-import { DropdownPicker, DropdownPickerConfig, DropdownValueConfig, TextDropdownPicker } from '../dropdown_picker.js';
+import { DropdownPicker, DropdownPickerConfig, DropdownValueConfig } from '../dropdown_picker.js';
 import { Input, InputConfig } from '../input.js';
 import { AdaptiveStringPicker } from '../inputs/string_picker.js';
 import { NumberPicker, NumberPickerConfig } from '../number_picker.js';
 import { UnitPicker, UnitPickerConfig, UnitValue } from '../unit_picker.js';
-//import { APLValueRuneSlot, APLValueRuneType } from '../../proto/apl.js';
-//import { FeralDruid_Rotation_AplType } from '../../proto/druid.js';
 
-export type ACTION_ID_SET = 'auras' | 'stackable_auras' | 'icd_auras' | 'exclusive_effect_auras' | 'castable_spells' | 'channel_spells' | 'dot_spells' | 'shield_spells';
+export type ACTION_ID_SET =
+	| 'auras'
+	| 'stackable_auras'
+	| 'icd_auras'
+	| 'exclusive_effect_auras'
+	| 'castable_spells'
+	| 'channel_spells'
+	| 'dot_spells'
+	| 'shield_spells';
 
-const actionIdSets: Record<ACTION_ID_SET, {
-	defaultLabel: string,
-	getActionIDs: (metadata: UnitMetadata) => Promise<Array<DropdownValueConfig<ActionId>>>,
-}> = {
-	'auras': {
+const actionIdSets: Record<
+	ACTION_ID_SET,
+	{
+		defaultLabel: string;
+		getActionIDs: (metadata: UnitMetadata) => Promise<Array<DropdownValueConfig<ActionId>>>;
+	}
+> = {
+	auras: {
 		defaultLabel: 'Aura',
 		getActionIDs: async metadata => {
 			return metadata.getAuras().map(actionId => {
-				const hasRanks = metadata.getAuras().filter(mainSpell => mainSpell.id.name.startsWith(actionId.id.name.replace(/ \(Rank \d+\)/g,''))).length > 1
+				const hasRanks =
+					metadata.getAuras().filter(mainSpell => mainSpell.id.name.startsWith(actionId.id.name.replace(/ \(Rank \d+\)/g, ''))).length > 1;
 				return {
 					value: actionId.id,
-					submenu: hasRanks ? [actionId.id.name.replace(/ \(Rank \d+\)/g,'')] : [],
+					submenu: hasRanks ? [actionId.id.name.replace(/ \(Rank \d+\)/g, '')] : [],
 				};
 			});
 		},
 	},
-	'stackable_auras': {
+	stackable_auras: {
 		defaultLabel: 'Aura',
 		getActionIDs: async metadata => {
-			return metadata.getAuras().filter(aura => aura.data.maxStacks > 0).map(actionId => {
-				const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g,'')
-				const hasRanks = metadata.getAuras().filter(aura => aura.id.name.startsWith(baseActionName)).length > 1
-				return {
-					value: actionId.id,
-					submenu: hasRanks ? [baseActionName] : [],
-				};
-			});
+			return metadata
+				.getAuras()
+				.filter(aura => aura.data.maxStacks > 0)
+				.map(actionId => {
+					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g, '');
+					const hasRanks = metadata.getAuras().filter(aura => aura.id.name.startsWith(baseActionName)).length > 1;
+					return {
+						value: actionId.id,
+						submenu: hasRanks ? [baseActionName] : [],
+					};
+				});
 		},
 	},
-	'icd_auras': {
+	icd_auras: {
 		defaultLabel: 'Aura',
 		getActionIDs: async metadata => {
-			return metadata.getAuras().filter(aura => aura.data.hasIcd).map(actionId => {
-				const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g,'')
-				const hasRanks = metadata.getAuras().filter(aura => aura.id.name.startsWith(baseActionName)).length > 1
-				return {
-					value: actionId.id,
-					submenu: hasRanks ? [baseActionName] : [],
-				};
-			});
+			return metadata
+				.getAuras()
+				.filter(aura => aura.data.hasIcd)
+				.map(actionId => {
+					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g, '');
+					const hasRanks = metadata.getAuras().filter(aura => aura.id.name.startsWith(baseActionName)).length > 1;
+					return {
+						value: actionId.id,
+						submenu: hasRanks ? [baseActionName] : [],
+					};
+				});
 		},
 	},
-	'exclusive_effect_auras': {
+	exclusive_effect_auras: {
 		defaultLabel: 'Aura',
 		getActionIDs: async metadata => {
-			return metadata.getAuras().filter(aura => aura.data.hasExclusiveEffect).map(actionId => {
-				const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g,'')
-				const hasRanks = metadata.getAuras().filter(aura => aura.id.name.startsWith(baseActionName)).length > 1
-				return {
-					value: actionId.id,
-					submenu: hasRanks ? [baseActionName] : [],
-				};
-			});
+			return metadata
+				.getAuras()
+				.filter(aura => aura.data.hasExclusiveEffect)
+				.map(actionId => {
+					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g, '');
+					const hasRanks = metadata.getAuras().filter(aura => aura.id.name.startsWith(baseActionName)).length > 1;
+					return {
+						value: actionId.id,
+						submenu: hasRanks ? [baseActionName] : [],
+					};
+				});
 		},
 	},
-	'castable_spells': {
+	castable_spells: {
 		defaultLabel: 'Spell',
 		getActionIDs: async metadata => {
 			const castableSpells = metadata.getSpells().filter(spell => spell.data.isCastable);
 
 			// Split up non-cooldowns and cooldowns into separate sections for easier browsing.
-			const { 'spells': spells, 'cooldowns': cooldowns } = bucket(castableSpells, spell => spell.data.isMajorCooldown ? 'cooldowns' : 'spells');
+			const { spells: spells, cooldowns: cooldowns } = bucket(castableSpells, spell => (spell.data.isMajorCooldown ? 'cooldowns' : 'spells'));
 
-			const placeholders: Array<ActionId> = [
-				ActionId.fromOtherId(OtherAction.OtherActionPotion),
-			];
+			const placeholders: Array<ActionId> = [ActionId.fromOtherId(OtherAction.OtherActionPotion)];
 
 			return [
-				[{
-					value: ActionId.fromEmpty(),
-					headerText: 'Spells',
-					submenu: ['Spells'],
-				}],
+				[
+					{
+						value: ActionId.fromEmpty(),
+						headerText: 'Spells',
+						submenu: ['Spells'],
+					},
+				],
 				(spells || []).map(actionId => {
-					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g,'')
-					const hasRanks = spells.filter(spell => spell.id.name.startsWith(baseActionName)).length > 1
+					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g, '');
+					const hasRanks = spells.filter(spell => spell.id.name.startsWith(baseActionName)).length > 1;
 					return {
 						value: actionId.id,
 						submenu: hasRanks ? ['Spells', baseActionName] : ['Spells'],
-						extraCssClasses: (actionId.data.prepullOnly
+						extraCssClasses: actionId.data.prepullOnly
 							? ['apl-prepull-actions-only']
-							: (actionId.data.encounterOnly
+							: actionId.data.encounterOnly
 								? ['apl-priority-list-only']
-								: [])),
+								: [],
 					};
 				}),
-				[{
-					value: ActionId.fromEmpty(),
-					headerText: 'Cooldowns',
-					submenu: ['Cooldowns'],
-				}],
+				[
+					{
+						value: ActionId.fromEmpty(),
+						headerText: 'Cooldowns',
+						submenu: ['Cooldowns'],
+					},
+				],
 				(cooldowns || []).map(actionId => {
 					// This regex also captures the percentages used in the custom Berserking cooldowns
-					const baseActionName = actionId.id.name.replace(/ \([\w\s%]+\)/g,'')
-					const hasRanks = cooldowns.filter(spell => spell.id.name.startsWith(baseActionName)).length > 1
+					const baseActionName = actionId.id.name.replace(/ \([\w\s%]+\)/g, '');
+					const hasRanks = cooldowns.filter(spell => spell.id.name.startsWith(baseActionName)).length > 1;
 					return {
 						value: actionId.id,
 						submenu: hasRanks ? ['Cooldowns', baseActionName] : ['Cooldowns'],
-						extraCssClasses: (actionId.data.prepullOnly
+						extraCssClasses: actionId.data.prepullOnly
 							? ['apl-prepull-actions-only']
-							: (actionId.data.encounterOnly
+							: actionId.data.encounterOnly
 								? ['apl-priority-list-only']
-								: [])),
+								: [],
 					};
 				}),
-				[{
-					value: ActionId.fromEmpty(),
-					headerText: 'Placeholders',
-					submenu: ['Placeholders'],
-				}],
+				[
+					{
+						value: ActionId.fromEmpty(),
+						headerText: 'Placeholders',
+						submenu: ['Placeholders'],
+					},
+				],
 				placeholders.map(actionId => {
 					return {
 						value: actionId,
@@ -134,55 +157,65 @@ const actionIdSets: Record<ACTION_ID_SET, {
 			].flat();
 		},
 	},
-	'channel_spells': {
+	channel_spells: {
 		defaultLabel: 'Channeled Spell',
 		getActionIDs: async metadata => {
-			return metadata.getSpells().filter(spell => spell.data.isCastable && spell.data.isChanneled).map(actionId => {
-				const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g,'')
-				const hasRanks = metadata.getSpells().filter(spell => spell.id.name.startsWith(baseActionName)).length > 1
-				return {
-					value: actionId.id,
-					submenu: hasRanks ? [baseActionName] : [],
-				};
-			});
+			return metadata
+				.getSpells()
+				.filter(spell => spell.data.isCastable && spell.data.isChanneled)
+				.map(actionId => {
+					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g, '');
+					const hasRanks = metadata.getSpells().filter(spell => spell.id.name.startsWith(baseActionName)).length > 1;
+					return {
+						value: actionId.id,
+						submenu: hasRanks ? [baseActionName] : [],
+					};
+				});
 		},
 	},
-	'dot_spells': {
+	dot_spells: {
 		defaultLabel: 'DoT Spell',
 		getActionIDs: async metadata => {
-			return metadata.getSpells().filter(spell => spell.data.hasDot).map(actionId => {
-				const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g,'')
-				const hasRanks = metadata.getSpells().filter(spell => spell.id.name.startsWith(baseActionName)).length > 1
-				return {
-					value: actionId.id,
-					submenu: hasRanks ? [baseActionName] : [],
-				};
-			});
+			return metadata
+				.getSpells()
+				.filter(spell => spell.data.hasDot)
+				.map(actionId => {
+					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g, '');
+					const hasRanks = metadata.getSpells().filter(spell => spell.id.name.startsWith(baseActionName)).length > 1;
+					return {
+						value: actionId.id,
+						submenu: hasRanks ? [baseActionName] : [],
+					};
+				});
 		},
 	},
-	'shield_spells': {
+	shield_spells: {
 		defaultLabel: 'Shield Spell',
 		getActionIDs: async metadata => {
-			return metadata.getSpells().filter(spell => spell.data.hasShield).map(actionId => {
-				const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g,'')
-				const hasRanks = metadata.getSpells().filter(spell => spell.id.name.startsWith(baseActionName)).length > 1
-				return {
-					value: actionId.id,
-					submenu: hasRanks ? [baseActionName] : [],
-				};
-			});
+			return metadata
+				.getSpells()
+				.filter(spell => spell.data.hasShield)
+				.map(actionId => {
+					const baseActionName = actionId.id.name.replace(/ \(Rank \d+\)/g, '');
+					const hasRanks = metadata.getSpells().filter(spell => spell.id.name.startsWith(baseActionName)).length > 1;
+					return {
+						value: actionId.id,
+						submenu: hasRanks ? [baseActionName] : [],
+					};
+				});
 		},
 	},
 };
 
 export type DEFAULT_UNIT_REF = 'self' | 'currentTarget';
 
-export interface APLActionIDPickerConfig<ModObject> extends Omit<DropdownPickerConfig<ModObject, ActionID, ActionId>, 'defaultLabel' | 'equals' | 'setOptionContent' | 'values' | 'getValue' | 'setValue'> {
-	actionIdSet: ACTION_ID_SET,
-	getUnitRef: (player: Player<any>) => UnitReference,
-	defaultUnitRef: DEFAULT_UNIT_REF,
-	getValue: (obj: ModObject) => ActionID,
-	setValue: (eventID: EventID, obj: ModObject, newValue: ActionID) => void,
+export interface APLActionIDPickerConfig<ModObject>
+	extends Omit<DropdownPickerConfig<ModObject, ActionID, ActionId>, 'defaultLabel' | 'equals' | 'setOptionContent' | 'values' | 'getValue' | 'setValue'> {
+	actionIdSet: ACTION_ID_SET;
+	getUnitRef: (player: Player<any>) => UnitReference;
+	defaultUnitRef: DEFAULT_UNIT_REF;
+	getValue: (obj: ModObject) => ActionID;
+	setValue: (eventID: EventID, obj: ModObject, newValue: ActionID) => void;
 }
 
 export class APLActionIDPicker extends DropdownPicker<Player<any>, ActionID, ActionId> {
@@ -195,7 +228,7 @@ export class APLActionIDPicker extends DropdownPicker<Player<any>, ActionID, Act
 			},
 			valueToSource: (val: ActionId) => val.toProto(),
 			defaultLabel: actionIdSet.defaultLabel,
-			equals: (a, b) => ((a == null) == (b == null)) && (!a || a.equals(b!)),
+			equals: (a, b) => (a == null) == (b == null) && (!a || a.equals(b!)),
 			setOptionContent: (button, valueConfig) => {
 				const actionId = valueConfig.value;
 
@@ -207,20 +240,22 @@ export class APLActionIDPicker extends DropdownPicker<Player<any>, ActionID, Act
 				const textElem = document.createTextNode(actionId.name);
 				button.appendChild(textElem);
 			},
-			createMissingValue: value => value.fill().then(filledId => {
-				return {
-					value: filledId,
-				};
-			}),
+			createMissingValue: value =>
+				value.fill().then(filledId => {
+					return {
+						value: filledId,
+					};
+				}),
 			values: [],
 		});
 
 		const getUnitRef = config.getUnitRef;
-		const defaultRef = config.defaultUnitRef == 'self' ? UnitReference.create({type: UnitType.Self}) : UnitReference.create({type: UnitType.CurrentTarget});
+		const defaultRef =
+			config.defaultUnitRef == 'self' ? UnitReference.create({ type: UnitType.Self }) : UnitReference.create({ type: UnitType.CurrentTarget });
 		const getActionIDs = actionIdSet.getActionIDs;
 		const updateValues = async () => {
 			const unitRef = getUnitRef(player);
-			const metadata = player.sim.getUnitMetadata(unitRef, player, defaultRef)
+			const metadata = player.sim.getUnitMetadata(unitRef, player, defaultRef);
 			if (metadata) {
 				const values = await getActionIDs(metadata);
 				this.setOptions(values);
@@ -233,45 +268,54 @@ export class APLActionIDPicker extends DropdownPicker<Player<any>, ActionID, Act
 
 export type UNIT_SET = 'aura_sources' | 'aura_sources_targets_first' | 'targets';
 
-const unitSets: Record<UNIT_SET, {
-	// Uses target icon by default instead of person icon. This should be set to true for inputs that default to CurrentTarget.
-	targetUI?: boolean,
-	getUnits: (player: Player<any>) => Array<UnitReference|undefined>,
-}> = {
-	'aura_sources': {
+const unitSets: Record<
+	UNIT_SET,
+	{
+		// Uses target icon by default instead of person icon. This should be set to true for inputs that default to CurrentTarget.
+		targetUI?: boolean;
+		getUnits: (player: Player<any>) => Array<UnitReference | undefined>;
+	}
+> = {
+	aura_sources: {
 		getUnits: player => {
 			return [
 				undefined,
-				player.getPetMetadatas().asList().map((petMetadata, i) => UnitReference.create({type: UnitType.Pet, index: i, owner: UnitReference.create({type: UnitType.Self})})),
-				UnitReference.create({type: UnitType.CurrentTarget}),
-				player.sim.encounter.targetsMetadata.asList().map((targetMetadata, i) => UnitReference.create({type: UnitType.Target, index: i})),
+				player
+					.getPetMetadatas()
+					.asList()
+					.map((petMetadata, i) => UnitReference.create({ type: UnitType.Pet, index: i, owner: UnitReference.create({ type: UnitType.Self }) })),
+				UnitReference.create({ type: UnitType.CurrentTarget }),
+				player.sim.encounter.targetsMetadata.asList().map((targetMetadata, i) => UnitReference.create({ type: UnitType.Target, index: i })),
 			].flat();
 		},
 	},
-	'aura_sources_targets_first': {
+	aura_sources_targets_first: {
 		targetUI: true,
 		getUnits: player => {
 			return [
 				undefined,
-				player.sim.encounter.targetsMetadata.asList().map((targetMetadata, i) => UnitReference.create({type: UnitType.Target, index: i})),
-				UnitReference.create({type: UnitType.Self}),
-				player.getPetMetadatas().asList().map((petMetadata, i) => UnitReference.create({type: UnitType.Pet, index: i, owner: UnitReference.create({type: UnitType.Self})})),
+				player.sim.encounter.targetsMetadata.asList().map((targetMetadata, i) => UnitReference.create({ type: UnitType.Target, index: i })),
+				UnitReference.create({ type: UnitType.Self }),
+				player
+					.getPetMetadatas()
+					.asList()
+					.map((petMetadata, i) => UnitReference.create({ type: UnitType.Pet, index: i, owner: UnitReference.create({ type: UnitType.Self }) })),
 			].flat();
 		},
 	},
-	'targets': {
+	targets: {
 		targetUI: true,
 		getUnits: player => {
 			return [
 				undefined,
-				player.sim.encounter.targetsMetadata.asList().map((targetMetadata, i) => UnitReference.create({type: UnitType.Target, index: i})),
+				player.sim.encounter.targetsMetadata.asList().map((targetMetadata, i) => UnitReference.create({ type: UnitType.Target, index: i })),
 			].flat();
 		},
 	},
 };
 
 export interface APLUnitPickerConfig extends Omit<UnitPickerConfig<Player<any>>, 'values'> {
-	unitSet: UNIT_SET,
+	unitSet: UNIT_SET;
 }
 
 export class APLUnitPicker extends UnitPicker<Player<any>> {
@@ -281,7 +325,7 @@ export class APLUnitPicker extends UnitPicker<Player<any>> {
 		const targetUI = !!unitSets[config.unitSet].targetUI;
 		super(parent, player, {
 			...config,
-			sourceToValue: (src: UnitReference|undefined) => APLUnitPicker.refToValue(src, player, targetUI),
+			sourceToValue: (src: UnitReference | undefined) => APLUnitPicker.refToValue(src, player, targetUI),
 			valueToSource: (val: UnitValue) => val.value,
 			values: [],
 			hideLabelWhenDefaultSelected: true,
@@ -293,7 +337,7 @@ export class APLUnitPicker extends UnitPicker<Player<any>> {
 		player.sim.unitMetadataEmitter.on(() => this.updateValues());
 	}
 
-	private static refToValue(ref: UnitReference|undefined, thisPlayer: Player<any>, targetUI: boolean|undefined): UnitValue {
+	private static refToValue(ref: UnitReference | undefined, thisPlayer: Player<any>, targetUI: boolean | undefined): UnitValue {
 		if (!ref || ref.type == UnitType.Unknown) {
 			return {
 				value: ref,
@@ -323,7 +367,7 @@ export class APLUnitPicker extends UnitPicker<Player<any>> {
 				};
 			}
 		} else if (ref.type == UnitType.Target) {
-			const targetMetadata = thisPlayer.sim.encounter.targetsMetadata.asList()[ref.index]
+			const targetMetadata = thisPlayer.sim.encounter.targetsMetadata.asList()[ref.index];
 			if (targetMetadata) {
 				return {
 					value: ref,
@@ -332,9 +376,9 @@ export class APLUnitPicker extends UnitPicker<Player<any>> {
 				};
 			}
 		} else if (ref.type == UnitType.Pet) {
-			const petMetadata = thisPlayer.sim.getUnitMetadata(ref, thisPlayer, UnitReference.create({type: UnitType.Self}));
+			const petMetadata = thisPlayer.sim.getUnitMetadata(ref, thisPlayer, UnitReference.create({ type: UnitType.Self }));
 			let name = `Pet ${ref.index + 1}`;
-			let icon: string|ActionId = 'fa-paw';
+			let icon: string | ActionId = 'fa-paw';
 			if (petMetadata) {
 				const petName = petMetadata.getName();
 				if (petName) {
@@ -359,40 +403,47 @@ export class APLUnitPicker extends UnitPicker<Player<any>> {
 		const unitSet = unitSets[this.unitSet];
 		const values = unitSet.getUnits(this.modObject);
 
-		this.setOptions(values.map(v => {
-			const valueConfig: DropdownValueConfig<UnitValue> = {
-				value: APLUnitPicker.refToValue(v, this.modObject, unitSet.targetUI),
-			};
-			if (v && v.type == UnitType.Pet) {
-				if (unitSet.targetUI) {
-					valueConfig.submenu = [APLUnitPicker.refToValue(v.owner!, this.modObject, unitSet.targetUI)];
-				} else {
-					valueConfig.submenu = [APLUnitPicker.refToValue(undefined, this.modObject, unitSet.targetUI)];
+		this.setOptions(
+			values.map(v => {
+				const valueConfig: DropdownValueConfig<UnitValue> = {
+					value: APLUnitPicker.refToValue(v, this.modObject, unitSet.targetUI),
+				};
+				if (v && v.type == UnitType.Pet) {
+					if (unitSet.targetUI) {
+						valueConfig.submenu = [APLUnitPicker.refToValue(v.owner!, this.modObject, unitSet.targetUI)];
+					} else {
+						valueConfig.submenu = [APLUnitPicker.refToValue(undefined, this.modObject, unitSet.targetUI)];
+					}
 				}
-			}
-			return valueConfig;
-		}));
+				return valueConfig;
+			}),
+		);
 	}
 }
 
-type APLPickerBuilderFieldFactory<F> = (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, F>, getParentValue: () => any) => Input<Player<any>, F>;
+type APLPickerBuilderFieldFactory<F> = (
+	parent: HTMLElement,
+	player: Player<any>,
+	config: InputConfig<Player<any>, F>,
+	getParentValue: () => any,
+) => Input<Player<any>, F>;
 
 export interface APLPickerBuilderFieldConfig<T, F extends keyof T> {
-	field: F,
-	newValue: () => T[F],
-	factory: APLPickerBuilderFieldFactory<T[F]>,
+	field: F;
+	newValue: () => T[F];
+	factory: APLPickerBuilderFieldFactory<T[F]>;
 
-	label?: string,
-	labelTooltip?: string,
+	label?: string;
+	labelTooltip?: string;
 }
 
 export interface APLPickerBuilderConfig<T> extends InputConfig<Player<any>, T> {
-	newValue: () => T,
-	fields: Array<APLPickerBuilderFieldConfig<T, any>>,
+	newValue: () => T;
+	fields: Array<APLPickerBuilderFieldConfig<T, any>>;
 }
 
 export interface APLPickerBuilderField<T, F extends keyof T> extends APLPickerBuilderFieldConfig<T, F> {
-	picker: Input<Player<any>, T[F]>,
+	picker: Input<Player<any>, T[F]>;
 }
 
 export class APLPickerBuilder<T> extends Input<Player<any>, T> {
@@ -408,27 +459,35 @@ export class APLPickerBuilder<T> extends Input<Player<any>, T> {
 		this.init();
 	}
 
-	private static makeFieldPicker<T, F extends keyof T>(builder: APLPickerBuilder<T>, fieldConfig: APLPickerBuilderFieldConfig<T, F>): APLPickerBuilderField<T, F> {
-		const field: F = fieldConfig.field
-		const picker = fieldConfig.factory(builder.rootElem, builder.modObject, {
-			label: fieldConfig.label,
-			labelTooltip: fieldConfig.labelTooltip,
-			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
-			getValue: () => {
-				const source = builder.getSourceValue();
-				if (!source[field]) {
-					source[field] = fieldConfig.newValue();
-				}
-				return source[field];
+	private static makeFieldPicker<T, F extends keyof T>(
+		builder: APLPickerBuilder<T>,
+		fieldConfig: APLPickerBuilderFieldConfig<T, F>,
+	): APLPickerBuilderField<T, F> {
+		const field: F = fieldConfig.field;
+		const picker = fieldConfig.factory(
+			builder.rootElem,
+			builder.modObject,
+			{
+				label: fieldConfig.label,
+				labelTooltip: fieldConfig.labelTooltip,
+				changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
+				getValue: () => {
+					const source = builder.getSourceValue();
+					if (!source[field]) {
+						source[field] = fieldConfig.newValue();
+					}
+					return source[field];
+				},
+				setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
+					builder.getSourceValue()[field] = newValue;
+					player.rotationChangeEmitter.emit(eventID);
+				},
 			},
-			setValue: (eventID: EventID, player: Player<any>, newValue: any) => {
-				builder.getSourceValue()[field] = newValue;
-				player.rotationChangeEmitter.emit(eventID);
-			},
-		}, () => builder.getSourceValue())
+			() => builder.getSourceValue(),
+		);
 
 		if (field === 'vals' || field === 'actions') {
-			picker.rootElem.classList.add('apl-picker-builder-multi')
+			picker.rootElem.classList.add('apl-picker-builder-multi');
 		}
 
 		return {
@@ -456,7 +515,13 @@ export class APLPickerBuilder<T> extends Input<Player<any>, T> {
 	}
 }
 
-export function actionIdFieldConfig(field: string, actionIdSet: ACTION_ID_SET, unitRefField?: string, defaultUnitRef?: DEFAULT_UNIT_REF, options?: Partial<APLPickerBuilderFieldConfig<any, any>>): APLPickerBuilderFieldConfig<any, any> {
+export function actionIdFieldConfig(
+	field: string,
+	actionIdSet: ACTION_ID_SET,
+	unitRefField?: string,
+	defaultUnitRef?: DEFAULT_UNIT_REF,
+	options?: Partial<APLPickerBuilderFieldConfig<any, any>>,
+): APLPickerBuilderFieldConfig<any, any> {
 	return {
 		field: field,
 		newValue: () => ActionID.create(),
@@ -464,27 +529,36 @@ export function actionIdFieldConfig(field: string, actionIdSet: ACTION_ID_SET, u
 			return new APLActionIDPicker(parent, player, {
 				...config,
 				actionIdSet: actionIdSet,
-				getUnitRef: () => unitRefField ? getParentValue()[unitRefField] : UnitReference.create(),
+				getUnitRef: () => (unitRefField ? getParentValue()[unitRefField] : UnitReference.create()),
 				defaultUnitRef: defaultUnitRef || 'self',
-			})
+			});
 		},
 		...(options || {}),
 	};
 }
 
-export function unitFieldConfig(field: string, unitSet: UNIT_SET, options?: Partial<APLPickerBuilderFieldConfig<any, any>>): APLPickerBuilderFieldConfig<any, any> {
+export function unitFieldConfig(
+	field: string,
+	unitSet: UNIT_SET,
+	options?: Partial<APLPickerBuilderFieldConfig<any, any>>,
+): APLPickerBuilderFieldConfig<any, any> {
 	return {
 		field: field,
 		newValue: () => undefined,
-		factory: (parent, player, config) => new APLUnitPicker(parent, player, {
-			...config,
-			unitSet: unitSet,
-		}),
+		factory: (parent, player, config) =>
+			new APLUnitPicker(parent, player, {
+				...config,
+				unitSet: unitSet,
+			}),
 		...(options || {}),
 	};
 }
 
-export function booleanFieldConfig(field: string, label?:string, options?: Partial<APLPickerBuilderFieldConfig<any, any>>): APLPickerBuilderFieldConfig<any, any> {
+export function booleanFieldConfig(
+	field: string,
+	label?: string,
+	options?: Partial<APLPickerBuilderFieldConfig<any, any>>,
+): APLPickerBuilderFieldConfig<any, any> {
 	return {
 		field: field,
 		newValue: () => false,
@@ -497,7 +571,11 @@ export function booleanFieldConfig(field: string, label?:string, options?: Parti
 	};
 }
 
-export function numberFieldConfig(field: string, float: boolean, options?: Partial<APLPickerBuilderFieldConfig<any, any>>): APLPickerBuilderFieldConfig<any, any> {
+export function numberFieldConfig(
+	field: string,
+	float: boolean,
+	options?: Partial<APLPickerBuilderFieldConfig<any, any>>,
+): APLPickerBuilderFieldConfig<any, any> {
 	return {
 		field: field,
 		newValue: () => 0,
@@ -592,12 +670,15 @@ export function rotationTypeFieldConfig(field: string): APLPickerBuilderFieldCon
 }
 */
 
-export function aplInputBuilder<T>(newValue: () => T, fields: Array<APLPickerBuilderFieldConfig<T, keyof T>>): (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, T>) => Input<Player<any>, T> {
+export function aplInputBuilder<T>(
+	newValue: () => T,
+	fields: Array<APLPickerBuilderFieldConfig<T, keyof T>>,
+): (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, T>) => Input<Player<any>, T> {
 	return (parent, player, config) => {
 		return new APLPickerBuilder(parent, player, {
 			...config,
 			newValue: newValue,
 			fields: fields,
-		})
-	}
+		});
+	};
 }

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -1,95 +1,84 @@
-import {
-	Class,
-	Spec,
-} from '../../proto/common.js';
-
-import {
-	ShamanTotems_TotemType as TotemType,
-} from '../../proto/shaman.js';
-
+import { Player } from '../../player.js';
 import {
 	APLValue,
 	APLValueAnd,
-	APLValueOr,
-	APLValueNot,
+	APLValueAuraICDIsReadyWithReactionTime,
+	APLValueAuraInternalCooldown,
+	APLValueAuraIsActive,
+	APLValueAuraIsActiveWithReactionTime,
+	APLValueAuraNumStacks,
+	APLValueAuraRemainingTime,
+	APLValueAuraShouldRefresh,
+	APLValueAutoSwingTime,
+	APLValueAutoSwingTime_SwingType as AutoSwingType,
+	APLValueAutoTimeToNext,
+	APLValueAutoTimeToNext_AttackType as AutoAttackType,
+	APLValueCatExcessEnergy,
+	APLValueCatNewSavageRoarDuration,
+	APLValueChannelClipDelay,
 	APLValueCompare,
 	APLValueCompare_ComparisonOperator as ComparisonOperator,
-	APLValueMath,
-	APLValueMath_MathOperator as MathOperator,
-	APLValueMax,
-	APLValueMin,
 	APLValueConst,
-	APLValueCurrentTime,
-	APLValueCurrentTimePercent,
-	APLValueRemainingTime,
-	APLValueRemainingTimePercent,
-	APLValueIsExecutePhase,
-	APLValueIsExecutePhase_ExecutePhaseThreshold as ExecutePhaseThreshold,
+	APLValueCurrentComboPoints,
+	APLValueCurrentEnergy,
 	APLValueCurrentHealth,
 	APLValueCurrentHealthPercent,
 	APLValueCurrentMana,
 	APLValueCurrentManaPercent,
 	APLValueCurrentRage,
-	APLValueCurrentEnergy,
-	APLValueCurrentComboPoints,
-	APLValueGCDIsReady,
-	APLValueGCDTimeToReady,
-	APLValueAutoTimeToNext,
-	APLValueAutoTimeToNext_AttackType as AutoAttackType,
-	APLValueSpellCanCast,
-	APLValueSpellIsReady,
-	APLValueSpellTimeToReady,
-	APLValueSpellCastTime,
-	APLValueSpellTravelTime,
-	APLValueSpellCPM,
-	APLValueSpellIsChanneling,
-	APLValueSpellChanneledTicks,
-	APLValueSpellCurrentCost,
-	APLValueChannelClipDelay,
-	APLValueFrontOfTarget,
-	APLValueAuraIsActive,
-	APLValueAuraIsActiveWithReactionTime,
-	APLValueAuraRemainingTime,
-	APLValueAuraNumStacks,
-	APLValueAuraInternalCooldown,
-	APLValueAuraICDIsReadyWithReactionTime,
-	APLValueAuraShouldRefresh,
+	APLValueCurrentSealRemainingTime,
+	APLValueCurrentTime,
+	APLValueCurrentTimePercent,
 	APLValueDotIsActive,
 	APLValueDotRemainingTime,
+	APLValueFrontOfTarget,
+	APLValueGCDIsReady,
+	APLValueGCDTimeToReady,
+	APLValueIsExecutePhase,
+	APLValueIsExecutePhase_ExecutePhaseThreshold as ExecutePhaseThreshold,
+	APLValueMath,
+	APLValueMath_MathOperator as MathOperator,
+	APLValueMax,
+	APLValueMin,
+	APLValueNot,
+	APLValueNumberTargets,
+	APLValueOr,
+	APLValueRemainingTime,
+	APLValueRemainingTimePercent,
 	APLValueSequenceIsComplete,
 	APLValueSequenceIsReady,
 	APLValueSequenceTimeToReady,
-	APLValueNumberTargets,
+	APLValueSpellCanCast,
+	APLValueSpellCastTime,
+	APLValueSpellChanneledTicks,
+	APLValueSpellCPM,
+	APLValueSpellCurrentCost,
+	APLValueSpellIsChanneling,
+	APLValueSpellIsReady,
+	APLValueSpellTimeToReady,
+	APLValueSpellTravelTime,
 	APLValueTotemRemainingTime,
-	APLValueCatExcessEnergy,
 	APLValueWarlockShouldRecastDrainSoul,
 	APLValueWarlockShouldRefreshCorruption,
-	APLValueCatNewSavageRoarDuration,
-	APLValueCurrentSealRemainingTime,
-	APLValueAutoSwingTime,
-	APLValueAutoSwingTime_SwingType as AutoSwingType,
 } from '../../proto/apl.js';
-
+import { Class, Spec } from '../../proto/common.js';
+import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
 import { EventID } from '../../typed_event.js';
-import { Input, InputConfig } from '../input.js';
-import { Player } from '../../player.js';
 import { TextDropdownPicker, TextDropdownValueConfig } from '../dropdown_picker.js';
+import { Input, InputConfig } from '../input.js';
 import { ListItemPickerConfig, ListPicker } from '../list_picker.js';
-
 import * as AplHelpers from './apl_helpers.js';
 
-export interface APLValuePickerConfig extends InputConfig<Player<any>, APLValue | undefined> {
-}
+export interface APLValuePickerConfig extends InputConfig<Player<any>, APLValue | undefined> {}
 
 export type APLValueKind = APLValue['value']['oneofKind'];
-export type APLValueImplStruct<F extends APLValueKind> = Extract<APLValue['value'], {oneofKind: F}>;
+export type APLValueImplStruct<F extends APLValueKind> = Extract<APLValue['value'], { oneofKind: F }>;
 type APLValueImplTypesUnion = {
 	[f in NonNullable<APLValueKind>]: f extends keyof APLValueImplStruct<f> ? APLValueImplStruct<f>[f] : never;
 };
-export type APLValueImplType = APLValueImplTypesUnion[NonNullable<APLValueKind>]|undefined;
+export type APLValueImplType = APLValueImplTypesUnion[NonNullable<APLValueKind>] | undefined;
 
 export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
-
 	private kindPicker: TextDropdownPicker<Player<any>, APLValueKind>;
 
 	private currentKind: APLValueKind;
@@ -100,23 +89,28 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 
 		const isPrepull = this.rootElem.closest('.apl-prepull-action-picker') != null;
 
-		const allValueKinds = (Object.keys(valueKindFactories) as Array<NonNullable<APLValueKind>>)
-			.filter(valueKind => valueKindFactories[valueKind].includeIf?.(player, isPrepull) ?? true);
+		const allValueKinds = (Object.keys(valueKindFactories) as Array<NonNullable<APLValueKind>>).filter(
+			valueKind => valueKindFactories[valueKind].includeIf?.(player, isPrepull) ?? true,
+		);
 
 		this.kindPicker = new TextDropdownPicker(this.rootElem, player, {
 			defaultLabel: 'No Condition',
-			values: [{
-				value: undefined,
-				label: '<None>',
-			} as TextDropdownValueConfig<APLValueKind>].concat(allValueKinds.map(kind => {
-				const factory = valueKindFactories[kind];
-				return {
-					value: kind,
-					label: factory.label,
-					submenu: factory.submenu,
-					tooltip: factory.fullDescription ? `<p>${factory.shortDescription}</p> ${factory.fullDescription}` : factory.shortDescription,
-				};
-			})),
+			values: [
+				{
+					value: undefined,
+					label: '<None>',
+				} as TextDropdownValueConfig<APLValueKind>,
+			].concat(
+				allValueKinds.map(kind => {
+					const factory = valueKindFactories[kind];
+					return {
+						value: kind,
+						label: factory.label,
+						submenu: factory.submenu,
+						tooltip: factory.fullDescription ? `<p>${factory.shortDescription}</p> ${factory.fullDescription}` : factory.shortDescription,
+					};
+				}),
+			),
 			equals: (a, b) => a == b,
 			changedEvent: (player: Player<any>) => player.rotationChangeEmitter,
 			getValue: (_player: Player<any>) => this.getSourceValue()?.value.oneofKind,
@@ -141,7 +135,9 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 								if (sourceValue.value.oneofKind == 'or') {
 									(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = sourceValue.value.or.vals;
 								} else {
-									(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = [this.makeAPLValue(oldKind, this.valuePicker.getInputValue())];
+									(newSourceValue.value as APLValueImplStruct<'and'>).and.vals = [
+										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+									];
 								}
 							} else if (newKind == 'or') {
 								if (sourceValue.value.oneofKind == 'and') {
@@ -153,13 +149,17 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 								if (sourceValue.value.oneofKind == 'max') {
 									(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = sourceValue.value.max.vals;
 								} else {
-									(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = [this.makeAPLValue(oldKind, this.valuePicker.getInputValue())];
+									(newSourceValue.value as APLValueImplStruct<'min'>).min.vals = [
+										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+									];
 								}
 							} else if (newKind == 'max') {
 								if (sourceValue.value.oneofKind == 'min') {
 									(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = sourceValue.value.min.vals;
 								} else {
-									(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = [this.makeAPLValue(oldKind, this.valuePicker.getInputValue())];
+									(newSourceValue.value as APLValueImplStruct<'max'>).max.vals = [
+										this.makeAPLValue(oldKind, this.valuePicker.getInputValue()),
+									];
 								}
 							} else if (sourceValue.value.oneofKind == 'and' && sourceValue.value.and.vals?.[0]?.value.oneofKind == newKind) {
 								newSourceValue = sourceValue.value.and.vals[0];
@@ -204,15 +204,15 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 			return APLValue.create({
 				value: {
 					oneofKind: kind,
-					...((() => {
+					...(() => {
 						const val: any = {};
 						if (kind && this.valuePicker) {
 							val[kind] = this.valuePicker.getInputValue();
 						}
 						return val;
-					})()),
+					})(),
 				},
-			})
+			});
 		}
 	}
 
@@ -231,7 +231,7 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 		}
 		const obj: any = { oneofKind: kind };
 		obj[kind] = implVal;
-		return APLValue.create({value: obj});
+		return APLValue.create({ value: obj });
 	}
 
 	private updateValuePicker(newKind: APLValueKind) {
@@ -271,32 +271,33 @@ export class APLValuePicker extends Input<Player<any>, APLValue | undefined> {
 }
 
 type ValueKindConfig<T> = {
-	label: string,
-	submenu?: Array<string>,
-	shortDescription: string,
-	fullDescription?: string,
-	newValue: () => T,
-	includeIf?: (player: Player<any>, isPrepull: boolean) => boolean,
-	factory: (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, T>) => Input<Player<any>, T>,
+	label: string;
+	submenu?: Array<string>;
+	shortDescription: string;
+	fullDescription?: string;
+	newValue: () => T;
+	includeIf?: (player: Player<any>, isPrepull: boolean) => boolean;
+	factory: (parent: HTMLElement, player: Player<any>, config: InputConfig<Player<any>, T>) => Input<Player<any>, T>;
 };
 
 function comparisonOperatorFieldConfig(field: string): AplHelpers.APLPickerBuilderFieldConfig<any, any> {
 	return {
 		field: field,
 		newValue: () => ComparisonOperator.OpEq,
-		factory: (parent, player, config) => new TextDropdownPicker(parent, player, {
-			...config,
-			defaultLabel: 'None',
-			equals: (a, b) => a == b,
-			values: [
-				{ value: ComparisonOperator.OpEq, label: '==' },
-				{ value: ComparisonOperator.OpNe, label: '!=' },
-				{ value: ComparisonOperator.OpGe, label: '>=' },
-				{ value: ComparisonOperator.OpGt, label: '>' },
-				{ value: ComparisonOperator.OpLe, label: '<=' },
-				{ value: ComparisonOperator.OpLt, label: '<' },
-			],
-		}),
+		factory: (parent, player, config) =>
+			new TextDropdownPicker(parent, player, {
+				...config,
+				defaultLabel: 'None',
+				equals: (a, b) => a == b,
+				values: [
+					{ value: ComparisonOperator.OpEq, label: '==' },
+					{ value: ComparisonOperator.OpNe, label: '!=' },
+					{ value: ComparisonOperator.OpGe, label: '>=' },
+					{ value: ComparisonOperator.OpGt, label: '>' },
+					{ value: ComparisonOperator.OpLe, label: '<=' },
+					{ value: ComparisonOperator.OpLt, label: '<' },
+				],
+			}),
 	};
 }
 
@@ -304,17 +305,18 @@ function mathOperatorFieldConfig(field: string): AplHelpers.APLPickerBuilderFiel
 	return {
 		field: field,
 		newValue: () => MathOperator.OpAdd,
-		factory: (parent, player, config) => new TextDropdownPicker(parent, player, {
-			...config,
-			defaultLabel: 'None',
-			equals: (a, b) => a == b,
-			values: [
-				{ value: MathOperator.OpAdd, label: '+' },
-				{ value: MathOperator.OpSub, label: '-' },
-				{ value: MathOperator.OpMul, label: '*' },
-				{ value: MathOperator.OpDiv, label: '/' },
-			],
-		}),
+		factory: (parent, player, config) =>
+			new TextDropdownPicker(parent, player, {
+				...config,
+				defaultLabel: 'None',
+				equals: (a, b) => a == b,
+				values: [
+					{ value: MathOperator.OpAdd, label: '+' },
+					{ value: MathOperator.OpSub, label: '-' },
+					{ value: MathOperator.OpMul, label: '*' },
+					{ value: MathOperator.OpDiv, label: '/' },
+				],
+			}),
 	};
 }
 
@@ -322,18 +324,19 @@ function autoTypeFieldConfig(field: string): AplHelpers.APLPickerBuilderFieldCon
 	return {
 		field: field,
 		newValue: () => AutoAttackType.Any,
-		factory: (parent, player, config) => new TextDropdownPicker(parent, player, {
-			...config,
-			defaultLabel: 'None',
-			equals: (a, b) => a == b,
-			values: [
-				{ value: AutoAttackType.Any, label: 'Any' },
-				{ value: AutoAttackType.Melee, label: 'Melee' },
-				{ value: AutoAttackType.MainHand, label: 'Main Hand' },
-				{ value: AutoAttackType.OffHand, label: 'Off Hand' },
-				{ value: AutoAttackType.Ranged, label: 'Ranged' },
-			],
-		}),
+		factory: (parent, player, config) =>
+			new TextDropdownPicker(parent, player, {
+				...config,
+				defaultLabel: 'None',
+				equals: (a, b) => a == b,
+				values: [
+					{ value: AutoAttackType.Any, label: 'Any' },
+					{ value: AutoAttackType.Melee, label: 'Melee' },
+					{ value: AutoAttackType.MainHand, label: 'Main Hand' },
+					{ value: AutoAttackType.OffHand, label: 'Off Hand' },
+					{ value: AutoAttackType.Ranged, label: 'Ranged' },
+				],
+			}),
 	};
 }
 
@@ -341,16 +344,17 @@ function autoSwingTypeFieldConfig(field: string): AplHelpers.APLPickerBuilderFie
 	return {
 		field: field,
 		newValue: () => AutoSwingType.MainHand,
-		factory: (parent, player, config) => new TextDropdownPicker(parent, player, {
-			...config,
-			defaultLabel: 'None',
-			equals: (a, b) => a == b,
-			values: [
-				{ value: AutoSwingType.MainHand, label: 'Main Hand' },
-				{ value: AutoSwingType.OffHand, label: 'Off Hand' },
-				{ value: AutoSwingType.Ranged, label: 'Ranged' },
-			],
-		}),
+		factory: (parent, player, config) =>
+			new TextDropdownPicker(parent, player, {
+				...config,
+				defaultLabel: 'None',
+				equals: (a, b) => a == b,
+				values: [
+					{ value: AutoSwingType.MainHand, label: 'Main Hand' },
+					{ value: AutoSwingType.OffHand, label: 'Off Hand' },
+					{ value: AutoSwingType.Ranged, label: 'Ranged' },
+				],
+			}),
 	};
 }
 
@@ -358,16 +362,17 @@ function executePhaseThresholdFieldConfig(field: string): AplHelpers.APLPickerBu
 	return {
 		field: field,
 		newValue: () => ExecutePhaseThreshold.E20,
-		factory: (parent, player, config) => new TextDropdownPicker(parent, player, {
-			...config,
-			defaultLabel: 'None',
-			equals: (a, b) => a == b,
-			values: [
-				{ value: ExecutePhaseThreshold.E20, label: '20%' },
-				{ value: ExecutePhaseThreshold.E25, label: '25%' },
-				{ value: ExecutePhaseThreshold.E35, label: '35%' },
-			],
-		}),
+		factory: (parent, player, config) =>
+			new TextDropdownPicker(parent, player, {
+				...config,
+				defaultLabel: 'None',
+				equals: (a, b) => a == b,
+				values: [
+					{ value: ExecutePhaseThreshold.E20, label: '20%' },
+					{ value: ExecutePhaseThreshold.E25, label: '25%' },
+					{ value: ExecutePhaseThreshold.E35, label: '35%' },
+				],
+			}),
 	};
 }
 
@@ -375,21 +380,25 @@ function totemTypeFieldConfig(field: string): AplHelpers.APLPickerBuilderFieldCo
 	return {
 		field: field,
 		newValue: () => TotemType.Water,
-		factory: (parent, player, config) => new TextDropdownPicker(parent, player, {
-			...config,
-			defaultLabel: 'None',
-			equals: (a, b) => a == b,
-			values: [
-				{ value: TotemType.Earth, label: 'Earth' },
-				{ value: TotemType.Air, label: 'Air' },
-				{ value: TotemType.Fire, label: 'Fire' },
-				{ value: TotemType.Water, label: 'Water' },
-			],
-		}),
+		factory: (parent, player, config) =>
+			new TextDropdownPicker(parent, player, {
+				...config,
+				defaultLabel: 'None',
+				equals: (a, b) => a == b,
+				values: [
+					{ value: TotemType.Earth, label: 'Earth' },
+					{ value: TotemType.Air, label: 'Air' },
+					{ value: TotemType.Fire, label: 'Fire' },
+					{ value: TotemType.Water, label: 'Water' },
+				],
+			}),
 	};
 }
 
-export function valueFieldConfig(field: string, options?: Partial<AplHelpers.APLPickerBuilderFieldConfig<any, any>>): AplHelpers.APLPickerBuilderFieldConfig<any, any> {
+export function valueFieldConfig(
+	field: string,
+	options?: Partial<AplHelpers.APLPickerBuilderFieldConfig<any, any>>,
+): AplHelpers.APLPickerBuilderFieldConfig<any, any> {
 	return {
 		field: field,
 		newValue: APLValue.create,
@@ -402,34 +411,44 @@ export function valueListFieldConfig(field: string): AplHelpers.APLPickerBuilder
 	return {
 		field: field,
 		newValue: () => [],
-		factory: (parent, player, config) => new ListPicker<Player<any>, APLValue | undefined>(parent, player, {
-			...config,
-			// Override setValue to replace undefined elements with default messages.
-			setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLValue | undefined>) => {
-				config.setValue(eventID, player, newValue.map(val => val || APLValue.create()));
-			},
-			itemLabel: 'Value',
-			newItem: APLValue.create,
-			copyItem: (oldValue: APLValue | undefined) => oldValue ? APLValue.clone(oldValue) : oldValue,
-			newItemPicker: (parent: HTMLElement, listPicker: ListPicker<Player<any>, APLValue | undefined>, index: number, config: ListItemPickerConfig<Player<any>, APLValue | undefined>) => new APLValuePicker(parent, player, config),
-			allowedActions: ['create', 'delete'],
-			actions: {
-				create: {
-					useIcon: true,
+		factory: (parent, player, config) =>
+			new ListPicker<Player<any>, APLValue | undefined>(parent, player, {
+				...config,
+				// Override setValue to replace undefined elements with default messages.
+				setValue: (eventID: EventID, player: Player<any>, newValue: Array<APLValue | undefined>) => {
+					config.setValue(
+						eventID,
+						player,
+						newValue.map(val => val || APLValue.create()),
+					);
 				},
-			},
-		}),
+				itemLabel: 'Value',
+				newItem: APLValue.create,
+				copyItem: (oldValue: APLValue | undefined) => (oldValue ? APLValue.clone(oldValue) : oldValue),
+				newItemPicker: (
+					parent: HTMLElement,
+					listPicker: ListPicker<Player<any>, APLValue | undefined>,
+					index: number,
+					config: ListItemPickerConfig<Player<any>, APLValue | undefined>,
+				) => new APLValuePicker(parent, player, config),
+				allowedActions: ['create', 'delete'],
+				actions: {
+					create: {
+						useIcon: true,
+					},
+				},
+			}),
 	};
 }
 
 function inputBuilder<T extends APLValueImplType>(config: {
-	label: string,
-	submenu?: Array<string>,
-	shortDescription: string,
-	fullDescription?: string,
-	newValue: () => T,
-	includeIf?: (player: Player<any>, isPrepull: boolean) => boolean,
-	fields: Array<AplHelpers.APLPickerBuilderFieldConfig<T, keyof T>>,
+	label: string;
+	submenu?: Array<string>;
+	shortDescription: string;
+	fullDescription?: string;
+	newValue: () => T;
+	includeIf?: (player: Player<any>, isPrepull: boolean) => boolean;
+	fields: Array<AplHelpers.APLPickerBuilderFieldConfig<T, keyof T>>;
 }): ValueKindConfig<T> {
 	return {
 		label: config.label,
@@ -442,9 +461,9 @@ function inputBuilder<T extends APLValueImplType>(config: {
 	};
 }
 
-const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APLValueImplTypesUnion[f]>} = {
+const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<APLValueImplTypesUnion[f]> } = {
 	// Operators
-	'const': inputBuilder({
+	const: inputBuilder({
 		label: 'Const',
 		shortDescription: 'A fixed value.',
 		fullDescription: `
@@ -458,124 +477,103 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 		</p>
 		`,
 		newValue: APLValueConst.create,
-		fields: [
-			AplHelpers.stringFieldConfig('val'),
-		],
+		fields: [AplHelpers.stringFieldConfig('val')],
 	}),
-	'cmp': inputBuilder({
+	cmp: inputBuilder({
 		label: 'Compare',
 		submenu: ['Logic'],
 		shortDescription: 'Compares two values.',
 		newValue: APLValueCompare.create,
-		fields: [
-			valueFieldConfig('lhs'),
-			comparisonOperatorFieldConfig('op'),
-			valueFieldConfig('rhs'),
-		],
+		fields: [valueFieldConfig('lhs'), comparisonOperatorFieldConfig('op'), valueFieldConfig('rhs')],
 	}),
-	'math': inputBuilder({
+	math: inputBuilder({
 		label: 'Math',
 		submenu: ['Logic'],
 		shortDescription: 'Do basic math on two values.',
 		newValue: APLValueMath.create,
-		fields: [
-			valueFieldConfig('lhs'),
-			mathOperatorFieldConfig('op'),
-			valueFieldConfig('rhs'),
-		],
+		fields: [valueFieldConfig('lhs'), mathOperatorFieldConfig('op'), valueFieldConfig('rhs')],
 	}),
-	'max': inputBuilder({
+	max: inputBuilder({
 		label: 'Max',
 		submenu: ['Logic'],
 		shortDescription: 'Returns the largest value among the subvalues.',
 		newValue: APLValueMax.create,
-		fields: [
-			valueListFieldConfig('vals'),
-		],
+		fields: [valueListFieldConfig('vals')],
 	}),
-	'min': inputBuilder({
+	min: inputBuilder({
 		label: 'Min',
 		submenu: ['Logic'],
 		shortDescription: 'Returns the smallest value among the subvalues.',
 		newValue: APLValueMin.create,
-		fields: [
-			valueListFieldConfig('vals'),
-		],
+		fields: [valueListFieldConfig('vals')],
 	}),
-	'and': inputBuilder({
+	and: inputBuilder({
 		label: 'All of',
 		submenu: ['Logic'],
 		shortDescription: 'Returns <b>True</b> if all of the sub-values are <b>True</b>, otherwise <b>False</b>',
 		newValue: APLValueAnd.create,
-		fields: [
-			valueListFieldConfig('vals'),
-		],
+		fields: [valueListFieldConfig('vals')],
 	}),
-	'or': inputBuilder({
+	or: inputBuilder({
 		label: 'Any of',
 		submenu: ['Logic'],
 		shortDescription: 'Returns <b>True</b> if any of the sub-values are <b>True</b>, otherwise <b>False</b>',
 		newValue: APLValueOr.create,
-		fields: [
-			valueListFieldConfig('vals'),
-		],
+		fields: [valueListFieldConfig('vals')],
 	}),
-	'not': inputBuilder({
+	not: inputBuilder({
 		label: 'Not',
 		submenu: ['Logic'],
 		shortDescription: 'Returns the opposite of the inner value, i.e. <b>True</b> if the value is <b>False</b> and vice-versa.',
 		newValue: APLValueNot.create,
-		fields: [
-			valueFieldConfig('val'),
-		],
+		fields: [valueFieldConfig('val')],
 	}),
 
 	// Encounter
-	'currentTime': inputBuilder({
+	currentTime: inputBuilder({
 		label: 'Current Time',
 		submenu: ['Encounter'],
 		shortDescription: 'Elapsed time of the current sim iteration.',
 		newValue: APLValueCurrentTime.create,
 		fields: [],
 	}),
-	'currentTimePercent': inputBuilder({
+	currentTimePercent: inputBuilder({
 		label: 'Current Time (%)',
 		submenu: ['Encounter'],
 		shortDescription: 'Elapsed time of the current sim iteration, as a percentage.',
 		newValue: APLValueCurrentTimePercent.create,
 		fields: [],
 	}),
-	'remainingTime': inputBuilder({
+	remainingTime: inputBuilder({
 		label: 'Remaining Time',
 		submenu: ['Encounter'],
 		shortDescription: 'Elapsed time of the remaining sim iteration.',
 		newValue: APLValueRemainingTime.create,
 		fields: [],
 	}),
-	'remainingTimePercent': inputBuilder({
+	remainingTimePercent: inputBuilder({
 		label: 'Remaining Time (%)',
 		submenu: ['Encounter'],
 		shortDescription: 'Elapsed time of the remaining sim iteration, as a percentage.',
 		newValue: APLValueRemainingTimePercent.create,
 		fields: [],
 	}),
-	'isExecutePhase': inputBuilder({
+	isExecutePhase: inputBuilder({
 		label: 'Is Execute Phase',
 		submenu: ['Encounter'],
-		shortDescription: '<b>True</b> if the encounter is in Execute Phase, meaning the target\'s health is less than the given threshold, otherwise <b>False</b>.',
+		shortDescription:
+			"<b>True</b> if the encounter is in Execute Phase, meaning the target's health is less than the given threshold, otherwise <b>False</b>.",
 		newValue: APLValueIsExecutePhase.create,
-		fields: [
-			executePhaseThresholdFieldConfig('threshold'),
-		],
+		fields: [executePhaseThresholdFieldConfig('threshold')],
 	}),
-	'numberTargets': inputBuilder({
+	numberTargets: inputBuilder({
 		label: 'Number of Targets',
 		submenu: ['Encounter'],
 		shortDescription: 'Count of targets in the current encounter',
 		newValue: APLValueNumberTargets.create,
 		fields: [],
 	}),
-	'frontOfTarget': inputBuilder({
+	frontOfTarget: inputBuilder({
 		label: 'Front of Target',
 		submenu: ['Encounter'],
 		shortDescription: '<b>True</b> if facing from of target',
@@ -584,53 +582,49 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 	}),
 
 	// Resources
-	'currentHealth': inputBuilder({
+	currentHealth: inputBuilder({
 		label: 'Health',
 		submenu: ['Resources'],
 		shortDescription: 'Amount of currently available Health.',
 		newValue: APLValueCurrentHealth.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources')],
 	}),
-	'currentHealthPercent': inputBuilder({
+	currentHealthPercent: inputBuilder({
 		label: 'Health (%)',
 		submenu: ['Resources'],
 		shortDescription: 'Amount of currently available Health, as a percentage.',
 		newValue: APLValueCurrentHealthPercent.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources')],
 	}),
-	'currentMana': inputBuilder({
+	currentMana: inputBuilder({
 		label: 'Mana',
 		submenu: ['Resources'],
 		shortDescription: 'Amount of currently available Mana.',
 		newValue: APLValueCurrentMana.create,
 		fields: [],
 	}),
-	'currentManaPercent': inputBuilder({
+	currentManaPercent: inputBuilder({
 		label: 'Mana (%)',
 		submenu: ['Resources'],
 		shortDescription: 'Amount of currently available Mana, as a percentage.',
 		newValue: APLValueCurrentManaPercent.create,
 		fields: [],
 	}),
-	'currentRage': inputBuilder({
+	currentRage: inputBuilder({
 		label: 'Rage',
 		submenu: ['Resources'],
 		shortDescription: 'Amount of currently available Rage.',
 		newValue: APLValueCurrentRage.create,
 		fields: [],
 	}),
-	'currentEnergy': inputBuilder({
+	currentEnergy: inputBuilder({
 		label: 'Energy',
 		submenu: ['Resources'],
 		shortDescription: 'Amount of currently available Energy.',
 		newValue: APLValueCurrentEnergy.create,
 		fields: [],
 	}),
-	'currentComboPoints': inputBuilder({
+	currentComboPoints: inputBuilder({
 		label: 'Combo Points',
 		submenu: ['Resources'],
 		shortDescription: 'Amount of currently available Combo Points.',
@@ -639,14 +633,14 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 	}),
 
 	// GCD
-	'gcdIsReady': inputBuilder({
+	gcdIsReady: inputBuilder({
 		label: 'GCD Is Ready',
 		submenu: ['GCD'],
 		shortDescription: '<b>True</b> if the GCD is not on cooldown, otherwise <b>False</b>.',
 		newValue: APLValueGCDIsReady.create,
 		fields: [],
 	}),
-	'gcdTimeToReady': inputBuilder({
+	gcdTimeToReady: inputBuilder({
 		label: 'GCD Time To Ready',
 		submenu: ['GCD'],
 		shortDescription: 'Amount of time remaining before the GCD comes off cooldown, or <b>0</b> if it is not on cooldown.',
@@ -655,36 +649,30 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 	}),
 
 	// Auto attacks
-	'autoTimeToNext': inputBuilder({
+	autoTimeToNext: inputBuilder({
 		label: 'Time To Next Auto',
 		submenu: ['Auto'],
 		shortDescription: 'Amount of time remaining before the next Main-hand or Off-hand melee attack, or <b>0</b> if autoattacks are not engaged.',
 		newValue: APLValueAutoTimeToNext.create,
-		fields: [
-			autoTypeFieldConfig('autoType')
-		],
+		fields: [autoTypeFieldConfig('autoType')],
 	}),
-	'autoSwingTime': inputBuilder({
+	autoSwingTime: inputBuilder({
 		label: 'Auto Swing Time',
 		submenu: ['Auto'],
 		shortDescription: 'Total swing duration including all haste buffs.',
 		newValue: APLValueAutoSwingTime.create,
-		fields: [
-			autoSwingTypeFieldConfig('autoType')
-		],
+		fields: [autoSwingTypeFieldConfig('autoType')],
 	}),
 
 	// Spells
-	'spellCurrentCost': inputBuilder({
+	spellCurrentCost: inputBuilder({
 		label: 'Current Cost',
 		submenu: ['Spell'],
 		shortDescription: 'Returns current resource cost of spell',
 		newValue: APLValueSpellCurrentCost.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
 	}),
-	'spellCanCast': inputBuilder({
+	spellCanCast: inputBuilder({
 		label: 'Can Cast',
 		submenu: ['Spell'],
 		shortDescription: '<b>True</b> if all requirements for casting the spell are currently met, otherwise <b>False</b>.',
@@ -692,144 +680,111 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 			<p>The <b>Cast Spell</b> action does not need to be conditioned on this, because it applies this check automatically.</p>
 		`,
 		newValue: APLValueSpellCanCast.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
 	}),
-	'spellIsReady': inputBuilder({
+	spellIsReady: inputBuilder({
 		label: 'Is Ready',
 		submenu: ['Spell'],
 		shortDescription: '<b>True</b> if the spell is not on cooldown, otherwise <b>False</b>.',
 		newValue: APLValueSpellIsReady.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
 	}),
-	'spellTimeToReady': inputBuilder({
+	spellTimeToReady: inputBuilder({
 		label: 'Time To Ready',
 		submenu: ['Spell'],
 		shortDescription: 'Amount of time remaining before the spell comes off cooldown, or <b>0</b> if it is not on cooldown.',
 		newValue: APLValueSpellTimeToReady.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
 	}),
-	'spellCastTime': inputBuilder({
+	spellCastTime: inputBuilder({
 		label: 'Cast Time',
 		submenu: ['Spell'],
 		shortDescription: 'Amount of time to cast the spell including any haste and spell cast time adjustments.',
 		newValue: APLValueSpellCastTime.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
 	}),
-	'spellTravelTime': inputBuilder({
+	spellTravelTime: inputBuilder({
 		label: 'Travel Time',
 		submenu: ['Spell'],
 		shortDescription: 'Amount of time for the spell to travel to the target.',
 		newValue: APLValueSpellTravelTime.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
 	}),
-	'spellCpm': inputBuilder({
+	spellCpm: inputBuilder({
 		label: 'CPM',
 		submenu: ['Spell'],
 		shortDescription: 'Casts Per Minute for the spell so far in the current iteration.',
 		newValue: APLValueSpellCPM.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
 	}),
-	'spellIsChanneling': inputBuilder({
+	spellIsChanneling: inputBuilder({
 		label: 'Is Channeling',
 		submenu: ['Spell'],
 		shortDescription: '<b>True</b> if this spell is currently being channeled, otherwise <b>False</b>.',
 		newValue: APLValueSpellIsChanneling.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'channel_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'channel_spells', '')],
 	}),
-	'spellChanneledTicks': inputBuilder({
+	spellChanneledTicks: inputBuilder({
 		label: 'Channeled Ticks',
 		submenu: ['Spell'],
 		shortDescription: 'The number of completed ticks in the current channel of this spell, or <b>0</b> if the spell is not being channeled.',
 		newValue: APLValueSpellChanneledTicks.create,
-		fields: [
-			AplHelpers.actionIdFieldConfig('spellId', 'channel_spells', ''),
-		],
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'channel_spells', '')],
 	}),
-	'channelClipDelay': inputBuilder({
+	channelClipDelay: inputBuilder({
 		label: 'Channel Clip Delay',
 		submenu: ['Spell'],
 		shortDescription: 'The amount of time specified by the <b>Channel Clip Delay</b> setting.',
 		newValue: APLValueChannelClipDelay.create,
-		fields: [
-		],
+		fields: [],
 	}),
 
 	// Auras
-	'auraIsActive': inputBuilder({
+	auraIsActive: inputBuilder({
 		label: 'Aura Active',
 		submenu: ['Aura'],
 		shortDescription: '<b>True</b> if the aura is currently active, otherwise <b>False</b>.',
 		newValue: APLValueAuraIsActive.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-			AplHelpers.actionIdFieldConfig('auraId', 'auras', 'sourceUnit'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'), AplHelpers.actionIdFieldConfig('auraId', 'auras', 'sourceUnit')],
 	}),
-	'auraIsActiveWithReactionTime': inputBuilder({
+	auraIsActiveWithReactionTime: inputBuilder({
 		label: 'Aura Active (with Reaction Time)',
 		submenu: ['Aura'],
-		shortDescription: '<b>True</b> if the aura is currently active AND it has been active for at least as long as the player reaction time (configured in Settings), otherwise <b>False</b>.',
+		shortDescription:
+			'<b>True</b> if the aura is currently active AND it has been active for at least as long as the player reaction time (configured in Settings), otherwise <b>False</b>.',
 		newValue: APLValueAuraIsActiveWithReactionTime.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-			AplHelpers.actionIdFieldConfig('auraId', 'auras', 'sourceUnit'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'), AplHelpers.actionIdFieldConfig('auraId', 'auras', 'sourceUnit')],
 	}),
-	'auraRemainingTime': inputBuilder({
+	auraRemainingTime: inputBuilder({
 		label: 'Aura Remaining Time',
 		submenu: ['Aura'],
 		shortDescription: 'Time remaining before this aura will expire, or 0 if the aura is not currently active.',
 		newValue: APLValueAuraRemainingTime.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-			AplHelpers.actionIdFieldConfig('auraId', 'auras', 'sourceUnit'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'), AplHelpers.actionIdFieldConfig('auraId', 'auras', 'sourceUnit')],
 	}),
-	'auraNumStacks': inputBuilder({
+	auraNumStacks: inputBuilder({
 		label: 'Aura Num Stacks',
 		submenu: ['Aura'],
 		shortDescription: 'Number of stacks of the aura.',
 		newValue: APLValueAuraNumStacks.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-			AplHelpers.actionIdFieldConfig('auraId', 'stackable_auras', 'sourceUnit'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'), AplHelpers.actionIdFieldConfig('auraId', 'stackable_auras', 'sourceUnit')],
 	}),
-	'auraInternalCooldown': inputBuilder({
+	auraInternalCooldown: inputBuilder({
 		label: 'Aura Remaining ICD',
 		submenu: ['Aura'],
-		shortDescription: 'Time remaining before this aura\'s internal cooldown will be ready, or <b>0</b> if the ICD is ready now.',
+		shortDescription: "Time remaining before this aura's internal cooldown will be ready, or <b>0</b> if the ICD is ready now.",
 		newValue: APLValueAuraInternalCooldown.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-			AplHelpers.actionIdFieldConfig('auraId', 'icd_auras', 'sourceUnit'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'), AplHelpers.actionIdFieldConfig('auraId', 'icd_auras', 'sourceUnit')],
 	}),
-	'auraIcdIsReadyWithReactionTime': inputBuilder({
+	auraIcdIsReadyWithReactionTime: inputBuilder({
 		label: 'Aura ICD Is Ready (with Reaction Time)',
 		submenu: ['Aura'],
-		shortDescription: '<b>True</b> if the aura\'s ICD is currently ready OR it was put on CD recently, within the player\'s reaction time (configured in Settings), otherwise <b>False</b>.',
+		shortDescription:
+			"<b>True</b> if the aura's ICD is currently ready OR it was put on CD recently, within the player's reaction time (configured in Settings), otherwise <b>False</b>.",
 		newValue: APLValueAuraICDIsReadyWithReactionTime.create,
-		fields: [
-			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'),
-			AplHelpers.actionIdFieldConfig('auraId', 'icd_auras', 'sourceUnit'),
-		],
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'), AplHelpers.actionIdFieldConfig('auraId', 'icd_auras', 'sourceUnit')],
 	}),
-	'auraShouldRefresh': inputBuilder({
+	auraShouldRefresh: inputBuilder({
 		label: 'Should Refresh Aura',
 		submenu: ['Aura'],
 		shortDescription: 'Whether this aura should be refreshed, e.g. for the purpose of maintaining a debuff.',
@@ -837,16 +792,17 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 		<p>This condition checks not only the specified aura but also any other auras on the same unit, including auras applied by other raid members, which apply the same debuff category.</p>
 		<p>For example, 'Should Refresh Debuff(Sunder Armor)' will return <b>False</b> if the unit has an active Expose Armor aura.</p>
 		`,
-		newValue: () => APLValueAuraShouldRefresh.create({
-			maxOverlap: {
-				value: {
-					oneofKind: 'const',
-					const: {
-						val: '0ms',
+		newValue: () =>
+			APLValueAuraShouldRefresh.create({
+				maxOverlap: {
+					value: {
+						oneofKind: 'const',
+						const: {
+							val: '0ms',
+						},
 					},
 				},
-			},
-		}),
+			}),
 		fields: [
 			AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources_targets_first'),
 			AplHelpers.actionIdFieldConfig('auraId', 'exclusive_effect_auras', 'sourceUnit', 'currentTarget'),
@@ -858,109 +814,89 @@ const valueKindFactories: {[f in NonNullable<APLValueKind>]: ValueKindConfig<APL
 	}),
 
 	// DoT
-	'dotIsActive': inputBuilder({
+	dotIsActive: inputBuilder({
 		label: 'Dot Is Active',
 		submenu: ['DoT'],
 		shortDescription: '<b>True</b> if the specified dot is currently ticking, otherwise <b>False</b>.',
 		newValue: APLValueDotIsActive.create,
-		fields: [
-			AplHelpers.unitFieldConfig('targetUnit', 'targets'),
-			AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', ''),
-		],
+		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets'), AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', '')],
 	}),
-	'dotRemainingTime': inputBuilder({
+	dotRemainingTime: inputBuilder({
 		label: 'Dot Remaining Time',
 		submenu: ['DoT'],
 		shortDescription: 'Time remaining before the last tick of this DoT will occur, or 0 if the DoT is not currently ticking.',
 		newValue: APLValueDotRemainingTime.create,
-		fields: [
-			AplHelpers.unitFieldConfig('targetUnit', 'targets'),
-			AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', ''),
-		],
+		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets'), AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', '')],
 	}),
-	'sequenceIsComplete': inputBuilder({
+	sequenceIsComplete: inputBuilder({
 		label: 'Sequence Is Complete',
 		submenu: ['Sequence'],
 		shortDescription: '<b>True</b> if there are no more subactions left to execute in the sequence, otherwise <b>False</b>.',
 		newValue: APLValueSequenceIsComplete.create,
-		fields: [
-			AplHelpers.stringFieldConfig('sequenceName'),
-		],
+		fields: [AplHelpers.stringFieldConfig('sequenceName')],
 	}),
-	'sequenceIsReady': inputBuilder({
+	sequenceIsReady: inputBuilder({
 		label: 'Sequence Is Ready',
 		submenu: ['Sequence'],
 		shortDescription: '<b>True</b> if the next subaction in the sequence is ready to be executed, otherwise <b>False</b>.',
 		newValue: APLValueSequenceIsReady.create,
-		fields: [
-			AplHelpers.stringFieldConfig('sequenceName'),
-		],
+		fields: [AplHelpers.stringFieldConfig('sequenceName')],
 	}),
-	'sequenceTimeToReady': inputBuilder({
+	sequenceTimeToReady: inputBuilder({
 		label: 'Sequence Time To Ready',
 		submenu: ['Sequence'],
 		shortDescription: 'Returns the amount of time remaining until the next subaction in the sequence will be ready.',
 		newValue: APLValueSequenceTimeToReady.create,
-		fields: [
-			AplHelpers.stringFieldConfig('sequenceName'),
-		],
+		fields: [AplHelpers.stringFieldConfig('sequenceName')],
 	}),
 
 	// Class/spec specific values
-	'totemRemainingTime': inputBuilder({
+	totemRemainingTime: inputBuilder({
 		label: 'Totem Remaining Time',
 		submenu: ['Shaman'],
 		shortDescription: 'Returns the amount of time remaining until the totem will expire.',
 		newValue: APLValueTotemRemainingTime.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassShaman,
-		fields: [
-			totemTypeFieldConfig('totemType'),
-		],
+		fields: [totemTypeFieldConfig('totemType')],
 	}),
-	'catExcessEnergy': inputBuilder({
+	catExcessEnergy: inputBuilder({
 		label: 'Excess Energy',
 		submenu: ['Feral Druid'],
 		shortDescription: 'Returns the amount of excess energy available, after subtracting energy that will be needed to maintain DoTs.',
 		newValue: APLValueCatExcessEnergy.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.spec == Spec.SpecFeralDruid,
-		fields: [
-		],
+		fields: [],
 	}),
-	'catNewSavageRoarDuration': inputBuilder({
+	catNewSavageRoarDuration: inputBuilder({
 		label: 'New Savage Roar Duration',
 		submenu: ['Feral Druid'],
 		shortDescription: 'Returns duration of savage roar based on current combo points',
 		newValue: APLValueCatNewSavageRoarDuration.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.spec == Spec.SpecFeralDruid,
-		fields: [
-		],
+		fields: [],
 	}),
-	'warlockShouldRecastDrainSoul': inputBuilder({
+	warlockShouldRecastDrainSoul: inputBuilder({
 		label: 'Should Recast Drain Soul',
 		submenu: ['Warlock'],
 		shortDescription: 'Returns <b>True</b> if the current Drain Soul channel should be immediately recast, to get a better snapshot.',
 		newValue: APLValueWarlockShouldRecastDrainSoul.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
-		fields: [
-		],
+		fields: [],
 	}),
-	'warlockShouldRefreshCorruption': inputBuilder({
+	warlockShouldRefreshCorruption: inputBuilder({
 		label: 'Should Refresh Corruption',
 		submenu: ['Warlock'],
 		shortDescription: 'Returns <b>True</b> if the current Corruption has expired, or should be refreshed to get a better snapshot.',
 		newValue: APLValueWarlockShouldRefreshCorruption.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
-		fields: [
-			AplHelpers.unitFieldConfig('targetUnit', 'targets'),
-		],
+		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets')],
 	}),
-	'currentSealRemainingTime': inputBuilder({
+	currentSealRemainingTime: inputBuilder({
 		label: 'Current Seal Remaining Time',
 		submenu: ['Paladin'],
-		shortDescription: 'Returns the amount of time remaining until the Paladin\'s current Seal aura will expire.',
+		shortDescription: "Returns the amount of time remaining until the Paladin's current Seal aura will expire.",
 		newValue: APLValueCurrentSealRemainingTime.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassPaladin,
-		fields: [
-		]
+		fields: [],
 	}),
 };

--- a/ui/index_template.html
+++ b/ui/index_template.html
@@ -1,41 +1,46 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
+	<head>
+		<title>@@TITLE@@</title>
+		<meta charset="utf-8" />
 
-<head>
-  <title>@@TITLE@@</title>
-  <meta charset="utf-8">
+		<link rel="icon" href="/sod/assets/favicon_io/favicon.ico" type="image/x-icon" />
 
-  <link rel="icon" href="/sod/assets/favicon_io/favicon.ico" type="image/x-icon">
+		<meta name="description" content="Simulations for World of Warcraft® Classic Season of Discovery." />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <meta name="description" content="Simulations for World of Warcraft® Classic Season of Discovery.">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="preload" href="/sod/assets/database/db.json" as="fetch" crossorigin="anonymous" />
+		<link rel="stylesheet" href="../scss/core/individual_sim_ui/index.scss" />
+		<link rel="stylesheet" href="../scss/sims/@@SPEC@@/index.scss" />
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
+			integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer" />
 
-  <link rel="preload" href="/sod/assets/database/db.json" as="fetch" crossOrigin="anonymous">
-  <link rel="stylesheet" href="../scss/core/individual_sim_ui/index.scss" />
-  <link rel="stylesheet" href="../scss/sims/@@SPEC@@/index.scss">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"
-    integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg=="
-    crossorigin="anonymous" referrerpolicy="no-referrer" />
+		<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+		<script
+			src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"
+			integrity="sha512-qzgd5cYSZcosqpzpn7zF2ZId8f/8CHmFKZ8j7mU4OUXTNRd5g+ZHBPsgKEwoqxCtdQvExE5LprwwPAgoicguNg=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"></script>
+		<script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+		<script src="../index.ts" type="module"></script>
+		<script src="./index.ts" type="module"></script>
+		<script
+			src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.5.1/chart.min.js"
+			integrity="sha512-Wt1bJGtlnMtGP0dqNFH1xlkLBNpEodaiQ8ZN5JLA5wpc1sUlk/O5uuOMNgvzddzkpvZ9GLyYNa8w2s7rqiTk5Q=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer"></script>
+	</head>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.3/js/jquery.tablesorter.min.js"
-    integrity="sha512-qzgd5cYSZcosqpzpn7zF2ZId8f/8CHmFKZ8j7mU4OUXTNRd5g+ZHBPsgKEwoqxCtdQvExE5LprwwPAgoicguNg=="
-    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
-  <script src="../index.ts" type="module"></script>
-  <script src="./index.ts" type="module"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.5.1/chart.min.js"
-    integrity="sha512-Wt1bJGtlnMtGP0dqNFH1xlkLBNpEodaiQ8ZN5JLA5wpc1sUlk/O5uuOMNgvzddzkpvZ9GLyYNa8w2s7rqiTk5Q=="
-    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.4/pako.min.js" type="module"></script>
-</head>
-
-<body id="bootstrap-overrides">
-</body>
-<!-- Load wowhead scripts after done loading everything else -->
-<script>const whTooltips = { colorLinks: true };</script>
-<script src="https://wow.zamimg.com/js/tooltips.js"></script>
-<!--<script>const aowow_tooltips = {colorlinks: true}</script>
+	<body id="bootstrap-overrides"></body>
+	<!-- Load wowhead scripts after done loading everything else -->
+	<script>
+		const whTooltips = { colorLinks: true };
+	</script>
+	<script src="https://wow.zamimg.com/js/tooltips.js"></script>
+	<!--<script>const aowow_tooltips = {colorlinks: true}</script>
 	<script type="text/javascript" src="https://wotlk.evowow.com/static/widgets/power.js"></script>-->
-
 </html>


### PR DESCRIPTION
https://github.com/wowsims/sod/pull/394 upgraded the `protobuf-ts` from 2.9.1 to 2.9.4 which introduced a breaking error when switching rotations.

![image](https://github.com/wowsims/sod/assets/12898988/9aeed26e-1b08-46e1-a2b7-560bdc69cafc)

This issue originally was originally reported and tracked in https://github.com/timostamm/protobuf-ts/issues/616. A backwards-compatibility issue was mentioned but not resolved at the time.