### PR TITLE
Crit Multiplier Fixes

### DIFF
--- a/sim/_paladin/talents.go
+++ b/sim/_paladin/talents.go
@@ -225,12 +225,15 @@ func (paladin *Paladin) applyArdentDefender() {
 
 	// Spell to heal you when AD has procced; fire this before fatal damage so that a Death is not detected
 	procHeal := paladin.RegisterSpell(core.SpellConfig{
-		ActionID:         core.ActionID{SpellID: 66233},
-		SpellSchool:      core.SpellSchoolHoly,
-		ProcMask:         core.ProcMaskSpellHealing,
-		CritMultiplier:   1, // Assuming this can't really crit?
+		ActionID:    core.ActionID{SpellID: 66233},
+		SpellSchool: core.SpellSchoolHoly,
+		ProcMask:    core.ProcMaskSpellHealing,
+
+		CritMultiplier: 1, // Assuming this can't really crit?
+
 		ThreatMultiplier: 0.25,
 		DamageMultiplier: 1,
+
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			spell.CalcAndDealHealing(sim, &paladin.Unit, ardentHealAmount*paladin.MaxHealth(), spell.OutcomeHealingCrit)
 		},

--- a/sim/common/itemhelpers/weaponprocs.go
+++ b/sim/common/itemhelpers/weaponprocs.go
@@ -9,8 +9,14 @@ import (
 // Create a simple weapon proc that deals damage.
 func CreateWeaponProcDamage(itemId int32, itemName string, ppm float64, spellId int32, school core.SpellSchool,
 	dmgMin float64, dmgRange float64, bonusCoef float64, defType core.DefenseType) {
+
 	core.NewItemEffect(itemId, func(agent core.Agent) {
 		character := agent.GetCharacter()
+
+		critMultiplier := character.DefaultSpellCritMultiplier()
+		if defType == core.DefenseTypeMelee || defType == core.DefenseTypeRanged {
+			critMultiplier = character.DefaultMeleeCritMultiplier()
+		}
 
 		sc := core.SpellConfig{
 			ActionID:    core.ActionID{SpellID: spellId},
@@ -18,7 +24,7 @@ func CreateWeaponProcDamage(itemId int32, itemName string, ppm float64, spellId 
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   critMultiplier,
 			ThreatMultiplier: 1,
 		}
 

--- a/sim/common/sod/crafted/phase_2.go
+++ b/sim/common/sod/crafted/phase_2.go
@@ -141,11 +141,9 @@ func init() {
 			},
 
 			DamageMultiplier: 1,
-			CritMultiplier:   1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				// TODO: Verify if this can crit
-				result := spell.CalcDamage(sim, &character.Unit, sim.Roll(343, 757), spell.OutcomeMagicCrit)
+				result := spell.CalcDamage(sim, &character.Unit, sim.Roll(343, 757), spell.OutcomeAlwaysHit)
 				if sim.Log != nil {
 					character.Log(sim, "Took %.1f damage from Gneuro-Logical Shock.", result.Damage)
 				}
@@ -264,11 +262,9 @@ func init() {
 			},
 
 			DamageMultiplier: 1,
-			CritMultiplier:   1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				// TODO: Verify if this can crit
-				result := spell.CalcDamage(sim, &character.Unit, sim.Roll(312, 668), spell.OutcomeMagicCrit)
+				result := spell.CalcDamage(sim, &character.Unit, sim.Roll(312, 668), spell.OutcomeAlwaysHit)
 				character.RemoveHealth(sim, result.Damage)
 				buffAura.Activate(sim)
 			},

--- a/sim/common/sod/enchant_effects.go
+++ b/sim/common/sod/enchant_effects.go
@@ -13,21 +13,18 @@ func init() {
 	core.NewEnchantEffect(7210, func(agent core.Agent) {
 		character := agent.GetCharacter()
 
-		procChance := 0.10
-		baseDamageLow := 60.0
-		baseDamageHigh := 90.0
-
 		procSpell := character.GetOrRegisterSpell(core.SpellConfig{
 			ActionID:    core.ActionID{SpellID: 439164},
 			SpellSchool: core.SpellSchoolNature,
 			ProcMask:    core.ProcMaskSpellDamage,
 
+			CritMultiplier: character.DefaultSpellCritMultiplier(),
+
 			DamageMultiplier: 1,
-			CritMultiplier:   1,
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				spell.CalcAndDealDamage(sim, target, sim.Roll(baseDamageLow, baseDamageHigh), spell.OutcomeMagicHitAndCrit)
+				spell.CalcAndDealDamage(sim, target, sim.Roll(60, 90), spell.OutcomeMagicHitAndCrit)
 			},
 		})
 
@@ -74,7 +71,7 @@ func init() {
 				}
 
 				if spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
-					if sim.RandomFloat("Dismantle") < procChance {
+					if sim.RandomFloat("Dismantle") < 0.10 {
 						// Spells proc both Main-Hand and Off-Hand if both are enchanted
 						if character.GetMHWeapon() != nil && character.GetMHWeapon().Enchant.EffectID == 7210 {
 							procSpell.Cast(sim, result.Target)
@@ -83,7 +80,7 @@ func init() {
 							procSpell.Cast(sim, result.Target)
 						}
 					}
-				} else if sim.RandomFloat("Dismantle") < procChance {
+				} else if sim.RandomFloat("Dismantle") < 0.10 {
 					// Physical hits only proc on the hand that was hit with
 					procSpell.Cast(sim, result.Target)
 				}

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -628,6 +628,7 @@ func (aura *Aura) Activate(sim *Simulation) {
 		aura.onPeriodicHealTakenIndex = int32(len(aura.Unit.onPeriodicHealTakenAuras))
 		aura.Unit.onPeriodicHealTakenAuras = append(aura.Unit.onPeriodicHealTakenAuras, aura)
 	}
+
 	if aura.OnRageChange != nil {
 		aura.onRageChangeIndex = int32(len(aura.Unit.onRageChangeAuras))
 		aura.Unit.onRageChangeAuras = append(aura.Unit.onRageChangeAuras, aura)

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -101,7 +101,7 @@ func applyConsumeEffects(agent Agent, partyBuffs *proto.PartyBuffs) {
 	}
 
 	if consumes.DragonBreathChili {
-		MakePermanent(DragonBreathChiliAura(&character.Unit))
+		MakePermanent(DragonBreathChiliAura(character))
 	}
 
 	if consumes.AgilityElixir != proto.AgilityElixir_AgilityElixirUnknown {
@@ -464,18 +464,19 @@ func registerExplosivesCD(agent Agent, consumes *proto.Consumes) {
 	}
 }
 
-func DragonBreathChiliAura(unit *Unit) *Aura {
+func DragonBreathChiliAura(character *Character) *Aura {
 	baseDamage := 60.0
 	procChance := .05
 
-	procSpell := unit.RegisterSpell(SpellConfig{
+	procSpell := character.RegisterSpell(SpellConfig{
 		ActionID:    ActionID{SpellID: 15851},
 		SpellSchool: SpellSchoolFire,
 		ProcMask:    ProcMaskEmpty,
 		Flags:       SpellFlagNone,
 
+		CritMultiplier: character.DefaultSpellCritMultiplier(),
+
 		DamageMultiplier: 1,
-		CritMultiplier:   1,
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
@@ -483,7 +484,7 @@ func DragonBreathChiliAura(unit *Unit) *Aura {
 		},
 	})
 
-	aura := unit.GetOrRegisterAura(Aura{
+	aura := character.GetOrRegisterAura(Aura{
 		Label:    "Dragonbreath Chili",
 		ActionID: ActionID{SpellID: 15852},
 		Duration: NeverExpires,
@@ -529,9 +530,11 @@ func (character *Character) newBasicExplosiveSpellConfig(sharedTimer *Timer, act
 		},
 
 		// Explosives always have 1% resist chance, so just give them hit cap.
-		BonusHitRating:   100 * SpellHitRatingPerHitChance,
+		BonusHitRating: 100 * SpellHitRatingPerHitChance,
+
+		CritMultiplier: character.DefaultSpellCritMultiplier(),
+
 		DamageMultiplier: 1,
-		CritMultiplier:   2,
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
@@ -584,9 +587,11 @@ func (character *Character) newRadiationBombSpellConfig(sharedTimer *Timer, acti
 		},
 
 		// Explosives always have 1% resist chance, so just give them hit cap.
-		BonusHitRating:   100 * SpellHitRatingPerHitChance,
+		BonusHitRating: 100 * SpellHitRatingPerHitChance,
+
+		CritMultiplier: character.DefaultSpellCritMultiplier(),
+
 		DamageMultiplier: 1,
-		CritMultiplier:   2,
 		ThreatMultiplier: 1,
 
 		// TODO: This should use another spell (443813) as the DoT

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -575,8 +575,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 497.55193
-  tps: 367.72499
+  dps: 497.54349
+  tps: 367.719
  }
 }
 dps_results: {

--- a/sim/encounters/naxxramas/patchwerk10_ai.go
+++ b/sim/encounters/naxxramas/patchwerk10_ai.go
@@ -79,8 +79,9 @@ func (ai *Patchwerk10AI) registerHatefulStrikeSpell(target *core.Target) {
 			},
 		},
 
+		CritMultiplier: 1,
+
 		DamageMultiplier: 1,
-		CritMultiplier:   1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(27750, 32250)

--- a/sim/encounters/naxxramas/patchwerk25_ai.go
+++ b/sim/encounters/naxxramas/patchwerk25_ai.go
@@ -80,8 +80,9 @@ func (ai *Patchwerk25AI) registerHatefulStrikeSpell(target *core.Target) {
 			},
 		},
 
+		CritMultiplier: 1,
+
 		DamageMultiplier: 1,
-		CritMultiplier:   1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(79000, 81000)

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestBM-Lvl25-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.45975
+  weights: 0.45933
   weights: 0
   weights: 0
   weights: 0
@@ -117,8 +117,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.02236
-  weights: 2.59492
-  weights: 2.14195
+  weights: 2.59814
+  weights: 2.14097
   weights: 0
   weights: 0
   weights: 0
@@ -166,8 +166,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.33525
-  weights: 10.17894
-  weights: 7.80584
+  weights: 10.18317
+  weights: 7.80829
   weights: 0
   weights: 0
   weights: 0
@@ -197,637 +197,637 @@ stat_weights_results: {
 dps_results: {
  key: "TestBM-Lvl25-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 223.29525
-  tps: 91.18022
+  dps: 223.28743
+  tps: 91.1718
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 229.41051
-  tps: 94.56525
+  dps: 229.42799
+  tps: 94.58195
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 230.15497
-  tps: 95.2847
+  dps: 230.14715
+  tps: 95.27627
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-BloodlashBow-216516"
  value: {
-  dps: 232.9708
-  tps: 103.81778
+  dps: 232.95285
+  tps: 103.79978
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 259.13642
-  tps: 116.0656
+  dps: 259.12515
+  tps: 116.05414
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 227.32307
-  tps: 99.04053
+  dps: 227.23936
+  tps: 98.95651
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 235.82022
-  tps: 100.98388
+  dps: 235.87525
+  tps: 101.03872
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 228.30831
-  tps: 98.312
+  dps: 228.3113
+  tps: 98.3112
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-InsulatedLeathers"
  value: {
-  dps: 228.37501
-  tps: 95.35489
+  dps: 228.34368
+  tps: 95.32338
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 229.27528
-  tps: 99.21378
+  dps: 229.29166
+  tps: 99.22986
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-IrradiatedGarments"
  value: {
-  dps: 230.82128
-  tps: 100.43886
+  dps: 230.81128
+  tps: 100.42856
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 238.12804
-  tps: 99.55941
+  dps: 238.12622
+  tps: 99.55698
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-StormshroudArmor"
  value: {
-  dps: 188.84082
-  tps: 89.43168
+  dps: 188.82702
+  tps: 89.41788
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 224.85436
-  tps: 92.98264
+  dps: 224.83681
+  tps: 92.96434
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Average-Default"
  value: {
-  dps: 240.9783
-  tps: 101.25241
+  dps: 240.97726
+  tps: 101.25133
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 244.78976
-  tps: 112.21161
+  dps: 244.8033
+  tps: 112.22634
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 232.51857
-  tps: 98.38044
+  dps: 232.51098
+  tps: 98.37406
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 279.92556
-  tps: 111.36968
+  dps: 280.02442
+  tps: 111.47457
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 120.30847
-  tps: 61.27242
+  dps: 120.30809
+  tps: 61.27271
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 115.07283
-  tps: 55.5643
+  dps: 115.10183
+  tps: 55.59414
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 136.49828
-  tps: 60.63121
+  dps: 136.56682
+  tps: 60.70392
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 246.94886
-  tps: 109.34736
+  dps: 246.95526
+  tps: 109.35494
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 234.11841
-  tps: 96.71326
+  dps: 234.12655
+  tps: 96.7226
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 282.74186
-  tps: 109.39744
+  dps: 282.84072
+  tps: 109.50234
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 120.50913
-  tps: 60.40311
+  dps: 120.524
+  tps: 60.41865
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 115.99091
-  tps: 54.70154
+  dps: 116.01537
+  tps: 54.72684
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 137.16363
-  tps: 61.1463
+  dps: 137.25968
+  tps: 61.24651
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 238.15465
-  tps: 99.45896
+  dps: 238.16779
+  tps: 99.47192
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 664.69855
-  tps: 222.76993
+  dps: 665.21379
+  tps: 223.28517
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 649.52334
-  tps: 216.08551
+  dps: 650.11457
+  tps: 216.67674
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 670.47237
-  tps: 223.87128
+  dps: 670.94872
+  tps: 224.34763
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 646.69153
-  tps: 242.94793
+  dps: 647.22816
+  tps: 243.48457
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 608.33591
-  tps: 222.90915
+  dps: 609.13138
+  tps: 223.70463
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 602.75932
-  tps: 216.88697
+  dps: 603.26218
+  tps: 217.38982
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 618.44457
-  tps: 230.44161
+  dps: 619.20912
+  tps: 231.20616
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 645.16273
-  tps: 240.55346
+  dps: 645.70797
+  tps: 241.0987
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 616.51102
-  tps: 228.50806
+  dps: 617.17981
+  tps: 229.17685
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 622.01187
-  tps: 231.41568
+  dps: 622.85341
+  tps: 232.25723
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 844.53308
-  tps: 265.20416
+  dps: 845.23766
+  tps: 265.90874
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 732.38271
-  tps: 228.00879
+  dps: 733.01586
+  tps: 228.64194
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 644.95949
-  tps: 213.80456
+  dps: 645.50703
+  tps: 214.35209
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Average-Default"
  value: {
-  dps: 849.15229
-  tps: 267.34618
+  dps: 850.03966
+  tps: 268.23354
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1409.15726
-  tps: 857.43541
+  dps: 1411.16632
+  tps: 859.44447
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 744.15748
-  tps: 191.80814
+  dps: 744.57317
+  tps: 192.22383
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 772.81524
-  tps: 203.31738
+  dps: 773.09731
+  tps: 203.59946
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 653.95895
-  tps: 548.07255
+  dps: 654.35141
+  tps: 548.46502
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 337.62084
-  tps: 105.19208
+  dps: 337.71174
+  tps: 105.28298
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 367.011
-  tps: 105.99387
+  dps: 367.08052
+  tps: 106.06339
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 529.92038
-  tps: 521.21494
+  dps: 529.85202
+  tps: 521.14658
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 469.94928
-  tps: 228.75756
+  dps: 469.87552
+  tps: 228.6838
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 513.73237
-  tps: 242.62906
+  dps: 513.55036
+  tps: 242.44705
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 257.11378
-  tps: 454.3999
+  dps: 257.08484
+  tps: 454.37096
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 218.20856
-  tps: 134.56809
+  dps: 218.10495
+  tps: 134.46448
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 246.40713
-  tps: 144.17845
+  dps: 246.19419
+  tps: 143.96552
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 462.50135
-  tps: 452.04432
+  dps: 462.7904
+  tps: 452.33337
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 462.50135
-  tps: 188.46312
+  dps: 462.7904
+  tps: 188.75217
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 503.84869
-  tps: 205.23256
+  dps: 504.04313
+  tps: 205.42699
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 218.64669
-  tps: 426.6353
+  dps: 218.70003
+  tps: 426.68864
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 218.64669
-  tps: 111.61697
+  dps: 218.70003
+  tps: 111.67031
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 244.44855
-  tps: 115.67788
+  dps: 244.51021
+  tps: 115.73954
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 734.34878
-  tps: 837.09641
+  dps: 734.10383
+  tps: 836.84311
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 655.71546
-  tps: 409.36756
+  dps: 655.505
+  tps: 409.15344
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 715.47823
-  tps: 442.93236
+  dps: 715.10042
+  tps: 442.53625
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 394.57831
-  tps: 656.35655
+  dps: 394.48946
+  tps: 656.26675
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 347.77883
-  tps: 255.78046
+  dps: 347.88581
+  tps: 255.88719
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 371.53495
-  tps: 273.87494
+  dps: 371.51661
+  tps: 273.85534
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1414.49936
-  tps: 846.46765
+  dps: 1416.46773
+  tps: 848.43602
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 752.38236
-  tps: 190.02431
+  dps: 752.80567
+  tps: 190.44761
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 786.41937
-  tps: 200.42892
+  dps: 786.78618
+  tps: 200.79572
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 649.78533
-  tps: 544.37986
+  dps: 650.19168
+  tps: 544.78621
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 339.04645
-  tps: 104.46004
+  dps: 339.13842
+  tps: 104.55202
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 371.64242
-  tps: 108.1986
+  dps: 371.73645
+  tps: 108.29263
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 536.95947
-  tps: 518.01586
+  dps: 536.85272
+  tps: 517.90911
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 477.20269
-  tps: 225.41657
+  dps: 477.08037
+  tps: 225.29425
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 523.11818
-  tps: 239.62213
+  dps: 522.93617
+  tps: 239.44012
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 258.63634
-  tps: 446.42131
+  dps: 258.58249
+  tps: 446.36746
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.91938
-  tps: 132.9388
+  dps: 219.85993
+  tps: 132.87935
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 249.35557
-  tps: 142.50084
+  dps: 249.14264
+  tps: 142.28791
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 470.99504
-  tps: 445.06074
+  dps: 471.27113
+  tps: 445.33942
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 470.99504
-  tps: 183.72373
+  dps: 471.27113
+  tps: 184.00242
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 518.37593
-  tps: 208.38711
+  dps: 518.57036
+  tps: 208.58154
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 222.01694
-  tps: 426.36807
+  dps: 222.06982
+  tps: 426.42095
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 222.01694
-  tps: 110.1386
+  dps: 222.06982
+  tps: 110.19148
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 248.12564
-  tps: 115.78449
+  dps: 248.1873
+  tps: 115.84616
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 736.00172
-  tps: 833.83943
+  dps: 735.88899
+  tps: 833.71835
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 663.058
-  tps: 403.94554
+  dps: 663.0376
+  tps: 403.92149
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 721.82657
-  tps: 437.96468
+  dps: 721.47328
+  tps: 437.5931
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 394.20681
-  tps: 653.12811
+  dps: 394.19991
+  tps: 653.12025
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 348.71191
-  tps: 251.48436
+  dps: 348.67702
+  tps: 251.44923
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 371.91336
-  tps: 269.57967
+  dps: 372.03061
+  tps: 269.69567
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 806.04258
-  tps: 244.28634
+  dps: 806.63246
+  tps: 244.87621
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestMM-Lvl25-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.43926
+  weights: 0.43869
   weights: 0
   weights: 0
   weights: 0
@@ -117,8 +117,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.02322
-  weights: 2.34102
-  weights: 1.72476
+  weights: 2.34555
+  weights: 1.72533
   weights: 0
   weights: 0
   weights: 0
@@ -166,7 +166,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.11468
-  weights: 3.03759
+  weights: 3.04479
   weights: 4.05779
   weights: 0
   weights: 0
@@ -197,392 +197,392 @@ stat_weights_results: {
 dps_results: {
  key: "TestMM-Lvl25-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 203.38692
-  tps: 93.21409
+  dps: 203.42166
+  tps: 93.24823
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 208.69764
-  tps: 95.75122
+  dps: 208.67459
+  tps: 95.72741
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 210.24951
-  tps: 97.65586
+  dps: 210.28425
+  tps: 97.68999
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-BloodlashBow-216516"
  value: {
-  dps: 206.56548
-  tps: 101.14995
+  dps: 206.54099
+  tps: 101.1254
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 239.40324
-  tps: 119.19822
+  dps: 239.40515
+  tps: 119.19994
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 208.22916
-  tps: 100.83701
+  dps: 208.28855
+  tps: 100.89609
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 213.61756
-  tps: 103.30446
+  dps: 213.61942
+  tps: 103.30614
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 210.01292
-  tps: 100.93874
+  dps: 209.90911
+  tps: 100.83114
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-InsulatedLeathers"
  value: {
-  dps: 208.53721
-  tps: 98.7923
+  dps: 208.50764
+  tps: 98.76254
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 207.79359
-  tps: 99.39708
+  dps: 207.77601
+  tps: 99.37921
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-IrradiatedGarments"
  value: {
-  dps: 209.78158
-  tps: 101.6742
+  dps: 209.8399
+  tps: 101.73223
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 215.15163
-  tps: 98.96728
+  dps: 215.17156
+  tps: 98.98661
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-StormshroudArmor"
  value: {
-  dps: 174.03722
-  tps: 91.30592
+  dps: 174.02273
+  tps: 91.29143
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 204.18567
-  tps: 92.7198
+  dps: 204.16812
+  tps: 92.7015
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Average-Default"
  value: {
-  dps: 218.5098
-  tps: 101.49675
+  dps: 218.50977
+  tps: 101.49667
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 218.9581
-  tps: 110.30951
+  dps: 218.97668
+  tps: 110.32929
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 205.72998
-  tps: 95.58942
+  dps: 205.71696
+  tps: 95.57634
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 255.11915
-  tps: 115.20546
+  dps: 255.18129
+  tps: 115.26732
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 107.9874
-  tps: 60.67064
+  dps: 107.97469
+  tps: 60.6586
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 103.26286
-  tps: 55.47763
+  dps: 103.29348
+  tps: 55.50826
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 123.76846
-  tps: 63.04069
+  dps: 123.78241
+  tps: 63.05469
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 225.23631
-  tps: 111.27945
+  dps: 225.24556
+  tps: 111.28989
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 212.15448
-  tps: 97.75986
+  dps: 212.12648
+  tps: 97.73181
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 260.88954
-  tps: 115.79519
+  dps: 260.95168
+  tps: 115.85705
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 110.64748
-  tps: 61.14671
+  dps: 110.64744
+  tps: 61.14734
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 105.66031
-  tps: 55.40994
+  dps: 105.7141
+  tps: 55.46374
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 125.92369
-  tps: 62.65739
+  dps: 125.9691
+  tps: 62.70285
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 215.31793
-  tps: 100.02988
+  dps: 215.32035
+  tps: 100.03212
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 300.15349
-  tps: 158.41932
+  dps: 300.60716
+  tps: 158.873
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 292.73332
-  tps: 152.49117
+  dps: 293.30857
+  tps: 153.06642
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 304.06638
-  tps: 160.19722
+  dps: 304.52005
+  tps: 160.65089
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BloodlashBow-216516"
  value: {
-  dps: 326.76022
-  tps: 177.2763
+  dps: 327.23334
+  tps: 177.75201
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 313.93222
-  tps: 167.32152
+  dps: 314.45394
+  tps: 167.84843
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 295.3287
-  tps: 155.736
+  dps: 296.0696
+  tps: 156.48088
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 292.02017
-  tps: 152.3987
+  dps: 292.49328
+  tps: 152.87441
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 296.9103
-  tps: 155.77086
+  dps: 297.57706
+  tps: 156.4446
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 316.42898
-  tps: 169.97314
+  dps: 316.92478
+  tps: 170.47412
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 296.64127
-  tps: 155.49982
+  dps: 297.28666
+  tps: 156.15196
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 300.89781
-  tps: 158.16877
+  dps: 301.79278
+  tps: 159.07165
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 322.72788
-  tps: 172.42001
+  dps: 323.20099
+  tps: 172.89572
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 308.77736
-  tps: 162.94573
+  dps: 309.12286
+  tps: 163.29123
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 290.62039
-  tps: 151.07932
+  dps: 291.18357
+  tps: 151.6425
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Average-Default"
  value: {
-  dps: 327.27197
-  tps: 176.92847
+  dps: 327.71667
+  tps: 177.37662
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 689.45878
-  tps: 879.45198
+  dps: 689.1875
+  tps: 879.17718
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 598.59442
-  tps: 474.65025
+  dps: 598.65385
+  tps: 474.71142
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 619.10965
-  tps: 492.75967
+  dps: 619.18993
+  tps: 492.84866
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 396.78369
-  tps: 640.03294
+  dps: 396.84555
+  tps: 640.09568
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 338.40062
-  tps: 289.20843
+  dps: 338.36425
+  tps: 289.17181
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 365.86359
-  tps: 308.54696
+  dps: 365.79079
+  tps: 308.47291
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 694.13934
-  tps: 877.51405
+  dps: 694.22998
+  tps: 877.60117
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 607.3839
-  tps: 475.95786
+  dps: 607.29254
+  tps: 475.86824
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 627.90331
-  tps: 492.9873
+  dps: 627.92709
+  tps: 493.01978
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 399.14662
-  tps: 640.69253
+  dps: 399.04508
+  tps: 640.59187
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 341.27469
-  tps: 288.95059
+  dps: 341.26665
+  tps: 288.9423
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 368.93282
-  tps: 307.80831
+  dps: 368.88067
+  tps: 307.75491
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 314.07853
-  tps: 163.06939
+  dps: 314.47387
+  tps: 163.46733
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -117,8 +117,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.02418
-  weights: 1.78994
-  weights: 1.85967
+  weights: 1.82002
+  weights: 1.86201
   weights: 0
   weights: 0
   weights: 0
@@ -166,7 +166,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.38811
-  weights: 10.13446
+  weights: 10.12975
   weights: 6.34394
   weights: 0
   weights: 0
@@ -197,385 +197,385 @@ stat_weights_results: {
 dps_results: {
  key: "TestSV-Lvl25-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 200.85064
-  tps: 87.92925
+  dps: 200.83488
+  tps: 87.91288
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 208.6298
-  tps: 93.23983
+  dps: 208.63634
+  tps: 93.2456
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 207.12029
-  tps: 91.72038
+  dps: 207.10452
+  tps: 91.70401
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-BloodlashBow-216516"
  value: {
-  dps: 204.99535
-  tps: 98.41307
+  dps: 205.03796
+  tps: 98.45562
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 236.60846
-  tps: 114.74026
+  dps: 236.6494
+  tps: 114.78101
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 208.10766
-  tps: 97.41439
+  dps: 208.07463
+  tps: 97.38106
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 214.3949
-  tps: 99.13491
+  dps: 214.40625
+  tps: 99.14609
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 207.66232
-  tps: 96.77849
+  dps: 207.57279
+  tps: 96.68517
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-InsulatedLeathers"
  value: {
-  dps: 205.74271
-  tps: 94.29959
+  dps: 205.69296
+  tps: 94.24966
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 208.53934
-  tps: 98.18504
+  dps: 208.55645
+  tps: 98.20185
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-IrradiatedGarments"
  value: {
-  dps: 209.44573
-  tps: 98.8055
+  dps: 209.38901
+  tps: 98.74848
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 215.51984
-  tps: 97.2937
+  dps: 215.54446
+  tps: 97.31771
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-StormshroudArmor"
  value: {
-  dps: 173.54924
-  tps: 88.27827
+  dps: 173.53388
+  tps: 88.2629
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 204.29653
-  tps: 91.01152
+  dps: 204.27522
+  tps: 90.98946
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Average-Default"
  value: {
-  dps: 218.18303
-  tps: 99.72973
+  dps: 218.18403
+  tps: 99.73071
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 221.66944
-  tps: 109.40372
+  dps: 221.70442
+  tps: 109.43983
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 210.69737
-  tps: 96.56053
+  dps: 210.71123
+  tps: 96.5756
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 266.14604
-  tps: 114.12764
+  dps: 266.2449
+  tps: 114.23253
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 109.1972
-  tps: 59.91946
+  dps: 109.20216
+  tps: 59.92509
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 104.57571
-  tps: 54.03847
+  dps: 104.58579
+  tps: 54.04938
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 129.21688
-  tps: 60.51672
+  dps: 129.29917
+  tps: 60.60317
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 223.72173
-  tps: 107.60961
+  dps: 223.73765
+  tps: 107.62667
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 212.63891
-  tps: 94.81108
+  dps: 212.60378
+  tps: 94.77715
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 267.78672
-  tps: 112.29509
+  dps: 267.88558
+  tps: 112.39998
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 108.61927
-  tps: 59.14796
+  dps: 108.6409
+  tps: 59.17026
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 104.41639
-  tps: 53.13666
+  dps: 104.44368
+  tps: 53.16479
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 128.57964
-  tps: 61.83201
+  dps: 128.67569
+  tps: 61.93222
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 216.26152
-  tps: 99.12874
+  dps: 216.25886
+  tps: 99.1259
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 625.78401
-  tps: 248.51153
+  dps: 626.28629
+  tps: 249.01381
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 607.78065
-  tps: 240.75438
+  dps: 608.42781
+  tps: 241.40153
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 631.29734
-  tps: 250.21178
+  dps: 631.79962
+  tps: 250.71406
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 604.62395
-  tps: 264.18205
+  dps: 605.22505
+  tps: 264.78316
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 571.4137
-  tps: 247.89339
+  dps: 572.25268
+  tps: 248.73236
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 565.5056
-  tps: 241.55279
+  dps: 566.03061
+  tps: 242.07779
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 575.20408
-  tps: 250.04918
+  dps: 576.03889
+  tps: 250.88399
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 605.63317
-  tps: 263.01182
+  dps: 606.20663
+  tps: 263.58527
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 573.2054
-  tps: 248.0505
+  dps: 573.91761
+  tps: 248.7627
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 578.12991
-  tps: 251.12099
+  dps: 579.05586
+  tps: 252.04694
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 833.09856
-  tps: 285.19578
+  dps: 833.81976
+  tps: 285.91698
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 716.2494
-  tps: 254.24164
+  dps: 716.92002
+  tps: 254.91226
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 604.41163
-  tps: 239.20712
+  dps: 605.02956
+  tps: 239.82505
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
-  dps: 847.67382
-  tps: 296.24195
+  dps: 848.61412
+  tps: 297.18225
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1407.97576
-  tps: 861.73017
+  dps: 1409.91713
+  tps: 863.67154
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 708.40743
-  tps: 194.25775
+  dps: 708.81009
+  tps: 194.66041
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 722.6256
-  tps: 202.70097
+  dps: 722.94142
+  tps: 203.01679
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 656.46126
-  tps: 530.55498
+  dps: 656.91568
+  tps: 531.0094
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 329.29515
-  tps: 106.46179
+  dps: 329.37728
+  tps: 106.54392
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 347.2944
-  tps: 106.09934
+  dps: 347.37627
+  tps: 106.1812
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1416.82884
-  tps: 859.66061
+  dps: 1418.79993
+  tps: 861.63171
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 718.18519
-  tps: 194.60566
+  dps: 718.64229
+  tps: 195.06277
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 726.59836
-  tps: 201.78615
+  dps: 727.03057
+  tps: 202.21836
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 657.75375
-  tps: 525.8406
+  dps: 658.16303
+  tps: 526.24988
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 334.42407
-  tps: 107.39399
+  dps: 334.51222
+  tps: 107.48214
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 357.77129
-  tps: 110.33428
+  dps: 357.82508
+  tps: 110.38807
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 797.59203
-  tps: 273.92751
+  dps: 798.23582
+  tps: 274.5713
  }
 }

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -161,10 +161,8 @@ func (hunter *Hunter) makeQueueSpellsAndAura(srcSpell *core.Spell) *core.Spell {
 	})
 
 	queueSpell := hunter.RegisterSpell(core.SpellConfig{
-		ActionID:    srcSpell.WithTag(1),
-		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
+		ActionID: srcSpell.WithTag(1),
+		Flags:    core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
 
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
 			return hunter.curQueueAura != queueAura &&

--- a/sim/hunter/serpent_sting.go
+++ b/sim/hunter/serpent_sting.go
@@ -68,7 +68,7 @@ func (hunter *Hunter) getSerpentStingConfig(rank int) core.SpellConfig {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			// Reports of Bow of Searing Arrows proccing from SS applications means it has a hit event
-			result := spell.CalcDamage(sim, target, 0, spell.OutcomeRangedHit)
+			result := spell.CalcOutcome(sim, target, spell.OutcomeRangedHit)
 
 			spell.WaitTravelTime(sim, func(s *core.Simulation) {
 				spell.DealOutcome(sim, result)

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -148,12 +148,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.66558
-  weights: 0.56808
+  weights: 0.6677
+  weights: 0.59445
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.26795
+  weights: 0.27117
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.11562
+  weights: 2.06453
+  weights: 0.06757
   weights: 0
   weights: 0
-  weights: 0
-  weights: 0.30253
-  weights: 6.57178
-  weights: 7.20033
+  weights: 0.3035
+  weights: 6.61792
+  weights: 7.14924
   weights: 0
   weights: 0
   weights: 0
@@ -295,105 +295,105 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl40-AllItems-DiscardedTenetsoftheSilverHand-209574"
  value: {
-  dps: 580.83051
-  tps: 595.33979
+  dps: 582.20245
+  tps: 596.71173
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Average-Default"
  value: {
-  dps: 579.18954
-  tps: 593.34705
+  dps: 580.72305
+  tps: 594.88056
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 370.58188
-  tps: 621.39624
+  dps: 370.82032
+  tps: 621.63467
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 208.44327
-  tps: 220.68164
+  dps: 208.65798
+  tps: 220.89635
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 221.3238
-  tps: 233.36325
+  dps: 221.60539
+  tps: 233.64484
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 200.91951
-  tps: 365.66596
+  dps: 200.93351
+  tps: 365.67996
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 108.48271
-  tps: 116.54191
+  dps: 108.54396
+  tps: 116.60316
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 134.31107
-  tps: 144.9202
+  dps: 134.38107
+  tps: 144.9902
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 370.03028
-  tps: 618.39129
+  dps: 370.27223
+  tps: 618.63324
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 209.02564
-  tps: 221.2166
+  dps: 209.22627
+  tps: 221.41723
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 222.44037
-  tps: 234.51665
+  dps: 222.72196
+  tps: 234.79824
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 201.74979
-  tps: 368.78925
+  dps: 201.77604
+  tps: 368.8155
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 108.89205
-  tps: 116.83847
+  dps: 108.94805
+  tps: 116.89447
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 134.42992
-  tps: 145.08383
+  dps: 134.49992
+  tps: 145.15383
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 547.24928
-  tps: 561.29634
+  dps: 548.20099
+  tps: 562.24804
  }
 }

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -50,12 +50,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestShockadin-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.68782
-  weights: -1.00718
+  weights: 0.69096
+  weights: -0.99341
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.28052
+  weights: 0.28484
   weights: 0
   weights: 0
   weights: 0
@@ -63,13 +63,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.24909
-  weights: 0.28394
+  weights: 2.43834
+  weights: 0.33555
   weights: 0
   weights: 0
-  weights: 0.28422
-  weights: -3.67905
-  weights: 6.86752
+  weights: 0.28552
+  weights: -3.71002
+  weights: 6.80558
   weights: 0
   weights: 0
   weights: 0
@@ -99,105 +99,105 @@ stat_weights_results: {
 dps_results: {
  key: "TestShockadin-Lvl40-AllItems-DiscardedTenetsoftheSilverHand-209574"
  value: {
-  dps: 536.88455
-  tps: 555.30437
+  dps: 538.66294
+  tps: 557.08275
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Average-Default"
  value: {
-  dps: 527.94542
-  tps: 545.97829
+  dps: 530.16691
+  tps: 548.19979
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 558.10261
-  tps: 844.87892
+  dps: 558.21172
+  tps: 844.98803
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 155.14618
-  tps: 169.52531
+  dps: 155.29754
+  tps: 169.67666
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 169.40072
-  tps: 185.09554
+  dps: 169.61192
+  tps: 185.30673
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 284.04702
-  tps: 468.70529
+  dps: 284.06102
+  tps: 468.71929
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 85.77947
-  tps: 95.01239
+  dps: 85.81447
+  tps: 95.04739
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 110.15917
-  tps: 120.88285
+  dps: 110.22917
+  tps: 120.95285
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 565.89431
-  tps: 855.49041
+  dps: 565.99286
+  tps: 855.58896
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 154.72386
-  tps: 169.15345
+  dps: 154.86465
+  tps: 169.29424
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 170.36924
-  tps: 186.09033
+  dps: 170.58043
+  tps: 186.30152
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 282.51149
-  tps: 468.53794
+  dps: 282.53949
+  tps: 468.56594
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 87.38778
-  tps: 96.6891
+  dps: 87.40878
+  tps: 96.7101
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 111.76669
-  tps: 122.5588
+  dps: 111.83669
+  tps: 122.6288
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 511.70011
-  tps: 529.99131
+  dps: 513.73312
+  tps: 532.02432
  }
 }

--- a/sim/priest/devouring_plague.go
+++ b/sim/priest/devouring_plague.go
@@ -68,10 +68,9 @@ func (priest *Priest) getDevouringPlagueConfig(rank int, cdTimer *core.Timer) co
 			},
 		},
 
-		BonusHitRating:   priest.shadowHitModifier(),
-		BonusCritRating:  0,
+		BonusHitRating: priest.shadowHitModifier(),
+
 		DamageMultiplier: 1,
-		CritMultiplier:   1,
 		ThreatMultiplier: priest.shadowThreatModifier(),
 
 		Dot: core.DotConfig{

--- a/sim/priest/mind_flay.go
+++ b/sim/priest/mind_flay.go
@@ -73,10 +73,9 @@ func (priest *Priest) newMindFlaySpellConfig(rank int, tickIdx int32) core.Spell
 			},
 		},
 
-		BonusHitRating:   priest.shadowHitModifier(),
-		BonusCritRating:  0,
+		BonusHitRating: priest.shadowHitModifier(),
+
 		DamageMultiplier: 1,
-		CritMultiplier:   1,
 
 		Dot: core.DotConfig{
 			Aura: core.Aura{
@@ -119,10 +118,9 @@ func (priest *Priest) newMindFlayTickSpell(rank int, numTicks int32) *core.Spell
 
 		Rank: rank,
 
-		BonusHitRating:   1, // Not an independent hit once initial lands
-		BonusCritRating:  0,
+		BonusHitRating: 1, // Not an independent hit once initial lands
+
 		DamageMultiplier: priest.forceOfWillDamageModifier() * priest.darknessDamageModifier(),
-		CritMultiplier:   1.0,
 		ThreatMultiplier: priest.shadowThreatModifier(),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/priest/mind_sear.go
+++ b/sim/priest/mind_sear.go
@@ -53,10 +53,9 @@ func (priest *Priest) newMindSearSpellConfig(tickIdx int32) core.SpellConfig {
 			},
 		},
 
-		BonusHitRating:   priest.shadowHitModifier(),
-		BonusCritRating:  0,
+		BonusHitRating: priest.shadowHitModifier(),
+
 		DamageMultiplier: 1,
-		CritMultiplier:   1,
 
 		Dot: core.DotConfig{
 			IsAOE: true,
@@ -89,7 +88,7 @@ func (priest *Priest) newMindSearSpellConfig(tickIdx int32) core.SpellConfig {
 
 func (priest *Priest) newMindSearTickSpell(numTicks int32) *core.Spell {
 	level := float64(priest.Level)
-	baseDamage := (9.456667 + 0.635108*level + 0.039063*level*level)
+	baseDamage := 9.456667 + 0.635108*level + 0.039063*level*level
 	baseDamageLow := baseDamage * .7 * priest.darknessDamageModifier()
 	baseDamageHigh := baseDamage * .78 * priest.darknessDamageModifier()
 	spellCoeff := 0.15 // classic penalty for mf having a slow effect
@@ -99,15 +98,17 @@ func (priest *Priest) newMindSearTickSpell(numTicks int32) *core.Spell {
 		SpellSchool: core.SpellSchoolShadow,
 		ProcMask:    core.ProcMaskProc | core.ProcMaskNotInSpellbook,
 
-		BonusHitRating:   1, // Not an independent hit once initial lands
-		BonusCritRating:  priest.forceOfWillCritRating(),
+		BonusHitRating:  1, // Not an independent hit once initial lands
+		BonusCritRating: priest.forceOfWillCritRating(),
+
+		CritMultiplier: priest.DefaultSpellCritMultiplier(),
+
 		DamageMultiplier: priest.forceOfWillDamageModifier(),
-		CritMultiplier:   1,
 		ThreatMultiplier: priest.shadowThreatModifier(),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			damage := sim.Roll(baseDamageLow, baseDamageHigh) + (spellCoeff * spell.SpellDamage())
-			result := spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMagicHit)
+			result := spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMagicHitAndCrit)
 
 			if result.Landed() {
 				priest.AddShadowWeavingStack(sim, target)

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.08575
+  weights: 0.10986
   weights: 0
-  weights: 0.29521
-  weights: 0
-  weights: 0
+  weights: 0.29677
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.19616
   weights: 0
   weights: 0
-  weights: 0.14248
+  weights: 0.19772
+  weights: 0
+  weights: 0
+  weights: 0.26753
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.49097
+  weights: 0.55792
   weights: 0
-  weights: 0.54452
-  weights: 0
-  weights: 0
+  weights: 0.54754
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.54452
+  weights: 0
+  weights: 0
+  weights: 0.54754
   weights: 0
   weights: 0.12662
-  weights: 0.61495
+  weights: 0.79653
   weights: 0
   weights: 0
   weights: 0
@@ -197,252 +197,252 @@ stat_weights_results: {
 dps_results: {
  key: "TestShadow-Lvl25-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 86.81805
-  tps: 90.27451
+  dps: 87.60776
+  tps: 91.06422
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 95.84877
-  tps: 98.68616
+  dps: 96.82543
+  tps: 99.66283
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-AllItems-IrradiatedGarments"
  value: {
-  dps: 99.39666
-  tps: 102.04287
+  dps: 100.52419
+  tps: 103.1704
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 90.62572
-  tps: 91.25428
+  dps: 91.53618
+  tps: 92.16474
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Average-Default"
  value: {
-  dps: 116.9362
-  tps: 117.47063
+  dps: 117.83638
+  tps: 118.37081
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 118.82138
-  tps: 208.9355
+  dps: 119.78768
+  tps: 209.9018
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 118.82138
-  tps: 119.3294
+  dps: 119.78768
+  tps: 120.2957
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 176.01959
-  tps: 177.80167
+  dps: 177.18063
+  tps: 178.96271
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 70.13545
-  tps: 156.5544
+  dps: 70.81758
+  tps: 157.23654
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 70.13545
-  tps: 73.49001
+  dps: 70.81758
+  tps: 74.17214
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 116.40394
-  tps: 122.55068
+  dps: 117.11367
+  tps: 123.2604
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Undead-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 117.37112
-  tps: 206.93488
+  dps: 118.28688
+  tps: 207.85064
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Undead-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 117.37112
-  tps: 117.90354
+  dps: 118.28688
+  tps: 118.81929
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Undead-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 177.53438
-  tps: 179.35174
+  dps: 178.6605
+  tps: 180.47786
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Undead-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 69.17612
-  tps: 155.00698
+  dps: 69.70947
+  tps: 155.54033
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Undead-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 69.17612
-  tps: 72.46508
+  dps: 69.70947
+  tps: 72.99843
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Undead-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 115.43398
-  tps: 121.71961
+  dps: 116.02042
+  tps: 122.30604
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 117.37112
-  tps: 117.90354
+  dps: 118.28688
+  tps: 118.81929
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 336.18263
-  tps: 287.58032
+  dps: 338.94317
+  tps: 289.89917
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 346.63022
-  tps: 295.34913
+  dps: 350.36765
+  tps: 298.48857
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 346.69862
-  tps: 295.28726
+  dps: 350.08365
+  tps: 298.13068
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 344.69411
-  tps: 263.43978
+  dps: 348.68083
+  tps: 266.78862
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Average-Default"
  value: {
-  dps: 486.71491
-  tps: 387.46045
+  dps: 490.29411
+  tps: 390.46699
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 509.1035
-  tps: 721.22504
+  dps: 512.94021
+  tps: 724.44789
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 509.1035
-  tps: 406.38735
+  dps: 512.94021
+  tps: 409.6102
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 602.32281
-  tps: 488.80008
+  dps: 609.29338
+  tps: 494.65536
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 272.02487
-  tps: 410.63828
+  dps: 272.61709
+  tps: 411.13575
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 272.02487
-  tps: 205.94815
+  dps: 272.61709
+  tps: 206.44562
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 459.44388
-  tps: 353.62009
+  dps: 461.51988
+  tps: 355.36393
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Undead-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 487.95092
-  tps: 697.71766
+  dps: 492.19979
+  tps: 701.28671
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Undead-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 487.95092
-  tps: 388.38712
+  dps: 492.19979
+  tps: 391.95617
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Undead-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 614.3803
-  tps: 499.84825
+  dps: 618.73165
+  tps: 503.50339
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Undead-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 259.6571
-  tps: 398.6737
+  dps: 260.40452
+  tps: 399.30153
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Undead-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 259.6571
-  tps: 195.19007
+  dps: 260.40452
+  tps: 195.8179
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Undead-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 468.23156
-  tps: 359.33593
+  dps: 469.66904
+  tps: 360.54341
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 487.95092
-  tps: 388.38712
+  dps: 492.19979
+  tps: 391.95617
  }
 }

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -40,10 +40,12 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 			},
 		},
 
-		BonusHitRating:   priest.shadowHitModifier(),
-		BonusCritRating:  priest.forceOfWillCritRating(),
+		BonusHitRating:  priest.shadowHitModifier(),
+		BonusCritRating: priest.forceOfWillCritRating(),
+
+		CritMultiplier: priest.DefaultSpellCritMultiplier(),
+
 		DamageMultiplier: priest.forceOfWillDamageModifier(),
-		CritMultiplier:   1,
 		ThreatMultiplier: priest.shadowThreatModifier(),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/priest/shadow_word_pain.go
+++ b/sim/priest/shadow_word_pain.go
@@ -58,9 +58,8 @@ func (priest *Priest) getShadowWordPainConfig(rank int) core.SpellConfig {
 		},
 
 		BonusHitRating:   priest.shadowHitModifier(),
-		BonusCritRating:  0,
 		DamageMultiplier: priest.forceOfWillDamageModifier() * priest.darknessDamageModifier(),
-		CritMultiplier:   1,
+
 		ThreatMultiplier: priest.shadowThreatModifier(),
 
 		Dot: core.DotConfig{

--- a/sim/priest/void_plague.go
+++ b/sim/priest/void_plague.go
@@ -40,10 +40,9 @@ func (priest *Priest) getVoidPlagueConfig() core.SpellConfig {
 			},
 		},
 
-		BonusHitRating:   priest.shadowHitModifier(),
-		BonusCritRating:  priest.forceOfWillCritRating(),
+		BonusHitRating: priest.shadowHitModifier(),
+
 		DamageMultiplier: priest.forceOfWillDamageModifier() * priest.darknessDamageModifier(),
-		CritMultiplier:   1,
 		ThreatMultiplier: priest.shadowThreatModifier(),
 
 		Dot: core.DotConfig{

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestAssassination-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.41292
-  weights: 0.71252
+  weights: 0.40991
+  weights: 0.70952
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37538
-  weights: 5.46134
-  weights: 3.83426
+  weights: 0.37264
+  weights: 5.4166
+  weights: 3.7709
   weights: 0
   weights: 0
   weights: 0
@@ -295,98 +295,98 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Lvl40-Average-Default"
  value: {
-  dps: 579.90492
-  tps: 411.73249
+  dps: 577.37097
+  tps: 409.93339
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 299.42694
-  tps: 212.59313
+  dps: 297.06124
+  tps: 210.91348
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 299.42694
-  tps: 212.59313
+  dps: 297.06124
+  tps: 210.91348
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 327.16211
-  tps: 232.2851
+  dps: 324.02786
+  tps: 230.05978
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 158.70322
-  tps: 112.67929
+  dps: 157.88056
+  tps: 112.0952
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 158.70322
-  tps: 112.67929
+  dps: 157.88056
+  tps: 112.0952
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 171.47267
-  tps: 121.7456
+  dps: 170.3213
+  tps: 120.92812
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 301.64052
-  tps: 214.16477
+  dps: 299.12263
+  tps: 212.37706
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 301.64052
-  tps: 214.16477
+  dps: 299.12263
+  tps: 212.37706
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 332.56508
-  tps: 236.12121
+  dps: 329.2248
+  tps: 233.74961
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 159.46734
-  tps: 113.22181
+  dps: 158.58706
+  tps: 112.59681
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 159.46734
-  tps: 113.22181
+  dps: 158.58706
+  tps: 112.59681
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 173.74882
-  tps: 123.36166
+  dps: 172.4983
+  tps: 122.47379
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 550.44755
-  tps: 390.81776
+  dps: 548.23755
+  tps: 389.24866
  }
 }

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -49,8 +49,9 @@ func (rogue *Rogue) registerEnvenom() {
 			return rogue.ComboPoints() > 0 && target.GetAuraByID(rogue.DeadlyPoison[0].ActionID).IsActive()
 		},
 
+		CritMultiplier: rogue.MeleeCritMultiplier(false),
+
 		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
-		CritMultiplier:   rogue.MeleeCritMultiplier(true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/rogue/shuriken_toss.go
+++ b/sim/rogue/shuriken_toss.go
@@ -34,8 +34,9 @@ func (rogue *Rogue) registerShurikenTossSpell() {
 			IgnoreHaste: true,
 		},
 
+		CritMultiplier: rogue.RangedCritMultiplier(false),
+
 		DamageMultiplier: 1,
-		CritMultiplier:   rogue.RangedCritMultiplier(true),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/shaman/ancestral_awakening.go
+++ b/sim/shaman/ancestral_awakening.go
@@ -13,13 +13,16 @@ func (shaman *Shaman) applyAncestralAwakening() {
 	}
 
 	shaman.AncestralAwakening = shaman.RegisterSpell(core.SpellConfig{
-		ActionID:         core.ActionID{SpellID: int32(proto.ShamanRune_RuneFeetAncestralAwakening)},
-		SpellSchool:      core.SpellSchoolNature,
-		ProcMask:         core.ProcMaskSpellHealing,
-		Flags:            core.SpellFlagHelpful | core.SpellFlagAPL,
+		ActionID:    core.ActionID{SpellID: int32(proto.ShamanRune_RuneFeetAncestralAwakening)},
+		SpellSchool: core.SpellSchoolNature,
+		ProcMask:    core.ProcMaskSpellHealing,
+		Flags:       core.SpellFlagHelpful | core.SpellFlagAPL,
+
+		CritMultiplier: 1,
+
 		DamageMultiplier: 1 * (1 + .02*float64(shaman.Talents.Purification)),
-		CritMultiplier:   1,
 		ThreatMultiplier: 1,
+
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			spell.CalcAndDealHealing(sim, target, shaman.ancestralHealingAmount, spell.OutcomeHealing)
 		},

--- a/sim/shaman/ancestral_guidance.go
+++ b/sim/shaman/ancestral_guidance.go
@@ -26,8 +26,9 @@ func (shaman *Shaman) applyAncestralGuidance() {
 		ProcMask:    core.ProcMaskSpellDamage,
 		Flags:       core.SpellFlagIgnoreResists,
 
+		CritMultiplier: 1,
+
 		DamageMultiplier: 1,
-		CritMultiplier:   1,
 		ThreatMultiplier: 1,
 	})
 

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.50453
+  weights: 2.16482
   weights: 0
-  weights: 0.84792
+  weights: 0.84649
   weights: 0
-  weights: 0.27063
-  weights: 0
-  weights: 0
-  weights: 0.57729
+  weights: 0.27102
   weights: 0
   weights: 0
-  weights: 8.89256
-  weights: 3.53148
+  weights: 0.57547
+  weights: 0
+  weights: 0
+  weights: 8.81094
+  weights: 3.37777
   weights: 0
   weights: 0
   weights: 0
@@ -400,57 +400,57 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 274.46491
-  tps: 253.65805
+  dps: 271.65947
+  tps: 250.23481
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 277.48255
-  tps: 252.9502
+  dps: 277.829
+  tps: 253.1084
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 283.24736
-  tps: 262.03245
+  dps: 281.14687
+  tps: 259.65251
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 292.78356
-  tps: 268.78278
+  dps: 290.22982
+  tps: 265.90214
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 254.03447
-  tps: 232.44234
+  dps: 250.93911
+  tps: 228.76293
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 286.38191
-  tps: 263.12635
+  dps: 285.46802
+  tps: 261.91922
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 303.59499
-  tps: 278.54349
+  dps: 301.97397
+  tps: 276.76628
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 200.84337
-  tps: 175.86624
+  dps: 201.56759
+  tps: 176.72317
  }
 }
 dps_results: {
@@ -463,98 +463,98 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Average-Default"
  value: {
-  dps: 615.2976
-  tps: 523.99737
+  dps: 615.20954
+  tps: 523.84327
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 754.78878
-  tps: 1181.22628
+  dps: 756.45365
+  tps: 1180.97369
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 604.74941
-  tps: 517.70039
+  dps: 601.51932
+  tps: 514.20847
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 653.1019
-  tps: 564.73293
+  dps: 653.85073
+  tps: 565.80448
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 404.25322
-  tps: 751.61756
+  dps: 407.35465
+  tps: 754.58347
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 325.89489
-  tps: 281.6771
+  dps: 324.63317
+  tps: 280.38919
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 441.83082
-  tps: 386.34127
+  dps: 440.00101
+  tps: 384.7683
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 759.38743
-  tps: 1193.92278
+  dps: 761.43736
+  tps: 1194.28382
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 607.99426
-  tps: 520.03419
+  dps: 606.72908
+  tps: 518.20069
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 697.75252
-  tps: 611.91285
+  dps: 696.41623
+  tps: 609.80826
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 406.27242
-  tps: 760.57126
+  dps: 409.80457
+  tps: 764.19328
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 336.02873
-  tps: 290.30909
+  dps: 334.95277
+  tps: 289.45494
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 469.80142
-  tps: 417.38527
+  dps: 466.61025
+  tps: 411.77713
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 609.80612
-  tps: 518.44949
+  dps: 608.48939
+  tps: 516.30882
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -149,11 +149,11 @@ stat_weights_results: {
  key: "TestEnhancement-Lvl40-StatWeights-Default"
  value: {
   weights: 1.08382
-  weights: 0.69466
+  weights: 0.67845
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42112
+  weights: 0.42881
   weights: 0
   weights: 0
   weights: 0
@@ -166,8 +166,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.49264
-  weights: 4.84289
-  weights: 7.83704
+  weights: 4.43409
+  weights: 7.72165
   weights: 0
   weights: 0
   weights: 0
@@ -463,266 +463,266 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 653.24046
-  tps: 695.72747
+  dps: 653.90587
+  tps: 696.398
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 633.89404
-  tps: 676.11198
+  dps: 634.6859
+  tps: 676.91006
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 644.9432
-  tps: 688.18784
+  dps: 645.68684
+  tps: 688.9366
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 664.06841
-  tps: 703.15965
+  dps: 665.91143
+  tps: 705.57947
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 633.88408
-  tps: 663.82687
+  dps: 635.01631
+  tps: 665.4097
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 615.73426
-  tps: 646.57257
+  dps: 616.54032
+  tps: 647.42264
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 644.40685
-  tps: 673.48337
+  dps: 646.3219
+  tps: 675.65935
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 663.35161
-  tps: 690.91065
+  dps: 664.42347
+  tps: 692.40638
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 638.29008
-  tps: 667.7002
+  dps: 639.39468
+  tps: 669.35435
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 650.25755
-  tps: 679.74046
+  dps: 651.09541
+  tps: 680.71549
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 564.65476
-  tps: 581.94095
+  dps: 565.73166
+  tps: 583.13679
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 631.47924
-  tps: 673.81807
+  dps: 632.18434
+  tps: 674.52926
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
-  dps: 883.88576
-  tps: 934.33924
+  dps: 884.97784
+  tps: 935.47556
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 400.12111
-  tps: 452.70463
+  dps: 400.05247
+  tps: 452.0027
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 392.03575
-  tps: 441.90147
+  dps: 392.49263
+  tps: 442.23398
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 422.32407
-  tps: 474.93061
+  dps: 421.73764
+  tps: 474.13717
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 256.31636
-  tps: 297.47309
+  dps: 256.52788
+  tps: 297.59031
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 246.65916
-  tps: 286.37266
+  dps: 246.49059
+  tps: 285.86731
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 255.59273
-  tps: 296.44734
+  dps: 255.22045
+  tps: 295.78469
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 400.12111
-  tps: 451.76572
+  dps: 400.05247
+  tps: 451.06379
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 392.03575
-  tps: 441.41215
+  dps: 392.49263
+  tps: 441.74466
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 422.32407
-  tps: 473.61087
+  dps: 421.73764
+  tps: 472.81743
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 256.31636
-  tps: 297.38283
+  dps: 256.52788
+  tps: 297.50005
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 246.65916
-  tps: 286.15177
+  dps: 246.49059
+  tps: 285.64642
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 255.59273
-  tps: 296.22544
+  dps: 255.22045
+  tps: 295.56279
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 414.21325
-  tps: 465.63257
+  dps: 413.79004
+  tps: 465.76881
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 406.1496
-  tps: 457.30446
+  dps: 406.00035
+  tps: 456.75545
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 433.73969
-  tps: 487.25774
+  dps: 434.29699
+  tps: 488.16046
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 263.48113
-  tps: 303.9145
+  dps: 263.00236
+  tps: 303.35867
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 254.0408
-  tps: 293.75996
+  dps: 254.05123
+  tps: 293.73543
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 260.93182
-  tps: 301.00415
+  dps: 261.62066
+  tps: 302.58448
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 414.21325
-  tps: 465.62448
+  dps: 413.79004
+  tps: 465.76072
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 406.1496
-  tps: 457.235
+  dps: 406.00035
+  tps: 456.686
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 433.73969
-  tps: 486.89675
+  dps: 434.29699
+  tps: 487.79946
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes RB/RB-ShortSingleTarget"
  value: {
-  dps: 263.48113
-  tps: 303.88268
+  dps: 263.00236
+  tps: 303.32685
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 254.0408
-  tps: 293.62662
+  dps: 254.05123
+  tps: 293.60208
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 260.93182
-  tps: 301.04408
+  dps: 261.62066
+  tps: 302.62441
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 817.47666
-  tps: 865.30488
+  dps: 818.36034
+  tps: 866.2839
  }
 }

--- a/sim/shaman/water_totems.go
+++ b/sim/shaman/water_totems.go
@@ -49,8 +49,9 @@ func (shaman *Shaman) newHealingStreamTotemSpellConfig(rank int) core.SpellConfi
 		ProcMask:    core.ProcMaskSpellHealing,
 		Flags:       core.SpellFlagHelpful | core.SpellFlagNoOnCastComplete | core.SpellFlagNoLogs | core.SpellFlagNoMetrics,
 
+		CritMultiplier: 1,
+
 		DamageMultiplier: 1 + (.02 * float64(shaman.Talents.Purification)) + 0.05*float64(shaman.Talents.RestorativeTotems),
-		CritMultiplier:   1,
 		ThreatMultiplier: 1 - (float64(shaman.Talents.HealingGrace) * 0.05),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warlock/corruption.go
+++ b/sim/warlock/corruption.go
@@ -37,11 +37,10 @@ func (warlock *Warlock) getCorruptionConfig(rank int) core.SpellConfig {
 			},
 		},
 
-		BonusHitRating:           float64(warlock.Talents.Suppression) * 2 * core.SpellHitRatingPerHitChance,
-		BonusCritRating:          0,
+		BonusHitRating: float64(warlock.Talents.Suppression) * 2 * core.SpellHitRatingPerHitChance,
+
 		DamageMultiplierAdditive: 1 + 0.02*float64(warlock.Talents.ShadowMastery),
 		DamageMultiplier:         1,
-		CritMultiplier:           1,
 		ThreatMultiplier:         1,
 
 		Dot: core.DotConfig{

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -99,99 +99,99 @@ stat_weights_results: {
 dps_results: {
  key: "TestArms-Lvl40-AllItems-BlackfathomAvenger'sMail"
  value: {
-  dps: 682.56671
-  tps: 595.61172
+  dps: 682.58839
+  tps: 595.62906
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 648.28945
-  tps: 565.26556
+  dps: 648.31801
+  tps: 565.28841
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 677.22539
-  tps: 590.44818
+  dps: 677.24708
+  tps: 590.46553
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-ElectromanticDevastator'sMail"
  value: {
-  dps: 616.2211
-  tps: 534.62359
+  dps: 616.27313
+  tps: 534.66522
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-ElectromanticStormbringer'sChain"
  value: {
-  dps: 572.64962
-  tps: 496.41776
+  dps: 572.67962
+  tps: 496.44176
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-H.A.Z.A.R.D.Suit"
  value: {
-  dps: 626.94812
-  tps: 542.85274
+  dps: 626.96546
+  tps: 542.86662
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 569.94229
-  tps: 494.25189
+  dps: 569.95963
+  tps: 494.26577
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 577.71095
-  tps: 501.35325
+  dps: 577.58954
+  tps: 501.25612
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 632.20601
-  tps: 548.04097
+  dps: 632.25804
+  tps: 548.0826
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 576.76518
-  tps: 500.59663
+  dps: 576.78966
+  tps: 500.61622
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 580.51719
-  tps: 503.38583
+  dps: 580.63635
+  tps: 503.48116
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 583.18472
-  tps: 501.92081
+  dps: 583.21056
+  tps: 501.94148
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 647.53464
-  tps: 564.29162
+  dps: 647.56244
+  tps: 564.31386
  }
 }
 dps_results: {
  key: "TestArms-Lvl40-Average-Default"
  value: {
-  dps: 832.05272
-  tps: 721.47343
+  dps: 832.09902
+  tps: 721.51047
  }
 }
 dps_results: {
@@ -281,7 +281,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 776.96331
-  tps: 675.2021
+  dps: 777.00667
+  tps: 675.23679
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -176,8 +176,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 516.72086
-  tps: 488.44254
+  dps: 516.71834
+  tps: 488.44052
  }
 }
 dps_results: {

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -134,10 +134,8 @@ func (warrior *Warrior) makeQueueSpellsAndAura(srcSpell *core.Spell) *core.Spell
 	})
 
 	queueSpell := warrior.RegisterSpell(core.SpellConfig{
-		ActionID:    srcSpell.WithTag(1),
-		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
+		ActionID: srcSpell.WithTag(1),
+		Flags:    core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
 
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
 			return warrior.curQueueAura != queueAura &&

--- a/sim/warrior/items.go
+++ b/sim/warrior/items.go
@@ -29,7 +29,6 @@ func init() {
 			},
 
 			DamageMultiplier: 1,
-			CritMultiplier:   1,
 
 			Dot: core.DotConfig{
 				Aura: core.Aura{
@@ -41,7 +40,6 @@ func init() {
 				OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 					dot.SnapshotBaseDamage = 5 * character.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical]
 					attackTable := dot.Spell.Unit.AttackTables[target.UnitIndex][dot.Spell.CastType]
-					dot.SnapshotCritChance = 0
 					dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable)
 				},
 


### PR DESCRIPTION
[common] CreateWeaponProcDamage() is now using the proper critMultiplier for non-magic procs

[common] "Shocking" equipment now always deals non-crit self-damage 
[common, core] Dismantle and Dragonbreath Chili procs can now properly crit, and Explosive use spell crit multiplier

[hunter, warrior] next attack queue spells no longer have a ProcMask set

[priest] Mind Sear and Shadow Word: Death can now crit

[rogue] Envenom and Shuriken Toss were wrongly benefiting from Lethality
