### PR TITLE
Feral: Various updates for related issues

### DIFF
--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -102,21 +102,21 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.04809
+  weights: 0.04007
   weights: 0
-  weights: 0.49196
-  weights: 0
-  weights: 0
+  weights: 0.48914
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.75488
   weights: 0
   weights: 0
-  weights: 0.00039
+  weights: 0.7297
+  weights: 0
+  weights: 0
+  weights: 0.00087
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.36641
+  weights: -0.19383
   weights: 0
-  weights: 0.76341
-  weights: 0
-  weights: 0
+  weights: 0.77253
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 7.052
-  weights: 3.09018
+  weights: 0
+  weights: 0
+  weights: 5.27105
+  weights: 3.39546
   weights: 0
   weights: 0
   weights: 0
@@ -197,85 +197,85 @@ stat_weights_results: {
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 120.38364
-  tps: 122.98904
+  dps: 134.56272
+  tps: 137.16812
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 111.80441
-  tps: 114.40981
+  dps: 122.4109
+  tps: 125.01629
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 100.31363
-  tps: 102.91902
+  dps: 113.44712
+  tps: 116.05251
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 109.9742
-  tps: 112.57959
+  dps: 124.13496
+  tps: 126.74036
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-InsulatedLeathers"
  value: {
-  dps: 101.56636
-  tps: 104.17176
+  dps: 110.101
+  tps: 112.7064
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 109.58206
-  tps: 112.18745
+  dps: 125.57937
+  tps: 128.18477
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-IrradiatedGarments"
  value: {
-  dps: 113.81949
-  tps: 116.42488
+  dps: 130.00892
+  tps: 132.61431
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-StormshroudArmor"
  value: {
-  dps: 86.40914
-  tps: 89.01453
+  dps: 95.44963
+  tps: 98.05502
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 118.37057
-  tps: 120.97597
+  dps: 133.68748
+  tps: 136.29287
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Average-Default"
  value: {
-  dps: 172.74839
-  tps: 175.3518
+  dps: 172.27174
+  tps: 174.48348
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 171.10415
-  tps: 223.21202
+  dps: 170.35693
+  tps: 212.72652
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 171.10415
-  tps: 173.70954
+  dps: 170.35693
+  tps: 172.47541
  }
 }
 dps_results: {
@@ -288,15 +288,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 117.30489
-  tps: 169.41276
+  dps: 119.13658
+  tps: 158.15025
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 117.30489
-  tps: 119.91028
+  dps: 119.13658
+  tps: 121.08727
  }
 }
 dps_results: {
@@ -309,15 +309,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 170.75322
-  tps: 222.86109
+  dps: 169.95978
+  tps: 215.36751
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 170.75322
-  tps: 173.35861
+  dps: 169.95978
+  tps: 172.23016
  }
 }
 dps_results: {
@@ -330,15 +330,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 117.09355
-  tps: 169.20142
+  dps: 119.12793
+  tps: 166.12442
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 117.09355
-  tps: 119.69894
+  dps: 119.12793
+  tps: 121.47776
  }
 }
 dps_results: {
@@ -351,92 +351,92 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 171.76045
-  tps: 174.36585
+  dps: 171.21082
+  tps: 173.52388
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 398.34543
-  tps: 410.66972
+  dps: 435.71158
+  tps: 447.79937
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 379.43492
-  tps: 391.79221
+  dps: 412.07801
+  tps: 424.25106
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 220.63449
-  tps: 230.27754
+  dps: 203.84679
+  tps: 212.18909
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 231.01157
-  tps: 240.78936
+  dps: 222.35315
+  tps: 231.11619
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 225.55787
-  tps: 235.65742
+  dps: 214.61985
+  tps: 223.72665
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 235.7711
-  tps: 245.63689
+  dps: 225.86568
+  tps: 234.61772
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 237.94271
-  tps: 247.67375
+  dps: 229.03256
+  tps: 237.64986
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 182.81434
-  tps: 192.50414
+  dps: 181.77132
+  tps: 190.53162
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 395.54807
-  tps: 407.87236
+  dps: 433.52708
+  tps: 445.66163
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Average-Default"
  value: {
-  dps: 546.4361
-  tps: 558.16952
+  dps: 556.53678
+  tps: 567.07584
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 511.87866
-  tps: 698.00088
+  dps: 529.3738
+  tps: 710.36595
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 511.87866
-  tps: 521.18477
+  dps: 529.3738
+  tps: 538.42341
  }
 }
 dps_results: {
@@ -449,36 +449,36 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 377.42027
-  tps: 457.58623
+  dps: 403.90932
+  tps: 484.07529
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 377.42027
-  tps: 381.42857
+  dps: 403.90932
+  tps: 407.91762
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 447.08427
-  tps: 453.79177
+  dps: 445.18922
+  tps: 451.89672
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 513.90745
-  tps: 700.41467
+  dps: 528.73693
+  tps: 709.79196
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 513.90745
-  tps: 523.23281
+  dps: 528.73693
+  tps: 537.78969
  }
 }
 dps_results: {
@@ -491,28 +491,28 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 375.97048
-  tps: 456.13644
+  dps: 402.18428
+  tps: 482.35024
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 375.97048
-  tps: 379.97878
+  dps: 402.18428
+  tps: 406.19258
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 445.50711
-  tps: 452.21462
+  dps: 442.60611
+  tps: 449.31361
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 543.99669
-  tps: 555.70224
+  dps: 552.74858
+  tps: 563.29827
  }
 }

