### PR TITLE
Various cleanups & fixes

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -175,7 +175,7 @@ func applyDebuffEffects(target *Unit, targetIdx int, debuffs *proto.Debuffs, rai
 
 	// Atk spd reduction
 	if debuffs.ThunderClap != proto.TristateEffect_TristateEffectMissing {
-		MakePermanent(ThunderClapAura(target, GetTristateValueInt32(debuffs.ThunderClap, 0, 3), level))
+		MakePermanent(ThunderClapAura(target, 8205, time.Second*22, GetTristateValueInt32(debuffs.ThunderClap, 10, 16)))
 	}
 
 	// Miss
@@ -913,14 +913,13 @@ func apReductionEffect(aura *Aura, apReduction float64) *ExclusiveEffect {
 	})
 }
 
-// TODO: Classic
-func ThunderClapAura(target *Unit, points int32, playerLevel int32) *Aura {
+func ThunderClapAura(target *Unit, spellID int32, duration time.Duration, atkSpeedReductionPercent int32) *Aura {
 	aura := target.GetOrRegisterAura(Aura{
-		Label:    "ThunderClap-" + strconv.Itoa(int(points)),
-		ActionID: ActionID{SpellID: 47502},
-		Duration: time.Second * 30,
+		Label:    "ThunderClap-" + strconv.Itoa(int(atkSpeedReductionPercent)),
+		ActionID: ActionID{SpellID: spellID},
+		Duration: duration,
 	})
-	AtkSpeedReductionEffect(aura, []float64{1.1, 1.14, 1.17, 1.2}[points])
+	AtkSpeedReductionEffect(aura, 1+0.01*float64(atkSpeedReductionPercent))
 	return aura
 }
 

--- a/sim/core/racials.go
+++ b/sim/core/racials.go
@@ -13,12 +13,8 @@ func applyRaceEffects(agent Agent) {
 
 	switch character.Race {
 	case proto.Race_RaceDwarf:
-		character.PseudoStats.ReducedFrostHitTakenChance += 0.02
-
-		// Gun specialization (+1% ranged crit when using a gun).
-		if character.Ranged().RangedWeaponType == proto.RangedWeaponType_RangedWeaponTypeGun {
-			character.AddBonusRangedCritRating(1 * CritRatingPerCritChance)
-		}
+		character.AddStat(stats.FrostResistance, 10)
+		character.PseudoStats.GunsSkill += 5
 
 		actionID := ActionID{SpellID: 20594}
 
@@ -38,7 +34,7 @@ func applyRaceEffects(agent Agent) {
 			Cast: CastConfig{
 				CD: Cooldown{
 					Timer:    character.NewTimer(),
-					Duration: time.Minute * 2,
+					Duration: time.Minute * 3,
 				},
 			},
 			ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {
@@ -51,17 +47,17 @@ func applyRaceEffects(agent Agent) {
 			Type:  CooldownTypeSurvival,
 		})
 	case proto.Race_RaceGnome:
-		character.PseudoStats.ReducedArcaneHitTakenChance += 0.02
+		character.AddStat(stats.ArcaneResistance, 10)
 		character.MultiplyStat(stats.Intellect, 1.05)
 	case proto.Race_RaceHuman:
-		character.MultiplyStat(stats.Spirit, 1.03)
+		character.MultiplyStat(stats.Spirit, 1.05)
 		character.PseudoStats.MacesSkill += 5
 		character.PseudoStats.TwoHandedMacesSkill += 5
 		character.PseudoStats.SwordsSkill += 5
 		character.PseudoStats.TwoHandedSwordsSkill += 5
 	case proto.Race_RaceNightElf:
-		character.PseudoStats.ReducedNatureHitTakenChance += 0.02
-		character.PseudoStats.ReducedPhysicalHitTakenChance += 0.02
+		character.AddStat(stats.NatureResistance, 10)
+		character.AddStat(stats.Dodge, DodgeRatingPerDodgeChance*1)
 		// TODO: Shadowmeld?
 	case proto.Race_RaceOrc:
 		// Command (Pet damage +5%)
@@ -113,13 +109,11 @@ func applyRaceEffects(agent Agent) {
 		character.PseudoStats.AxesSkill += 5
 		character.PseudoStats.TwoHandedAxesSkill += 5
 	case proto.Race_RaceTauren:
-		character.PseudoStats.ReducedNatureHitTakenChance += 0.02
-		character.AddStat(stats.Health, character.GetBaseStats()[stats.Health]*0.05)
+		character.AddStat(stats.NatureResistance, 10)
+		character.MultiplyStat(stats.Health, 1.05)
 	case proto.Race_RaceTroll:
-		// Bow specialization (+1% ranged crit when using a bow).
-		if character.Ranged().RangedWeaponType == proto.RangedWeaponType_RangedWeaponTypeBow {
-			character.AddBonusRangedCritRating(1 * CritRatingPerCritChance)
-		}
+		character.PseudoStats.BowsSkill += 5
+		character.PseudoStats.ThrownSkill += 5
 
 		// Beast Slaying (+5% damage to beasts)
 		character.Env.RegisterPostFinalizeEffect(func() {
@@ -143,7 +137,7 @@ func applyRaceEffects(agent Agent) {
 		makeBerserkingCooldown(character, .25, berserkingTimer)
 		makeBerserkingCooldown(character, .3, berserkingTimer)
 	case proto.Race_RaceUndead:
-		character.PseudoStats.ReducedShadowHitTakenChance += 0.02
+		character.AddStat(stats.ShadowResistance, 10)
 	}
 }
 

--- a/sim/core/spell_outcome.go
+++ b/sim/core/spell_outcome.go
@@ -513,7 +513,7 @@ func (result *SpellResult) applyAttackTableHit(spell *Spell) {
 }
 
 func (result *SpellResult) applyEnemyAttackTableMiss(spell *Spell, attackTable *AttackTable, roll float64, chance *float64) bool {
-	missChance := attackTable.BaseMissChance + spell.Unit.PseudoStats.IncreasedMissChance + result.Target.GetDiminishedMissChance() + result.Target.PseudoStats.ReducedPhysicalHitTakenChance
+	missChance := attackTable.BaseMissChance + spell.Unit.PseudoStats.IncreasedMissChance + result.Target.GetDiminishedMissChance()
 	if spell.Unit.AutoAttacks.IsDualWielding && !spell.Unit.PseudoStats.DisableDWMissPenalty {
 		missChance += 0.19
 	}

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -483,13 +483,6 @@ type PseudoStats struct {
 
 	ArmorMultiplier float64 // Major/minor/special multiplicative armor modifiers
 
-	ReducedPhysicalHitTakenChance float64
-	ReducedArcaneHitTakenChance   float64
-	ReducedFireHitTakenChance     float64
-	ReducedFrostHitTakenChance    float64
-	ReducedNatureHitTakenChance   float64
-	ReducedShadowHitTakenChance   float64
-
 	HealingTakenMultiplier float64
 }
 

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -35,11 +35,11 @@ character_stats_results: {
   final_stats: 11.23108
   final_stats: 0
   final_stats: 0
-  final_stats: 1607
+  final_stats: 1670.655
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 0
+  final_stats: 10
   final_stats: 15
   final_stats: 21
   final_stats: 22
@@ -84,11 +84,11 @@ character_stats_results: {
   final_stats: 16.43417
   final_stats: 0
   final_stats: 0
-  final_stats: 3357.55
+  final_stats: 3489.57
   final_stats: 18.5
   final_stats: 23.5
   final_stats: 73.5
-  final_stats: 18.5
+  final_stats: 28.5
   final_stats: 23.5
   final_stats: 160
   final_stats: 0

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -35,11 +35,11 @@ character_stats_results: {
   final_stats: 38.83287
   final_stats: 0
   final_stats: 0
-  final_stats: 1805
+  final_stats: 1878.555
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 0
+  final_stats: 10
   final_stats: 10
   final_stats: 130
   final_stats: 0
@@ -84,11 +84,11 @@ character_stats_results: {
   final_stats: 58.94728
   final_stats: 0
   final_stats: 0
-  final_stats: 3797.55
+  final_stats: 3951.57
   final_stats: 18.5
   final_stats: 13.5
   final_stats: 83.5
-  final_stats: 18.5
+  final_stats: 28.5
   final_stats: 23.5
   final_stats: 100
   final_stats: 0

--- a/sim/druid/hurricane.go
+++ b/sim/druid/hurricane.go
@@ -88,14 +88,13 @@ func (druid *Druid) newHurricaneTickSpellConfig(rank int) core.SpellConfig {
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskProc,
 
-		CritMultiplier:   1,
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			damage := baseDamage + spellCoef*spell.SpellDamage()
 			for _, aoeTarget := range sim.Encounter.TargetUnits {
-				spell.CalcAndDealDamage(sim, aoeTarget, damage, spell.OutcomeMagicHitAndCrit)
+				spell.CalcAndDealDamage(sim, aoeTarget, damage, spell.OutcomeMagicHit)
 				// TODO: Apply attack speed reduction
 			}
 		},

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestMM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.83561
+  weights: 0.82573
   weights: 0
   weights: 0
   weights: 0
@@ -166,8 +166,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.35477
-  weights: 7.58201
+  weights: 5.36528
+  weights: 7.38854
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +175,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.24764
+  weights: 0.24394
   weights: 0
   weights: 0
   weights: 0
@@ -393,196 +393,196 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 545.95669
-  tps: 418.57583
+  dps: 536.52124
+  tps: 409.07529
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 547.70282
-  tps: 422.0814
+  dps: 538.42647
+  tps: 412.74077
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 559.08627
-  tps: 429.79295
+  dps: 549.39921
+  tps: 420.03958
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BloodlashBow-216516"
  value: {
-  dps: 577.45656
-  tps: 444.34103
+  dps: 568.98302
+  tps: 435.80078
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 574.4475
-  tps: 442.27983
+  dps: 564.63043
+  tps: 432.39947
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 559.81056
-  tps: 433.36135
+  dps: 550.54067
+  tps: 424.03107
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 536.07617
-  tps: 408.02366
+  dps: 526.80322
+  tps: 398.69032
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 564.05166
-  tps: 437.86833
+  dps: 554.80716
+  tps: 428.56316
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 567.70103
-  tps: 437.41172
+  dps: 558.08508
+  tps: 427.72972
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 554.47317
-  tps: 428.94842
+  dps: 545.33099
+  tps: 419.74557
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 566.50157
-  tps: 439.25638
+  dps: 557.20075
+  tps: 429.89549
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 617.29056
-  tps: 485.49597
+  dps: 607.80816
+  tps: 475.94866
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 441.19411
-  tps: 306.75153
+  dps: 432.58554
+  tps: 298.14297
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 541.74085
-  tps: 416.82792
+  dps: 532.51707
+  tps: 407.54019
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Average-Default"
  value: {
-  dps: 625.75578
-  tps: 493.81936
+  dps: 616.22713
+  tps: 484.21887
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 712.74238
-  tps: 890.67049
+  dps: 699.51268
+  tps: 877.7425
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 624.55659
-  tps: 499.63084
+  dps: 609.62231
+  tps: 484.58316
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 658.97856
-  tps: 537.34261
+  dps: 644.82772
+  tps: 523.23539
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 407.02848
-  tps: 667.32811
+  dps: 399.87022
+  tps: 660.12535
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 350.65621
-  tps: 302.52457
+  dps: 343.16517
+  tps: 295.02718
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 386.05725
-  tps: 332.01874
+  dps: 375.83918
+  tps: 321.58043
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 713.86358
-  tps: 890.52387
+  dps: 704.53562
+  tps: 881.12944
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 625.3742
-  tps: 493.54096
+  dps: 615.69669
+  tps: 483.79787
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 660.5579
-  tps: 531.2329
+  dps: 650.51177
+  tps: 520.85888
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 408.18932
-  tps: 650.37765
+  dps: 402.88448
+  tps: 645.03248
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 350.246
-  tps: 297.93634
+  dps: 344.92999
+  tps: 292.57234
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 383.853
-  tps: 326.43251
+  dps: 376.69604
+  tps: 319.03562
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 626.80742
-  tps: 494.61343
+  dps: 617.36214
+  tps: 485.10334
  }
 }

--- a/sim/hunter/aimed_shot.go
+++ b/sim/hunter/aimed_shot.go
@@ -55,9 +55,6 @@ func (hunter *Hunter) getAimedShotConfig(rank int, timer *core.Timer) core.Spell
 			return hunter.DistanceFromTarget >= 8
 		},
 
-		BonusCritRating: 0,
-		DamageMultiplierAdditive: 1 +
-			.05*float64(hunter.Talents.Barrage),
 		DamageMultiplier: 1,
 		CritMultiplier:   hunter.critMultiplier(true, hunter.CurrentTarget),
 		ThreatMultiplier: 1,

--- a/sim/hunter/carve.go
+++ b/sim/hunter/carve.go
@@ -26,7 +26,7 @@ func (hunter *Hunter) registerCarveSpell() {
 			Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | core.SpellFlagNoOnCastComplete,
 
 			DamageMultiplier: core.TernaryFloat64(hasDwRune, 1.5, 1) * 0.65,
-			CritMultiplier:   hunter.critMultiplier(true, hunter.CurrentTarget),
+			CritMultiplier:   hunter.critMultiplier(false, hunter.CurrentTarget),
 		})
 	}
 
@@ -54,7 +54,7 @@ func (hunter *Hunter) registerCarveSpell() {
 		},
 
 		DamageMultiplier: 0.65,
-		CritMultiplier:   hunter.critMultiplier(true, hunter.CurrentTarget),
+		CritMultiplier:   hunter.critMultiplier(false, hunter.CurrentTarget),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/hunter/explosive_trap.go
+++ b/sim/hunter/explosive_trap.go
@@ -42,7 +42,7 @@ func (hunter *Hunter) getExplosiveTrapConfig(rank int, timer *core.Timer) core.S
 		},
 
 		DamageMultiplierAdditive: 1 + 0.15*float64(hunter.Talents.CleverTraps),
-		CritMultiplier:           hunter.critMultiplier(true, hunter.CurrentTarget),
+		CritMultiplier:           hunter.critMultiplier(false, hunter.CurrentTarget),
 		ThreatMultiplier:         1,
 
 		Dot: core.DotConfig{

--- a/sim/hunter/immolation_trap.go
+++ b/sim/hunter/immolation_trap.go
@@ -38,7 +38,7 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 		},
 
 		DamageMultiplierAdditive: 1 + 0.15*float64(hunter.Talents.CleverTraps),
-		CritMultiplier:           hunter.critMultiplier(true, hunter.CurrentTarget),
+		CritMultiplier:           hunter.critMultiplier(false, hunter.CurrentTarget),
 		ThreatMultiplier:         1,
 
 		Dot: core.DotConfig{

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -46,7 +46,7 @@ func (hunter *Hunter) getRaptorStrikeConfig(rank int) core.SpellConfig {
 
 			BonusCritRating:  float64(hunter.Talents.SavageStrikes) * 10 * core.CritRatingPerCritChance,
 			DamageMultiplier: 1.5 * dwSpecMulti,
-			CritMultiplier:   hunter.critMultiplier(true, hunter.CurrentTarget),
+			CritMultiplier:   hunter.critMultiplier(false, hunter.CurrentTarget),
 		})
 	}
 

--- a/sim/hunter/serpent_sting.go
+++ b/sim/hunter/serpent_sting.go
@@ -41,7 +41,6 @@ func (hunter *Hunter) getSerpentStingConfig(rank int) core.SpellConfig {
 		},
 
 		DamageMultiplierAdditive: 1 + 0.02*float64(hunter.Talents.ImprovedSerpentSting),
-		CritMultiplier:           hunter.critMultiplier(true, hunter.CurrentTarget),
 		ThreatMultiplier:         1,
 
 		Dot: core.DotConfig{
@@ -56,7 +55,6 @@ func (hunter *Hunter) getSerpentStingConfig(rank int) core.SpellConfig {
 				dot.SnapshotBaseDamage = baseDamage + spellCoeff*dot.Spell.SpellDamage()
 				if !isRollover {
 					attackTable := dot.Spell.Unit.AttackTables[target.UnitIndex][dot.Spell.CastType]
-					dot.SnapshotCritChance = dot.Spell.PhysicalCritChance(attackTable)
 					dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable)
 				} else {
 					// Serpent Sting double dips on the generic spell power of the hunter when rollovered with Chimera

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.26638
+  weights: 0.26672
   weights: 0
-  weights: 0.56221
+  weights: 0.56067
   weights: 0
-  weights: 0.56221
-  weights: 0
-  weights: 0
+  weights: 0.56067
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.25935
-  weights: 3.43544
+  weights: 0
+  weights: 0
+  weights: 6.25159
+  weights: 3.44709
   weights: 0
   weights: 0
   weights: 0
@@ -323,126 +323,126 @@ dps_results: {
 dps_results: {
  key: "TestFire-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 302.82504
-  tps: 222.31586
+  dps: 301.99691
+  tps: 221.73618
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 315.54012
-  tps: 230.89092
+  dps: 314.64155
+  tps: 230.26193
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 329.89361
-  tps: 241.18994
+  dps: 328.98299
+  tps: 240.55251
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 299.01572
-  tps: 218.6013
+  dps: 298.18244
+  tps: 218.01801
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Average-Default"
  value: {
-  dps: 405.02482
-  tps: 294.12799
+  dps: 403.98488
+  tps: 293.40003
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1372.12277
-  tps: 1153.80533
+  dps: 1371.31039
+  tps: 1153.23667
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 412.9835
-  tps: 299.85446
+  dps: 411.9412
+  tps: 299.12485
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 617.25168
-  tps: 448.76118
+  dps: 613.70259
+  tps: 446.27681
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 911.30026
-  tps: 748.19614
+  dps: 910.76981
+  tps: 747.82483
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 233.40546
-  tps: 169.18562
+  dps: 232.54887
+  tps: 168.58601
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 456.84242
-  tps: 330.17969
+  dps: 453.98711
+  tps: 328.18098
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1341.37245
-  tps: 1131.00168
+  dps: 1340.55907
+  tps: 1130.43231
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 403.99011
-  tps: 293.41737
+  dps: 402.93554
+  tps: 292.67918
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 619.40019
-  tps: 450.17388
+  dps: 615.80151
+  tps: 447.65481
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 891.99373
-  tps: 733.79157
+  dps: 891.43345
+  tps: 733.39938
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 227.98416
-  tps: 165.30071
+  dps: 227.1366
+  tps: 164.70742
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 439.14533
-  tps: 317.56923
+  dps: 436.33346
+  tps: 315.60093
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 403.99011
-  tps: 293.41737
+  dps: 402.93554
+  tps: 292.67918
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.37015
+  weights: -0.36105
   weights: 0
-  weights: 0.76803
+  weights: 0.7661
   weights: 0
-  weights: 0.76803
-  weights: 0
-  weights: 0
+  weights: 0.7661
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.27157
-  weights: 4.86662
+  weights: 0
+  weights: 0
+  weights: 4.29062
+  weights: 4.85128
   weights: 0
   weights: 0
   weights: 0
@@ -99,126 +99,126 @@ stat_weights_results: {
 dps_results: {
  key: "TestFrostFire-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 394.3046
-  tps: 284.49422
+  dps: 393.20372
+  tps: 283.7236
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 431.62254
-  tps: 310.62933
+  dps: 430.42241
+  tps: 309.78924
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 443.38947
-  tps: 319.05843
+  dps: 442.19045
+  tps: 318.21911
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 413.43314
-  tps: 297.86575
+  dps: 412.31919
+  tps: 297.08598
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Average-Default"
  value: {
-  dps: 542.36199
-  tps: 388.89996
+  dps: 540.9194
+  tps: 387.89015
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frostfire-Frostfire-p2_frostfire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1160.4967
-  tps: 995.75719
+  dps: 1159.32824
+  tps: 994.93927
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frostfire-Frostfire-p2_frostfire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 535.78999
-  tps: 384.64375
+  dps: 534.38549
+  tps: 383.66059
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frostfire-Frostfire-p2_frostfire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 579.60524
-  tps: 418.80403
+  dps: 575.82491
+  tps: 416.1578
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frostfire-Frostfire-p2_frostfire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 582.80692
-  tps: 513.14148
+  dps: 581.78867
+  tps: 512.42871
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frostfire-Frostfire-p2_frostfire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 325.76197
-  tps: 233.52523
+  dps: 324.6918
+  tps: 232.7761
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frostfire-Frostfire-p2_frostfire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 429.88406
-  tps: 309.80637
+  dps: 426.80101
+  tps: 307.64824
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frostfire-Frostfire-p2_frostfire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1117.39437
-  tps: 960.6678
+  dps: 1116.26835
+  tps: 959.87958
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frostfire-Frostfire-p2_frostfire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 537.39508
-  tps: 385.50771
+  dps: 535.96402
+  tps: 384.50597
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frostfire-Frostfire-p2_frostfire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 584.19827
-  tps: 421.98929
+  dps: 580.47787
+  tps: 419.38501
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frostfire-Frostfire-p2_frostfire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 575.72743
-  tps: 507.84845
+  dps: 574.78087
+  tps: 507.18586
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frostfire-Frostfire-p2_frostfire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 317.15017
-  tps: 227.45218
+  dps: 316.03389
+  tps: 226.67079
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frostfire-Frostfire-p2_frostfire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 448.31681
-  tps: 322.6718
+  dps: 445.33693
+  tps: 320.58589
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 537.39508
-  tps: 385.50771
+  dps: 535.96402
+  tps: 384.50597
  }
 }

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -403,8 +403,6 @@ func (mage *Mage) registerCombustionCD() {
 		Duration: time.Minute * 3,
 	}
 
-	fireCombCritMult := mage.SpellCritMultiplier(1, 0.1) / mage.SpellCritMultiplier(1, 0)
-
 	var fireSpells []*core.Spell
 	mage.OnSpellRegistered(func(spell *core.Spell) {
 		if spell.SpellSchool.Matches(core.SpellSchoolFire) && spell.Flags.Matches(SpellFlagMage) {
@@ -422,16 +420,10 @@ func (mage *Mage) registerCombustionCD() {
 		MaxStacks: 20,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			numCrits = 0
-			for _, spell := range fireSpells {
-				spell.CritMultiplier *= fireCombCritMult
-			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			cd.Use(sim)
 			mage.UpdateMajorCooldowns()
-			for _, spell := range fireSpells {
-				spell.CritMultiplier /= fireCombCritMult
-			}
 		},
 		OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks int32, newStacks int32) {
 			bonusCrit := critPerStack * float64(newStacks-oldStacks)

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -5,7 +5,7 @@ character_stats_results: {
   final_stats: 111.54
   final_stats: 151.91
   final_stats: 58.74
-  final_stats: 58.2362
+  final_stats: 59.367
   final_stats: 25
   final_stats: 0
   final_stats: 10
@@ -54,7 +54,7 @@ character_stats_results: {
   final_stats: 171.38
   final_stats: 361.24
   final_stats: 89.98
-  final_stats: 99.4774
+  final_stats: 101.409
   final_stats: 42
   final_stats: 0
   final_stats: 10
@@ -198,7 +198,7 @@ dps_results: {
  key: "TestRetribution-Lvl25-Average-Default"
  value: {
   dps: 97.72132
-  tps: 103.99191
+  tps: 103.99131
  }
 }
 dps_results: {
@@ -247,14 +247,14 @@ dps_results: {
  key: "TestRetribution-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
   dps: 176.75848
-  tps: 301.57779
+  tps: 301.56649
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
   dps: 97.71289
-  tps: 103.95386
+  tps: 103.95329
  }
 }
 dps_results: {
@@ -267,15 +267,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 98.36564
-  tps: 204.41133
+  dps: 98.44316
+  tps: 204.41493
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 52.60198
-  tps: 57.90426
+  dps: 52.59829
+  tps: 57.89688
  }
 }
 dps_results: {
@@ -289,21 +289,21 @@ dps_results: {
  key: "TestRetribution-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
   dps: 92.84969
-  tps: 99.09065
+  tps: 99.09009
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-AllItems-DiscardedTenetsoftheSilverHand-209574"
  value: {
   dps: 210.1424
-  tps: 222.78023
+  tps: 222.774
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Average-Default"
  value: {
   dps: 208.90381
-  tps: 221.05769
+  tps: 221.04756
  }
 }
 dps_results: {
@@ -352,48 +352,48 @@ dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 370.03028
-  tps: 619.23058
+  tps: 618.39129
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 209.02564
-  tps: 221.21598
+  tps: 221.2166
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 222.44037
-  tps: 234.52083
+  tps: 234.51665
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 201.74979
-  tps: 368.84124
+  tps: 368.78925
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 108.79075
-  tps: 116.73909
+  dps: 108.89205
+  tps: 116.83847
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 134.42992
-  tps: 145.08563
+  tps: 145.08383
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 198.77643
-  tps: 210.78705
+  tps: 210.78886
  }
 }

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -5,7 +5,7 @@ character_stats_results: {
   final_stats: 180.18
   final_stats: 348.04
   final_stats: 98.978
-  final_stats: 99.4774
+  final_stats: 101.409
   final_stats: 42
   final_stats: 0
   final_stats: 10
@@ -50,12 +50,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestShockadin-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.12164
+  weights: 0.12148
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.15027
+  weights: 0.15017
   weights: 0
   weights: 0
   weights: 0
@@ -63,13 +63,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.58801
-  weights: 0.10074
+  weights: 1.53631
+  weights: 0.11876
   weights: 0
   weights: 0
-  weights: 0.05026
-  weights: 0.72602
-  weights: 0.67175
+  weights: 0.0502
+  weights: 0.54326
+  weights: 1.10238
   weights: 0
   weights: 0
   weights: 0
@@ -99,15 +99,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestShockadin-Lvl40-AllItems-DiscardedTenetsoftheSilverHand-209574"
  value: {
-  dps: 154.66221
-  tps: 169.05062
+  dps: 154.36041
+  tps: 168.72467
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Average-Default"
  value: {
-  dps: 156.63633
-  tps: 171.05679
+  dps: 156.68733
+  tps: 171.10783
  }
 }
 dps_results: {
@@ -155,49 +155,49 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 564.70143
-  tps: 854.16062
+  dps: 565.89431
+  tps: 855.49041
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 155.12581
-  tps: 169.56231
+  dps: 154.72386
+  tps: 169.15345
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 170.36924
-  tps: 186.09243
+  tps: 186.09033
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 285.61735
-  tps: 471.64416
+  dps: 282.51149
+  tps: 468.53794
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 86.72603
-  tps: 96.02737
+  dps: 87.38778
+  tps: 96.6891
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 111.76669
-  tps: 122.55889
+  tps: 122.5588
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 149.8716
-  tps: 164.15429
+  dps: 149.75939
+  tps: 164.03623
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -40,7 +40,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 20
+  final_stats: 30
   final_stats: 21
   final_stats: 0
   final_stats: 0
@@ -89,7 +89,7 @@ character_stats_results: {
   final_stats: 26.5
   final_stats: 76.5
   final_stats: 21.5
-  final_stats: 29.5
+  final_stats: 39.5
   final_stats: 290
   final_stats: 0
   final_stats: 14

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -16,7 +16,7 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 	// 2024-02-22 In-game value is ~66% base damage after tuning
 	baseCalc := (9.456667 + 0.635108*level + 0.039063*level*level) * .66
 	baseLowDamage := baseCalc * 5.32 * priest.darknessDamageModifier()
-	baseHightDamage := baseCalc * 6.2 * priest.darknessDamageModifier()
+	baseHighDamage := baseCalc * 6.2 * priest.darknessDamageModifier()
 	spellCoeff := 0.429
 	manaCost := .12
 	cooldown := time.Second * 12
@@ -47,7 +47,7 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 		ThreatMultiplier: priest.shadowThreatModifier(),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := sim.Roll(baseLowDamage, baseHightDamage) + spellCoeff*spell.SpellDamage()
+			baseDamage := sim.Roll(baseLowDamage, baseHighDamage) + spellCoeff*spell.SpellDamage()
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 
 			if result.Landed() {
@@ -56,7 +56,7 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 			spell.DealDamage(sim, result)
 		},
 		ExpectedInitialDamage: func(sim *core.Simulation, target *core.Unit, spell *core.Spell, _ bool) *core.SpellResult {
-			baseDamage := (baseLowDamage+baseHightDamage)/2 + spellCoeff*spell.SpellDamage()
+			baseDamage := (baseLowDamage+baseHighDamage)/2 + spellCoeff*spell.SpellDamage()
 			return spell.CalcDamage(sim, target, baseDamage, spell.OutcomeExpectedMagicHitAndCrit)
 		},
 	})

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -5,7 +5,7 @@ character_stats_results: {
   final_stats: 167.64
   final_stats: 143.11
   final_stats: 45.54
-  final_stats: 58.2362
+  final_stats: 59.367
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -54,7 +54,7 @@ character_stats_results: {
   final_stats: 210.98
   final_stats: 211.64
   final_stats: 64.68
-  final_stats: 72.2854
+  final_stats: 73.689
   final_stats: 25
   final_stats: 0
   final_stats: 0

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -5,7 +5,7 @@ character_stats_results: {
   final_stats: 167.64
   final_stats: 143.11
   final_stats: 45.54
-  final_stats: 58.2362
+  final_stats: 59.367
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -54,7 +54,7 @@ character_stats_results: {
   final_stats: 210.98
   final_stats: 211.64
   final_stats: 64.68
-  final_stats: 72.2854
+  final_stats: 73.689
   final_stats: 25
   final_stats: 0
   final_stats: 0

--- a/sim/shaman/ancestral_guidance.go
+++ b/sim/shaman/ancestral_guidance.go
@@ -28,7 +28,7 @@ func (shaman *Shaman) applyAncestralGuidance() {
 
 		DamageMultiplier: 1,
 		CritMultiplier:   1,
-		ThreatMultiplier: shaman.ShamanThreatMultiplier(1),
+		ThreatMultiplier: 1,
 	})
 
 	agHealSpell := shaman.RegisterSpell(core.SpellConfig{

--- a/sim/shaman/earth_shock.go
+++ b/sim/shaman/earth_shock.go
@@ -49,7 +49,7 @@ func (shaman *Shaman) newEarthShockSpellConfig(rank int, shockTimer *core.Timer)
 	spell.RequiredLevel = level
 	spell.Rank = rank
 
-	spell.ThreatMultiplier = shaman.ShamanThreatMultiplier(2)
+	spell.ThreatMultiplier = 2
 
 	spell.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 		baseDamage := sim.Roll(baseDamageLow, baseDamageHigh) + spellCoeff*spell.SpellDamage()

--- a/sim/shaman/electric_spell.go
+++ b/sim/shaman/electric_spell.go
@@ -57,7 +57,7 @@ func (shaman *Shaman) newElectricSpellConfig(actionID core.ActionID, baseCost fl
 			float64(shaman.Talents.CallOfThunder)*core.CritRatingPerCritChance,
 		DamageMultiplier: shaman.ConcussionMultiplier(),
 		CritMultiplier:   shaman.ElementalCritMultiplier(0),
-		ThreatMultiplier: shaman.ShamanThreatMultiplier(1),
+		ThreatMultiplier: 1,
 	}
 
 	return spell

--- a/sim/shaman/fire_nova.go
+++ b/sim/shaman/fire_nova.go
@@ -68,7 +68,7 @@ func (shaman *Shaman) newFireNovaSpellConfig(rank int) core.SpellConfig {
 
 		DamageMultiplier: 1,
 		CritMultiplier:   shaman.ElementalCritMultiplier(0),
-		ThreatMultiplier: shaman.ShamanThreatMultiplier(1),
+		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for _, aoeTarget := range sim.Encounter.TargetUnits {

--- a/sim/shaman/lava_burst.go
+++ b/sim/shaman/lava_burst.go
@@ -64,7 +64,7 @@ func (shaman *Shaman) newLavaBurstSpellConfig(isOverload bool) core.SpellConfig 
 
 		DamageMultiplier: 1,
 		CritMultiplier:   shaman.ElementalCritMultiplier(0),
-		ThreatMultiplier: shaman.ShamanThreatMultiplier(1),
+		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(baseDamageLow, baseDamageHigh) + spellCoeff*spell.SpellDamage()

--- a/sim/shaman/lava_lash.go
+++ b/sim/shaman/lava_lash.go
@@ -40,7 +40,7 @@ func (shaman *Shaman) applyLavaLash() {
 
 		DamageMultiplier: 1.5 * imbueMultiplier * (1 + (.02 * float64(shaman.Talents.WeaponMastery))),
 		CritMultiplier:   shaman.DefaultMeleeCritMultiplier(),
-		ThreatMultiplier: shaman.ShamanThreatMultiplier(1),
+		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := (spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower()) + spell.BonusWeaponDamage()) *

--- a/sim/shaman/molten_blast.go
+++ b/sim/shaman/molten_blast.go
@@ -47,7 +47,7 @@ func (shaman *Shaman) applyMoltenBlast() {
 
 		DamageMultiplier: 1,
 		CritMultiplier:   shaman.ElementalCritMultiplier(0),
-		ThreatMultiplier: shaman.ShamanThreatMultiplier(2),
+		ThreatMultiplier: 2,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for i, aoeTarget := range sim.Encounter.TargetUnits {

--- a/sim/shaman/runes.go
+++ b/sim/shaman/runes.go
@@ -277,6 +277,10 @@ func (shaman *Shaman) applyWayOfEarth() {
 		return
 	}
 
+	if shaman.Consumes.MainHandImbue == proto.WeaponImbue_RockbiterWeapon {
+		shaman.PseudoStats.ThreatMultiplier *= 1.5
+	}
+
 	shaman.RegisterAura(core.Aura{
 		Label:    "Way of Earth",
 		ActionID: core.ActionID{SpellID: int32(proto.ShamanRune_RuneLegsWayOfEarth)},

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -248,10 +248,6 @@ func (shaman *Shaman) ElementalCritMultiplier(secondary float64) float64 {
 	return shaman.SpellCritMultiplier(1, critBonus)
 }
 
-func (shaman *Shaman) ShamanThreatMultiplier(secondary float64) float64 {
-	return core.TernaryFloat64(shaman.HasRune(proto.ShamanRune_RuneLegsWayOfEarth), 1.5, 1) * secondary
-}
-
 func (shaman *Shaman) ConcussionMultiplier() float64 {
 	return 1 + 0.01*float64(shaman.Talents.Concussion)
 }

--- a/sim/shaman/shocks.go
+++ b/sim/shaman/shocks.go
@@ -34,7 +34,7 @@ func (shaman *Shaman) newShockSpellConfig(actionId core.ActionID, spellSchool co
 
 		DamageMultiplier: shaman.ConcussionMultiplier(),
 		CritMultiplier:   shaman.ElementalCritMultiplier(0),
-		ThreatMultiplier: shaman.ShamanThreatMultiplier(1),
+		ThreatMultiplier: 1,
 	}
 }
 

--- a/sim/shaman/talents.go
+++ b/sim/shaman/talents.go
@@ -293,9 +293,7 @@ func (shaman *Shaman) applyFlurry() {
 		return
 	}
 
-	bonus := 1.0 + 0.06*float64(shaman.Talents.Flurry)
-
-	inverseBonus := 1 / bonus
+	bonus := []float64{1, 1.1, 1.15, 1.2, 1.25, 1.3}[shaman.Talents.Flurry]
 
 	procAura := shaman.RegisterAura(core.Aura{
 		Label:     "Flurry Proc",
@@ -306,7 +304,7 @@ func (shaman *Shaman) applyFlurry() {
 			shaman.MultiplyMeleeSpeed(sim, bonus)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			shaman.MultiplyMeleeSpeed(sim, inverseBonus)
+			shaman.MultiplyMeleeSpeed(sim, 1/bonus)
 		},
 	})
 

--- a/sim/warlock/incinerate.go
+++ b/sim/warlock/incinerate.go
@@ -17,7 +17,7 @@ func (warlock *Warlock) registerIncinerateSpell() {
 	level := float64(warlock.GetCharacter().Level)
 	baseCalc := (6.568597 + 0.672028*level + 0.031721*level*level)
 	baseLowDamage := baseCalc * 2.22
-	baseHightDamage := baseCalc * 2.58
+	baseHighDamage := baseCalc * 2.58
 
 	warlock.IncinerateAura = warlock.RegisterAura(core.Aura{
 		Label:    "Incinerate Aura",
@@ -56,7 +56,7 @@ func (warlock *Warlock) registerIncinerateSpell() {
 		ThreatMultiplier:         1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			var baseDamage = sim.Roll(baseLowDamage, baseHightDamage) + spellCoeff*spell.SpellDamage()
+			var baseDamage = sim.Roll(baseLowDamage, baseHighDamage) + spellCoeff*spell.SpellDamage()
 
 			if warlock.LakeOfFireAuras != nil && warlock.LakeOfFireAuras.Get(target).IsActive() {
 				baseDamage *= 1.4

--- a/sim/warrior/bloodthirst.go
+++ b/sim/warrior/bloodthirst.go
@@ -33,7 +33,7 @@ func (warrior *Warrior) registerBloodthirstSpell(cdTimer *core.Timer) {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/concussion_blow.go
+++ b/sim/warrior/concussion_blow.go
@@ -33,7 +33,7 @@ func (warrior *Warrior) registerConcussionBlowSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 2,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/execute.go
+++ b/sim/warrior/execute.go
@@ -48,7 +48,7 @@ func (warrior *Warrior) registerExecuteSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1.25,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/hamstring.go
+++ b/sim/warrior/hamstring.go
@@ -36,7 +36,7 @@ func (warrior *Warrior) registerHamstringSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -31,7 +31,7 @@ func (warrior *Warrior) registerHeroicStrikeSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  259,
 
@@ -85,7 +85,7 @@ func (warrior *Warrior) registerCleaveSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  225,
 

--- a/sim/warrior/mortal_strike.go
+++ b/sim/warrior/mortal_strike.go
@@ -45,7 +45,7 @@ func (warrior *Warrior) registerMortalStrikeSpell(cdTimer *core.Timer) {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/overpower.go
+++ b/sim/warrior/overpower.go
@@ -70,7 +70,7 @@ func (warrior *Warrior) registerOverpowerSpell(cdTimer *core.Timer) {
 
 		BonusCritRating:  25 * core.CritRatingPerCritChance * float64(warrior.Talents.ImprovedOverpower),
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 0.75,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/quick_strike.go
+++ b/sim/warrior/quick_strike.go
@@ -27,9 +27,8 @@ func (warrior *Warrior) registerQuickStrike() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
-		FlatThreatBonus:  259,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(0.10*spell.MeleeAttackPower(), 0.20*spell.MeleeAttackPower())

--- a/sim/warrior/raging_blow.go
+++ b/sim/warrior/raging_blow.go
@@ -36,7 +36,7 @@ func (warrior *Warrior) registerRagingBlow() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/revenge.go
+++ b/sim/warrior/revenge.go
@@ -69,7 +69,7 @@ func (warrior *Warrior) registerRevengeSpell(cdTimer *core.Timer) {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  121,
 

--- a/sim/warrior/shield_slam.go
+++ b/sim/warrior/shield_slam.go
@@ -54,7 +54,7 @@ func (warrior *Warrior) registerShieldSlamSpell() {
 
 		BonusCritRating:  5 * core.CritRatingPerCritChance,
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1.3,
 		FlatThreatBonus:  770,
 

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -63,7 +63,7 @@ func (warrior *Warrior) registerSlamSpell() {
 
 		BonusCritRating:  0,
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  140,
 

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -69,7 +69,7 @@ func (warrior *Warrior) applyOneHandedWeaponSpecialization() {
 		return
 	}
 
-	warrior.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= 1 + 0.01*float64(warrior.Talents.OneHandedWeaponSpecialization)
+	warrior.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= 1 + 0.02*float64(warrior.Talents.OneHandedWeaponSpecialization)
 }
 
 func (warrior *Warrior) applyWeaponSpecializations() {

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -106,8 +106,8 @@ func (warrior *Warrior) AddPartyBuffs(_ *proto.PartyBuffs) {
 }
 
 func (warrior *Warrior) Initialize() {
-	warrior.AutoAttacks.MHConfig().CritMultiplier = warrior.autoCritMultiplier(mh)
-	warrior.AutoAttacks.OHConfig().CritMultiplier = warrior.autoCritMultiplier(oh)
+	warrior.AutoAttacks.MHConfig().CritMultiplier = warrior.autoCritMultiplier()
+	warrior.AutoAttacks.OHConfig().CritMultiplier = warrior.autoCritMultiplier()
 
 	primaryTimer := warrior.NewTimer()
 	overpowerRevengeTimer := warrior.NewTimer()
@@ -167,28 +167,12 @@ func NewWarrior(character *core.Character, talents string, inputs WarriorInputs)
 	return warrior
 }
 
-type hand int8
-
-const (
-	none hand = 0
-	mh   hand = 1
-	oh   hand = 2
-)
-
-func (warrior *Warrior) autoCritMultiplier(hand hand) float64 {
-	return warrior.MeleeCritMultiplier(primary(warrior, hand), 0)
+func (warrior *Warrior) autoCritMultiplier() float64 {
+	return warrior.MeleeCritMultiplier(1, 0)
 }
 
-func primary(warrior *Warrior, hand hand) float64 {
-	return 1
-}
-
-func isPoleaxe(weapon *core.Item) bool {
-	return weapon.WeaponType == proto.WeaponType_WeaponTypeAxe || weapon.WeaponType == proto.WeaponType_WeaponTypePolearm
-}
-
-func (warrior *Warrior) critMultiplier(hand hand) float64 {
-	return warrior.MeleeCritMultiplier(primary(warrior, hand), 0.1*float64(warrior.Talents.Impale))
+func (warrior *Warrior) critMultiplier() float64 {
+	return warrior.MeleeCritMultiplier(1, 0.1*float64(warrior.Talents.Impale))
 }
 
 // Agent is a generic way to access underlying warrior on any of the agents.

--- a/sim/warrior/whirlwind.go
+++ b/sim/warrior/whirlwind.go
@@ -39,7 +39,7 @@ func (warrior *Warrior) registerWhirlwindSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   warrior.critMultiplier(mh),
+		CritMultiplier:   warrior.critMultiplier(),
 		ThreatMultiplier: 1.25,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {


### PR DESCRIPTION
[core] remove no longer used ReducedXXXHitTakenChance pseudo stats
[core] make ThunderClapAura "classic"
[core] fix racials, e.g. all reduced hit taken chances are now just 10 resistance or 1% dodge, ranged crit becomes ranged weapon skill, humans gain 5% spirit (up from 3%), and tauren 5% health (up from just base health)

[druid] Hurricane cannot crit anymore

[hunter] Aimed Shot no longer benefits from Barrage [hunter] Carve, Raptor Strike, Serpent Sting, and traps no longer benefit from Mortal Shots

[mage] Combustion no longer increases crit multiplier

[shaman] correct lower Flurry ranks
[shaman] Way of Earth now increases all threat by 50%

[warrior] simplify warrior critical strike damage
[warrior] One-Handed Weapon Specialization now increases damage by 2% per point 
[warrior] Thunder Clap now deals physical damage (reduced by armor), but using defense type "magic" (i.e. OutcomeMagicHitAndCrit and SpellCritMultiplier); ThreatMultiplier increased to 2.5 w/o, and 3.75 w/ Furious Thunder