### PR TITLE
DP fix

### DIFF
--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestAssassination-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.33599
-  weights: 0.53083
+  weights: 0.336
+  weights: 0.53084
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.30544
-  weights: 2.13016
-  weights: 2.24311
+  weights: 0.30546
+  weights: 2.25275
+  weights: 2.2373
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestAssassination-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.40991
-  weights: 0.70952
+  weights: 0.4105
+  weights: 0.7101
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37264
-  weights: 5.4166
-  weights: 3.7709
+  weights: 0.37318
+  weights: 5.36032
+  weights: 3.76522
   weights: 0
   weights: 0
   weights: 0
@@ -197,196 +197,196 @@ stat_weights_results: {
 dps_results: {
  key: "TestAssassination-Lvl25-Average-Default"
  value: {
-  dps: 279.28085
-  tps: 198.2894
+  dps: 279.26775
+  tps: 198.2801
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 141.65813
-  tps: 100.57728
+  dps: 141.75307
+  tps: 100.64468
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 141.65813
-  tps: 100.57728
+  dps: 141.75307
+  tps: 100.64468
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 151.15408
-  tps: 107.31939
+  dps: 150.67933
+  tps: 106.98232
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 70.45631
-  tps: 50.02398
+  dps: 70.47462
+  tps: 50.03698
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 70.45631
-  tps: 50.02398
+  dps: 70.47462
+  tps: 50.03698
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 73.89603
-  tps: 52.46618
+  dps: 73.5965
+  tps: 52.25351
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 141.23497
-  tps: 100.27683
+  dps: 141.37181
+  tps: 100.37398
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 141.23497
-  tps: 100.27683
+  dps: 141.37181
+  tps: 100.37398
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 151.52223
-  tps: 107.58078
+  dps: 150.94534
+  tps: 107.17119
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 70.15017
-  tps: 49.80662
+  dps: 70.15003
+  tps: 49.80652
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 70.15017
-  tps: 49.80662
+  dps: 70.15003
+  tps: 49.80652
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 74.32925
-  tps: 52.77377
+  dps: 73.99483
+  tps: 52.53633
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 265.65621
-  tps: 188.61591
+  dps: 266.16067
+  tps: 188.97408
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Average-Default"
  value: {
-  dps: 577.37097
-  tps: 409.93339
+  dps: 577.39556
+  tps: 409.95085
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 297.06124
-  tps: 210.91348
+  dps: 297.47316
+  tps: 211.20595
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 297.06124
-  tps: 210.91348
+  dps: 297.47316
+  tps: 211.20595
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 324.02786
-  tps: 230.05978
+  dps: 323.18624
+  tps: 229.46223
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 157.88056
-  tps: 112.0952
+  dps: 158.13456
+  tps: 112.27554
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 157.88056
-  tps: 112.0952
+  dps: 158.13456
+  tps: 112.27554
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 170.3213
-  tps: 120.92812
+  dps: 170.00439
+  tps: 120.70312
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 299.12263
-  tps: 212.37706
+  dps: 299.73458
+  tps: 212.81155
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 299.12263
-  tps: 212.37706
+  dps: 299.73458
+  tps: 212.81155
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 329.2248
-  tps: 233.74961
+  dps: 328.22697
+  tps: 233.04115
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 158.58706
-  tps: 112.59681
+  dps: 158.84694
+  tps: 112.78133
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 158.58706
-  tps: 112.59681
+  dps: 158.84694
+  tps: 112.78133
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 172.4983
-  tps: 122.47379
+  dps: 172.05571
+  tps: 122.15955
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 548.23755
-  tps: 389.24866
+  dps: 548.64477
+  tps: 389.53779
  }
 }

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestCombat-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.24453
-  weights: 0.45828
+  weights: 0.24454
+  weights: 0.45829
   weights: 0
   weights: 0
   weights: 0
@@ -116,8 +116,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.2223
-  weights: 1.50013
+  weights: 0.22231
+  weights: 1.50398
   weights: 1.75981
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestCombat-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.3884
-  weights: 0.61949
+  weights: 0.3883
+  weights: 0.62197
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.35309
-  weights: 4.07901
-  weights: 3.72544
+  weights: 0.353
+  weights: 4.06654
+  weights: 3.72802
   weights: 0
   weights: 0
   weights: 0
@@ -197,196 +197,196 @@ stat_weights_results: {
 dps_results: {
  key: "TestCombat-Lvl25-Average-Default"
  value: {
-  dps: 208.06652
-  tps: 147.72723
+  dps: 208.0693
+  tps: 147.7292
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 49.90598
-  tps: 35.43325
+  dps: 49.90074
+  tps: 35.42952
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 49.90598
-  tps: 35.43325
+  dps: 49.90074
+  tps: 35.42952
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 52.56126
-  tps: 37.31849
+  dps: 52.51764
+  tps: 37.28753
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 24.83676
-  tps: 17.6341
+  dps: 24.83368
+  tps: 17.63191
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 24.83676
-  tps: 17.6341
+  dps: 24.83368
+  tps: 17.63191
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 26.66235
-  tps: 18.93027
+  dps: 26.6353
+  tps: 18.91106
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 49.80055
-  tps: 35.35839
+  dps: 49.79923
+  tps: 35.35746
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 49.80055
-  tps: 35.35839
+  dps: 49.79923
+  tps: 35.35746
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 52.38189
-  tps: 37.19114
+  dps: 52.33827
+  tps: 37.16017
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 24.75978
-  tps: 17.57944
+  dps: 24.75913
+  tps: 17.57898
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 24.75978
-  tps: 17.57944
+  dps: 24.75913
+  tps: 17.57898
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 26.41539
-  tps: 18.75492
+  dps: 26.38833
+  tps: 18.73572
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 195.72937
-  tps: 138.96785
+  dps: 195.84745
+  tps: 139.05169
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Average-Default"
  value: {
-  dps: 540.62851
-  tps: 383.84624
+  dps: 540.58015
+  tps: 383.81191
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 250.98828
-  tps: 178.20168
+  dps: 250.95547
+  tps: 178.17838
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 218.3513
-  tps: 155.02942
+  dps: 218.31849
+  tps: 155.00613
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 284.06546
-  tps: 201.68647
+  dps: 284.41598
+  tps: 201.93535
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 136.7624
-  tps: 97.1013
+  dps: 136.70458
+  tps: 97.06025
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 119.32213
-  tps: 84.71871
+  dps: 119.26431
+  tps: 84.67766
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 154.11677
-  tps: 109.42291
+  dps: 154.22213
+  tps: 109.49771
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 254.0796
-  tps: 180.39652
+  dps: 254.15692
+  tps: 180.45141
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 219.06151
-  tps: 155.53367
+  dps: 219.13883
+  tps: 155.58857
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 283.40657
-  tps: 201.21866
+  dps: 283.36175
+  tps: 201.18684
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 138.07285
-  tps: 98.03172
+  dps: 138.06522
+  tps: 98.0263
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 119.47961
-  tps: 84.83052
+  dps: 119.47198
+  tps: 84.82511
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 152.35068
-  tps: 108.16899
+  dps: 152.23927
+  tps: 108.08988
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 519.15295
-  tps: 368.59859
+  dps: 519.27062
+  tps: 368.68214
  }
 }

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -38,8 +38,6 @@ const (
 	DeadlyBrewProc
 )
 
-var WoundPoisonActionID = core.ActionID{SpellID: 13219}
-
 func (rogue *Rogue) GetInstantPoisonProcChance() float64 {
 	return (0.2 + rogue.improvedPoisons()) * (1 + rogue.instantPoisonProcChanceBonus)
 }
@@ -114,7 +112,6 @@ func (rogue *Rogue) applyDeadlyBrewDeadly() {
 			if spell == rogue.DeadlyPoison[DeadlyBrewProc] {
 				return
 			}
-
 			rogue.DeadlyPoison[DeadlyBrewProc].Cast(sim, result.Target)
 		},
 	})
@@ -207,6 +204,63 @@ func (rogue *Rogue) registerInstantPoisonSpell() {
 }
 
 func (rogue *Rogue) registerDeadlyPoisonSpell() {
+	baseDamageTick := map[int32]float64{
+		25: 9,
+		40: 13,
+		50: 20,
+		60: 27,
+	}[rogue.Level]
+	spellID := map[int32]int32{
+		25: 2823,
+		40: 2824,
+		50: 11355,
+		60: 11356,
+	}[rogue.Level]
+
+	hasDeadlyBrew := rogue.HasRune(proto.RogueRune_RuneDeadlyBrew)
+
+	rogue.deadlyPoisonTick = rogue.RegisterSpell(core.SpellConfig{
+		ActionID:    core.ActionID{SpellID: spellID},
+		SpellSchool: core.SpellSchoolNature,
+		DefenseType: core.DefenseTypeMagic,
+		ProcMask:    core.ProcMaskWeaponProc,
+		Flags:       core.SpellFlagPoison,
+
+		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		ThreatMultiplier: 1,
+
+		Dot: core.DotConfig{
+			Aura: core.Aura{
+				Label:     "DeadlyPoison",
+				MaxStacks: 5,
+				Duration:  time.Second * 12,
+			},
+			NumberOfTicks: 4,
+			TickLength:    time.Second * 3,
+
+			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, applyStack bool) {
+				if !applyStack {
+					return
+				}
+
+				// only the first stack snapshots the multiplier
+				if dot.GetStacks() == 1 {
+					attackTable := dot.Spell.Unit.AttackTables[target.UnitIndex][dot.Spell.CastType]
+					dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable)
+					dot.SnapshotBaseDamage = 0
+				}
+
+				// each stack snapshots the AP it was applied with
+				// 3.6% per stack for all ticks, or 0.9% per stack and tick
+				dot.SnapshotBaseDamage += baseDamageTick + core.TernaryFloat64(hasDeadlyBrew, 0.009*dot.Spell.MeleeAttackPower(), 0)
+			},
+
+			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickCounted)
+			},
+		},
+	})
+
 	rogue.DeadlyPoison = [3]*core.Spell{
 		rogue.makeDeadlyPoison(NormalProc),
 		rogue.makeDeadlyPoison(ShivProc),
@@ -217,7 +271,7 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 func (rogue *Rogue) registerWoundPoisonSpell() {
 	woundPoisonDebuffAura := core.Aura{
 		Label:     "WoundPoison-" + strconv.Itoa(int(rogue.Index)),
-		ActionID:  WoundPoisonActionID,
+		ActionID:  core.ActionID{SpellID: 13219},
 		MaxStacks: 5,
 		Duration:  time.Second * 15,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
@@ -276,7 +330,7 @@ func (rogue *Rogue) makeInstantPoison(procSource PoisonProcSource) *core.Spell {
 		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
 		ThreatMultiplier: 1,
 
-		BonusHitRating: core.Ternary[float64](procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
+		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(baseDamageByLevel, baseDamageByLevel+damageVariance) + core.TernaryFloat64(hasDeadlyBrew, 0.03*spell.MeleeAttackPower(), 0)
@@ -286,63 +340,10 @@ func (rogue *Rogue) makeInstantPoison(procSource PoisonProcSource) *core.Spell {
 }
 
 func (rogue *Rogue) makeDeadlyPoison(procSource PoisonProcSource) *core.Spell {
-	baseDamageTick := map[int32]float64{
-		25: 9,
-		40: 13,
-		50: 20,
-		60: 27,
-	}[rogue.Level]
-	spellID := map[int32]int32{
-		25: 2823,
-		40: 2824,
-		50: 11355,
-		60: 11356,
-	}[rogue.Level]
-
-	hasDeadlyBrew := rogue.HasRune(proto.RogueRune_RuneDeadlyBrew)
-
 	return rogue.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: spellID, Tag: int32(procSource)},
-		SpellSchool: core.SpellSchoolNature,
-		DefenseType: core.DefenseTypeMagic,
-		ProcMask:    core.ProcMaskWeaponProc,
-		Flags:       core.SpellFlagPoison,
+		ActionID: core.ActionID{SpellID: rogue.deadlyPoisonTick.SpellID, Tag: int32(procSource)},
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
-		ThreatMultiplier: 1,
-
-		BonusHitRating: core.Ternary[float64](procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
-
-		Dot: core.DotConfig{
-			Aura: core.Aura{
-				Label:     "DeadlyPoison",
-				MaxStacks: 5,
-				Duration:  time.Second * 12,
-			},
-			NumberOfTicks: 4,
-			TickLength:    time.Second * 3,
-
-			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, applyStack bool) {
-				if !applyStack {
-					return
-				}
-
-				// only the first stack snapshots the multiplier
-				if dot.GetStacks() == 1 {
-					attackTable := dot.Spell.Unit.AttackTables[target.UnitIndex][dot.Spell.CastType]
-					dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable)
-					dot.SnapshotBaseDamage = 0
-				}
-
-				// each stack snapshots the AP it was applied with
-				// 3.6% per stack for all ticks, or 0.9% per stack and tick
-				dot.SnapshotBaseDamage += baseDamageTick + core.TernaryFloat64(hasDeadlyBrew, 0.009*dot.Spell.MeleeAttackPower(), 0)
-			},
-
-			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTick)
-			},
-		},
+		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)
@@ -351,7 +352,7 @@ func (rogue *Rogue) makeDeadlyPoison(procSource PoisonProcSource) *core.Spell {
 				return
 			}
 
-			dot := spell.Dot(target)
+			dot := rogue.deadlyPoisonTick.Dot(target)
 
 			dot.ApplyOrRefresh(sim)
 			if dot.GetStacks() < dot.MaxStacks {
@@ -375,7 +376,7 @@ func (rogue *Rogue) makeWoundPoison(procSource PoisonProcSource) *core.Spell {
 		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
 		ThreatMultiplier: 1,
 
-		BonusHitRating: core.Ternary[float64](procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
+		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMagicHit)

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -74,6 +74,7 @@ type Rogue struct {
 	StealthAura          *core.Aura
 	WaylayAuras          core.AuraArray
 
+	deadlyPoisonTick       *core.Spell
 	woundPoisonDebuffAuras core.AuraArray
 
 	finishingMoveEffectApplier func(sim *core.Simulation, numPoints int32)


### PR DESCRIPTION
[rogue] use a common dot spell for all DP applications, so it doesn't matter how DP was applied

Fixes https://github.com/wowsims/sod/issues/447.

If applied via Deadly Brew or Shiv, DP applications and DP ticks can now be differentiated. Either the accounting isn't working as I'm expecting, or Deadly Brew somehow casts more DP applications than IP hits, which sounds wrong.

That's pre-existing, however, so not in this PR.