--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -34,7 +34,7 @@ func NewBalanceDruid(character *core.Character, options *proto.Player) *BalanceD
 	}
 
 	moonkin.SelfBuffs.InnervateTarget = &proto.UnitReference{}
-	if balanceOptions.Options.InnervateTarget.Type == proto.UnitReference_Unknown {
+	if balanceOptions.Options.InnervateTarget == nil || balanceOptions.Options.InnervateTarget.Type == proto.UnitReference_Unknown {
 		moonkin.SelfBuffs.InnervateTarget = &proto.UnitReference{
 			Type: proto.UnitReference_Self,
 		}

--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -34,7 +34,11 @@ func NewBalanceDruid(character *core.Character, options *proto.Player) *BalanceD
 	}
 
 	moonkin.SelfBuffs.InnervateTarget = &proto.UnitReference{}
-	if balanceOptions.Options.InnervateTarget != nil {
+	if balanceOptions.Options.InnervateTarget.Type == proto.UnitReference_Unknown {
+		moonkin.SelfBuffs.InnervateTarget = &proto.UnitReference{
+			Type: proto.UnitReference_Self,
+		}
+	} else {
 		moonkin.SelfBuffs.InnervateTarget = balanceOptions.Options.InnervateTarget
 	}
 

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -80,6 +80,7 @@ type Druid struct {
 	EclipseAura              *core.Aura
 	FaerieFireAuras          core.AuraArray
 	FrenziedRegenerationAura *core.Aura
+	FurorAura                *core.Aura
 	FuryOfStormrageAura      *core.Aura
 	MaulQueueAura            *core.Aura
 	MoonkinFormAura          *core.Aura

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestFeral-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.60272
-  weights: 0.52423
+  weights: 0.33814
+  weights: 0.1963
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.27397
-  weights: 2.68425
-  weights: 2.23394
+  weights: 0.1537
+  weights: 5.63363
+  weights: 1.16789
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.83108
-  weights: 0.79336
+  weights: 0.83779
+  weights: 0.64081
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37776
-  weights: 4.93973
-  weights: 5.52948
+  weights: 0.38081
+  weights: 5.76702
+  weights: 5.66973
   weights: 0
   weights: 0
   weights: 0
@@ -197,658 +197,658 @@ stat_weights_results: {
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 255.47517
-  tps: 185.66905
+  dps: 137.53129
+  tps: 114.50297
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 275.45458
-  tps: 199.94268
+  dps: 125.10009
+  tps: 108.75728
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 213.57924
-  tps: 155.49191
+  dps: 97.83901
+  tps: 88.74597
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 211.70971
-  tps: 154.21722
+  dps: 98.92514
+  tps: 89.85545
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-InsulatedLeathers"
  value: {
-  dps: 250.29666
-  tps: 181.78451
+  dps: 111.64039
+  tps: 101.79506
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 212.75883
-  tps: 154.96638
+  dps: 98.40427
+  tps: 89.5453
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-IrradiatedGarments"
  value: {
-  dps: 210.70588
-  tps: 153.49607
+  dps: 97.6598
+  tps: 88.85652
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-StormshroudArmor"
  value: {
-  dps: 206.44898
-  tps: 149.45605
+  dps: 100.83096
+  tps: 91.36312
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 250.21992
-  tps: 181.87925
+  dps: 127.80659
+  tps: 108.24016
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Average-Default"
  value: {
-  dps: 276.74473
-  tps: 200.82288
+  dps: 130.53426
+  tps: 112.61194
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 131.57154
-  tps: 152.60823
+  dps: 24.85698
+  tps: 43.11674
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 131.57154
-  tps: 97.1931
+  dps: 24.85698
+  tps: 20.22283
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 164.25161
-  tps: 126.94693
+  dps: 117.09677
+  tps: 94.50597
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-NoBleed-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 64.22972
-  tps: 103.46242
+  dps: 9.02344
+  tps: 22.20167
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-NoBleed-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 64.22972
-  tps: 48.90868
+  dps: 9.02344
+  tps: 7.71634
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-NoBleed-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 81.4146
-  tps: 66.00072
+  dps: 44.46459
+  tps: 38.04979
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 131.57154
-  tps: 152.60823
+  dps: 24.85698
+  tps: 43.11674
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 131.57154
-  tps: 97.1931
+  dps: 24.85698
+  tps: 20.22283
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 164.25161
-  tps: 126.94693
+  dps: 117.09677
+  tps: 94.50597
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 64.22972
-  tps: 103.46242
+  dps: 9.02344
+  tps: 22.20167
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 64.22972
-  tps: 48.90868
+  dps: 9.02344
+  tps: 7.71634
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Default-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 81.4146
-  tps: 66.00072
+  dps: 44.46459
+  tps: 38.04979
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 131.57154
-  tps: 152.60823
+  dps: 24.85698
+  tps: 43.11674
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 131.57154
-  tps: 97.1931
+  dps: 24.85698
+  tps: 20.22283
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 164.25161
-  tps: 126.94693
+  dps: 117.09677
+  tps: 94.50597
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Flower-Aoe-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 64.22972
-  tps: 103.46242
+  dps: 9.02344
+  tps: 22.20167
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Flower-Aoe-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 64.22972
-  tps: 48.90868
+  dps: 9.02344
+  tps: 7.71634
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-p1-Flower-Aoe-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 81.4146
-  tps: 66.00072
+  dps: 44.46459
+  tps: 38.04979
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 128.99566
-  tps: 149.08666
+  dps: 20.59116
+  tps: 32.91375
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 128.99566
-  tps: 95.26673
+  dps: 20.59116
+  tps: 16.68863
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 164.02061
-  tps: 126.71523
+  dps: 99.77265
+  tps: 80.42411
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-NoBleed-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 63.44882
-  tps: 101.16252
+  dps: 7.61148
+  tps: 15.30072
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-NoBleed-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 63.44882
-  tps: 48.2611
+  dps: 7.61148
+  tps: 6.51833
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-NoBleed-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 79.08021
-  tps: 64.31238
+  dps: 37.23886
+  tps: 31.92699
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 128.99566
-  tps: 149.08666
+  dps: 20.59116
+  tps: 32.91375
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 128.99566
-  tps: 95.26673
+  dps: 20.59116
+  tps: 16.68863
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 164.02061
-  tps: 126.71523
+  dps: 99.77265
+  tps: 80.42411
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 63.44882
-  tps: 101.16252
+  dps: 7.61148
+  tps: 15.30072
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 63.44882
-  tps: 48.2611
+  dps: 7.61148
+  tps: 6.51833
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Default-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 79.08021
-  tps: 64.31238
+  dps: 37.23886
+  tps: 31.92699
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 128.99566
-  tps: 149.08666
+  dps: 20.59116
+  tps: 32.91375
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 128.99566
-  tps: 95.26673
+  dps: 20.59116
+  tps: 16.68863
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 164.02061
-  tps: 126.71523
+  dps: 99.77265
+  tps: 80.42411
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Flower-Aoe-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 63.44882
-  tps: 101.16252
+  dps: 7.61148
+  tps: 15.30072
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Flower-Aoe-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 63.44882
-  tps: 48.2611
+  dps: 7.61148
+  tps: 6.51833
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-p1-Flower-Aoe-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 79.08021
-  tps: 64.31238
+  dps: 37.23886
+  tps: 31.92699
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 202.90039
-  tps: 147.38669
+  dps: 116.08589
+  tps: 99.19947
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 597.78421
-  tps: 443.82703
+  dps: 602.68131
+  tps: 447.56706
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 624.31496
-  tps: 462.99615
+  dps: 630.67869
+  tps: 468.00232
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-HyperconductiveMender'sMeditation"
  value: {
-  dps: 491.70279
-  tps: 366.63038
+  dps: 496.77313
+  tps: 370.60944
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-HyperconductiveWizard'sAttire"
  value: {
-  dps: 491.38115
-  tps: 366.39727
+  dps: 495.76583
+  tps: 369.89398
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-InsulatedLeathers"
  value: {
-  dps: 538.41104
-  tps: 400.03685
+  dps: 542.0546
+  tps: 403.02923
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-InsulatedSorceror'sLeathers"
  value: {
-  dps: 491.69221
-  tps: 366.62559
+  dps: 496.912
+  tps: 370.64704
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-IrradiatedGarments"
  value: {
-  dps: 489.93398
-  tps: 365.32472
+  dps: 493.95097
+  tps: 368.55343
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-StormshroudArmor"
  value: {
-  dps: 497.54349
-  tps: 367.719
+  dps: 502.92896
+  tps: 371.54921
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 594.06051
-  tps: 441.11358
+  dps: 600.92419
+  tps: 446.27561
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Average-Default"
  value: {
-  dps: 745.71103
-  tps: 547.62229
+  dps: 752.06923
+  tps: 553.34593
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 388.42898
-  tps: 330.69166
+  dps: 398.29909
+  tps: 337.57017
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 388.42898
-  tps: 280.53166
+  dps: 398.29909
+  tps: 288.29842
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 511.69937
-  tps: 376.63322
+  dps: 556.14963
+  tps: 412.08406
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 219.47881
-  tps: 157.0238
+  dps: 223.87161
+  tps: 164.75451
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.47881
-  tps: 157.0238
+  dps: 223.87161
+  tps: 160.85518
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 279.7827
-  tps: 204.61496
+  dps: 302.53737
+  tps: 224.33321
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 388.42898
-  tps: 330.69166
+  dps: 398.29909
+  tps: 337.57017
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 388.42898
-  tps: 280.53166
+  dps: 398.29909
+  tps: 288.29842
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 511.69937
-  tps: 376.63322
+  dps: 556.14963
+  tps: 412.08406
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 219.47881
-  tps: 157.0238
+  dps: 223.87161
+  tps: 164.75451
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.47881
-  tps: 157.0238
+  dps: 223.87161
+  tps: 160.85518
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 279.7827
-  tps: 204.61496
+  dps: 302.53737
+  tps: 224.33321
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 388.42898
-  tps: 330.69166
+  dps: 398.29909
+  tps: 337.57017
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 388.42898
-  tps: 280.53166
+  dps: 398.29909
+  tps: 288.29842
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 511.69937
-  tps: 376.63322
+  dps: 556.14963
+  tps: 412.08406
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 219.47881
-  tps: 157.0238
+  dps: 223.87161
+  tps: 164.75451
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.47881
-  tps: 157.0238
+  dps: 223.87161
+  tps: 160.85518
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 279.7827
-  tps: 204.61496
+  dps: 302.53737
+  tps: 224.33321
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 385.08208
-  tps: 328.0094
+  dps: 397.1112
+  tps: 338.27732
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 385.08208
-  tps: 278.00615
+  dps: 397.1112
+  tps: 287.53218
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 507.27319
-  tps: 372.78586
+  dps: 551.18937
+  tps: 408.89311
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 219.6436
-  tps: 157.23449
+  dps: 222.62725
+  tps: 177.51852
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.6436
-  tps: 157.23449
+  dps: 222.62725
+  tps: 160.65949
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 279.83558
-  tps: 205.12091
+  dps: 305.57846
+  tps: 229.93143
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 385.08208
-  tps: 328.0094
+  dps: 397.1112
+  tps: 338.27732
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 385.08208
-  tps: 278.00615
+  dps: 397.1112
+  tps: 287.53218
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 507.27319
-  tps: 372.78586
+  dps: 551.18937
+  tps: 408.89311
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 219.6436
-  tps: 157.23449
+  dps: 222.62725
+  tps: 177.51852
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.6436
-  tps: 157.23449
+  dps: 222.62725
+  tps: 160.65949
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 279.83558
-  tps: 205.12091
+  dps: 305.57846
+  tps: 229.93143
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 385.08208
-  tps: 328.0094
+  dps: 397.1112
+  tps: 338.27732
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 385.08208
-  tps: 278.00615
+  dps: 397.1112
+  tps: 287.53218
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 507.27319
-  tps: 372.78586
+  dps: 551.18937
+  tps: 408.89311
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 219.6436
-  tps: 157.23449
+  dps: 222.62725
+  tps: 177.51852
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.6436
-  tps: 157.23449
+  dps: 222.62725
+  tps: 160.65949
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 279.83558
-  tps: 205.12091
+  dps: 305.57846
+  tps: 229.93143
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 375.13631
-  tps: 266.46742
+  dps: 399.91185
+  tps: 286.42555
  }
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -35,7 +35,7 @@ func NewFeralDruid(character *core.Character, options *proto.Player) *FeralDruid
 	}
 
 	cat.SelfBuffs.InnervateTarget = &proto.UnitReference{}
-	if feralOptions.Options.InnervateTarget.Type == proto.UnitReference_Unknown {
+	if feralOptions.Options.InnervateTarget == nil || feralOptions.Options.InnervateTarget.Type == proto.UnitReference_Unknown {
 		cat.SelfBuffs.InnervateTarget = &proto.UnitReference{
 			Type: proto.UnitReference_Self,
 		}

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -35,7 +35,11 @@ func NewFeralDruid(character *core.Character, options *proto.Player) *FeralDruid
 	}
 
 	cat.SelfBuffs.InnervateTarget = &proto.UnitReference{}
-	if feralOptions.Options.InnervateTarget != nil {
+	if feralOptions.Options.InnervateTarget.Type == proto.UnitReference_Unknown {
+		cat.SelfBuffs.InnervateTarget = &proto.UnitReference{
+			Type: proto.UnitReference_Self,
+		}
+	} else {
 		cat.SelfBuffs.InnervateTarget = feralOptions.Options.InnervateTarget
 	}
 

--- a/sim/druid/runes.go
+++ b/sim/druid/runes.go
@@ -175,7 +175,7 @@ func (druid *Druid) applySunfire() {
 
 	druid.SunfireDotMultiplier = 1
 
-	druid.Sunfire = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
+	druid.Sunfire = druid.RegisterSpell(Humanoid|Bear|Cat|Moonkin, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 414684},
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskSpellDamage,

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -35,6 +35,7 @@ func (druid *Druid) ApplyTalents() {
 	druid.registerMoonkinFormSpell()
 	druid.applyOmenOfClarity()
 	druid.applyBloodFrenzy()
+	druid.applyFuror()
 }
 
 func (druid *Druid) setupNaturesGrace() {
@@ -217,9 +218,25 @@ func (druid *Druid) applyBloodFrenzy() {
 	})
 }
 
-// TODO: Class druid omen
-func (druid *Druid) applyOmenOfClarity() {
+// We're using an aura so that the APL can know if the Druid has furor for powershifting logic
+func (druid *Druid) applyFuror() {
+	if druid.Talents.Furor == 0 {
+		return
+	}
 
+	spellID := []int32{0, 17056, 17058, 17059, 17060, 17061}[druid.Talents.Furor]
+
+	druid.FurorAura = druid.RegisterAura(core.Aura{
+		Label:    "Furor",
+		ActionID: core.ActionID{SpellID: spellID},
+		Duration: core.NeverExpires,
+		OnReset: func(aura *core.Aura, sim *core.Simulation) {
+			aura.Activate(sim)
+		},
+	})
+}
+
+func (druid *Druid) applyOmenOfClarity() {
 	if !druid.Talents.OmenOfClarity {
 		return
 	}

--- a/ui/balance_druid/apls/phase_2.apl.json
+++ b/ui/balance_druid/apls/phase_2.apl.json
@@ -4,6 +4,8 @@
     {"action":{"castSpell":{"spellId":{"spellId":8950,"rank":3}}},"doAtValue":{"const":{"val":"-3.09s"}}}
   ],
   "priorityList": [
+    {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":24858}}}}},"castSpell":{"spellId":{"spellId":24858}}}},
+    {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentManaPercent":{}},"rhs":{"const":{"val":"40%"}}}},"castSpell":{"spellId":{"spellId":29166}}}},
     {"action":{"autocastOtherCooldowns":{}}},
     {"action":{"condition":{"spellCanCast":{"spellId":{"spellId":417157}}},"castSpell":{"spellId":{"spellId":417157}}}},
     {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":417157}}},"castSpell":{"spellId":{"spellId":8950,"rank":3}}}},

--- a/ui/balance_druid/inputs.ts
+++ b/ui/balance_druid/inputs.ts
@@ -1,29 +1,2 @@
-import { Spec, UnitReference, UnitReference_Type } from '../core/proto/common.js';
-import * as InputHelpers from '../core/components/input_helpers.js';
-import { ActionId } from '../core/proto_utils/action_id.js';
-import { Player } from '../core/player.js';
-import { EventID } from '../core/typed_event.js';
-
 // Configuration for spec-specific UI elements on the settings tab.
 // These don't need to be in a separate file but it keeps things cleaner.
-
-export const SelfInnervate = InputHelpers.makeSpecOptionsBooleanIconInput<Spec.SpecBalanceDruid>({
-	fieldName: 'innervateTarget',
-	actionId: () => ActionId.fromSpellId(29166),
-	extraCssClasses: [
-		'within-raid-sim-hide',
-	],
-	getValue: (player: Player<Spec.SpecBalanceDruid>) => player.getSpecOptions().innervateTarget?.type == UnitReference_Type.Player,
-	setValue: (eventID: EventID, player: Player<Spec.SpecBalanceDruid>, newValue: boolean) => {
-		const newOptions = player.getSpecOptions();
-		newOptions.innervateTarget = UnitReference.create({
-			type: newValue ? UnitReference_Type.Player : UnitReference_Type.Unknown,
-			index: 0,
-		});
-		player.setSpecOptions(eventID, newOptions);
-	},
-});
-
-export const BalanceDruidRotationConfig = {
-	inputs: [],
-};

--- a/ui/balance_druid/sim.ts
+++ b/ui/balance_druid/sim.ts
@@ -4,24 +4,17 @@ import * as OtherInputs from '../core/components/other_inputs.js';
 import { Phase } from '../core/constants/other.js';
 import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.js';
 import { Player } from '../core/player.js';
-import {
-	Class,
-	Faction,
-	Race,
-	Spec,
-	Stat,
-} from '../core/proto/common.js';
+import { Class, Faction, Race, Spec, Stat } from '../core/proto/common.js';
 import { Stats } from '../core/proto_utils/stats.js';
 import { getSpecIcon, specNames } from '../core/proto_utils/utils.js';
-import * as DruidInputs from './inputs.js';
+// import * as DruidInputs from './inputs.js';
 import * as Presets from './presets.js';
 
 const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	cssClass: 'balance-druid-sim-ui',
 	cssScheme: 'druid',
 	// List any known bugs / issues here, and they'll be shown on the site.
-	knownIssues: [
-	],
+	knownIssues: [],
 
 	// All stats for which EP should be calculated.
 	epStats: [
@@ -58,15 +51,15 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 		gear: Presets.DefaultGear.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap({
-			[Stat.StatIntellect]:	0.17,
-			[Stat.StatSpirit]: 		0.00,
-			[Stat.StatSpellPower]: 	1,
+			[Stat.StatIntellect]: 0.17,
+			[Stat.StatSpirit]: 0.0,
+			[Stat.StatSpellPower]: 1,
 			[Stat.StatArcanePower]: 0.67,
 			[Stat.StatNaturePower]: 0.33,
-			[Stat.StatSpellHit]: 	8.24,
-			[Stat.StatSpellCrit]: 	5.86,
-			[Stat.StatSpellHaste]: 	0.8,
-			[Stat.StatMP5]: 		0.00,
+			[Stat.StatSpellHit]: 8.24,
+			[Stat.StatSpellCrit]: 5.86,
+			[Stat.StatSpellHaste]: 0.8,
+			[Stat.StatMP5]: 0.0,
 		}),
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
@@ -83,12 +76,9 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	},
 
 	// IconInputs to include in the 'Player' section on the settings tab.
-	playerIconInputs: [
-		DruidInputs.SelfInnervate,
-	],
+	playerIconInputs: [],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
-	includeBuffDebuffInputs: [
-	],
+	includeBuffDebuffInputs: [],
 	excludeBuffDebuffInputs: [
 		BuffDebuffInputs.SpellISBDebuff,
 		BuffDebuffInputs.SpellScorchDebuff,
@@ -101,10 +91,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [
-			OtherInputs.ReactionTime,
-			OtherInputs.DistanceFromTarget,
-		],
+		inputs: [OtherInputs.ReactionTime, OtherInputs.DistanceFromTarget],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.
@@ -113,20 +100,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 
 	presets: {
 		// Preset talents that the user can quickly select.
-		talents: [
-			...Presets.TalentPresets[Phase.Phase2],
-			...Presets.TalentPresets[Phase.Phase1],
-		],
-		rotations: [
-			...Presets.APLPresets[Phase.Phase2],
-			...Presets.APLPresets[Phase.Phase1],
-		],
+		talents: [...Presets.TalentPresets[Phase.Phase2], ...Presets.TalentPresets[Phase.Phase1]],
+		rotations: [...Presets.APLPresets[Phase.Phase2], ...Presets.APLPresets[Phase.Phase1]],
 		// Preset gear configurations that the user can quickly select.
-		gear: [
-			Presets.GearBlank,
-			...Presets.GearPresets[Phase.Phase2],
-			...Presets.GearPresets[Phase.Phase1],
-		],
+		gear: [Presets.GearBlank, ...Presets.GearPresets[Phase.Phase2], ...Presets.GearPresets[Phase.Phase1]],
 	},
 
 	autoRotation: player => {
@@ -160,7 +137,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 			},
 		},
 	],
-})
+});
 
 // noinspection TypeScriptValidateTypes
 export class BalanceDruidSimUI extends IndividualSimUI<Spec.SpecBalanceDruid> {

--- a/ui/feral_druid/apls/phase_2.apl.json
+++ b/ui/feral_druid/apls/phase_2.apl.json
@@ -4,14 +4,17 @@
     {"action":{"activateAura":{"auraId":{"spellId":407988}}},"doAtValue":{"const":{"val":"-8s"}}}
   ],
   "priorityList": [
+    {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":768}}}}},"castSpell":{"spellId":{"spellId":768}}}},
+    {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentManaPercent":{}},"rhs":{"const":{"val":"40%"}}}},{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"14"}}}}]}},"castSpell":{"spellId":{"spellId":29166}}}},
+    {"action":{"autocastOtherCooldowns":{}}},
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":407988}}}}},"castSpell":{"spellId":{"spellId":407988}}}},
     {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"20"}}}},"castSpell":{"spellId":{"spellId":417045}}}},
-    {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":417045}}},"autocastOtherCooldowns":{}}},
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":409828}}}}},"castSpell":{"spellId":{"spellId":409828}}}},
-    {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":409828}}},{"auraIsActive":{"auraId":{"spellId":16870}}}]}},"castSpell":{"spellId":{"spellId":8992}}}},
-    {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":409828}}},{"cmp":{"op":"OpEq","lhs":{"currentComboPoints":{}},"rhs":{"const":{"val":"5"}}}},{"cmp":{"op":"OpGe","lhs":{"auraRemainingTime":{"auraId":{"spellId":407988}}},"rhs":{"const":{"val":"7"}}}}]}},"castSpell":{"spellId":{"spellId":9493}}}},
-    {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":409828}}},{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":1823}}}}}]}},"castSpell":{"spellId":{"spellId":1823}}}},
-    {"action":{"condition":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":409828}}},"castSpell":{"spellId":{"spellId":8992}}}},
-    {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"14"}}}},{"cmp":{"op":"OpGe","lhs":{"currentMana":{}},"rhs":{"const":{"val":"500"}}}}]}},"castSpell":{"spellId":{"spellId":768}}}}
+    {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":16870}}}]}},"castSpell":{"spellId":{"spellId":8992}}}},
+    {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentComboPoints":{}},"rhs":{"const":{"val":"5"}}}},{"cmp":{"op":"OpGe","lhs":{"auraRemainingTime":{"auraId":{"spellId":407988}}},"rhs":{"const":{"val":"7"}}}}]}},"castSpell":{"spellId":{"spellId":9493}}}},
+    {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":414684}}}}},"castSpell":{"spellId":{"spellId":414684}}}},
+    {"action":{"condition":{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":1823}}}}},"castSpell":{"spellId":{"spellId":1823}}}},
+    {"action":{"castSpell":{"spellId":{"spellId":8992}}}},
+    {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"14"}}}},{"cmp":{"op":"OpGe","lhs":{"currentMana":{}},"rhs":{"const":{"val":"500"}}}},{"auraIsActive":{"auraId":{"spellId":17061,"rank":5}}}]}},"castSpell":{"spellId":{"spellId":768}}}}
   ]
 }

