### PR TITLE
add defense type to weapon proc spells

### DIFF
--- a/sim/common/itemhelpers/weaponprocs.go
+++ b/sim/common/itemhelpers/weaponprocs.go
@@ -17,6 +17,7 @@ func CreateWeaponProcDamage(itemId int32, itemName string, ppm float64, spellId 
 			ActionID:    core.ActionID{SpellID: spellId},
 			SpellSchool: school,
 			ProcMask:    core.ProcMaskEmpty,
+			DefenseType: defType,
 
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,


### PR DESCRIPTION
re https://github.com/wowsims/sod/issues/443

Looks like weapon proc spells were missing a `DefenseType` assignment after https://github.com/wowsims/sod/pull/438