--- a/ui/feral_druid/inputs.ts
+++ b/ui/feral_druid/inputs.ts
@@ -1,29 +1,8 @@
-import { Player } from '../core/player.js';
-import { Spec, UnitReference, UnitReference_Type as UnitType } from '../core/proto/common.js';
-import { ActionId } from '../core/proto_utils/action_id.js';
-import { EventID } from '../core/typed_event.js';
-
 import * as InputHelpers from '../core/components/input_helpers.js';
+import { Spec } from '../core/proto/common.js';
 
 // Configuration for spec-specific UI elements on the settings tab.
 // These don't need to be in a separate file but it keeps things cleaner.
-
-export const SelfInnervate = InputHelpers.makeSpecOptionsBooleanIconInput<Spec.SpecFeralDruid>({
-	fieldName: 'innervateTarget',
-	actionId: () => ActionId.fromSpellId(29166),
-	extraCssClasses: [
-		'within-raid-sim-hide',
-	],
-	getValue: (player: Player<Spec.SpecFeralDruid>) => player.getSpecOptions().innervateTarget?.type == UnitType.Player,
-	setValue: (eventID: EventID, player: Player<Spec.SpecFeralDruid>, newValue: boolean) => {
-		const newOptions = player.getSpecOptions();
-		newOptions.innervateTarget = UnitReference.create({
-			type: newValue ? UnitType.Player : UnitType.Unknown,
-			index: 0,
-		});
-		player.setSpecOptions(eventID, newOptions);
-	},
-});
 
 export const LatencyMs = InputHelpers.makeSpecOptionsNumberInput<Spec.SpecFeralDruid>({
 	fieldName: 'latencyMs',
@@ -34,9 +13,9 @@ export const LatencyMs = InputHelpers.makeSpecOptionsNumberInput<Spec.SpecFeralD
 export const AssumeBleedActive = InputHelpers.makeSpecOptionsBooleanInput<Spec.SpecFeralDruid>({
 	fieldName: 'assumeBleedActive',
 	label: 'Assume Bleed Always Active',
-	labelTooltip: 'Assume bleed always exists for \'Rend and Tear\' calculations. Otherwise will only calculate based on own rip/rake/lacerate.',
+	labelTooltip: "Assume bleed always exists for 'Rend and Tear' calculations. Otherwise will only calculate based on own rip/rake/lacerate.",
 	extraCssClasses: ['within-raid-sim-hide'],
-})
+});
 
 export const FeralDruidRotationConfig = {
 	inputs: [

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -92,7 +92,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	},
 
 	// IconInputs to include in the 'Player' section on the settings tab.
-	playerIconInputs: [DruidInputs.SelfInnervate],
+	playerIconInputs: [],
 
 	// Inputs to include in the 'Rotation' section on the settings tab.
 	rotationInputs: DruidInputs.FeralDruidRotationConfig,


### PR DESCRIPTION
- [x] [Sunfire castable in cat and bear forms](https://github.com/wowsims/sod/issues/440)
- [x] [Druid shifts back into cat form after casting mana potion](https://github.com/wowsims/sod/issues/430) This was actually just an APL tweak to prioritize staying in cat form if it's not active
- [x] [Druid shifts back into cat form after casting Innervate on self](https://github.com/wowsims/sod/issues/427) Also removed the self innervate toggle in favor of APL controls
- [x] [Furor exposed as an error for powershifting conditions](https://github.com/wowsims/sod/issues/426)
- [x] Also fixed an issue where haste hands on-use was being held (caused by rotation)
- [x] Lots of tweaks to the feral rotation gains ~25 dps