### PR TITLE
Implemented Lock and Load helmet rune for hunters, added frost trap a…

### DIFF
--- a/assets/database/db.json
+++ b/assets/database/db.json
@@ -9839,6 +9839,7 @@
 {"id":415352,"name":"Engrave Belt - Melee Specialist","icon":"inv_axe_03","class":2,"type":8,"requiresLevel":1},
 {"id":415370,"name":"Engrave Chest - Lone Wolf","icon":"ability_mount_whitedirewolf","class":2,"type":5,"requiresLevel":1},
 {"id":415399,"name":"Engrave Pants - Sniper Training","icon":"ability_hunter_longshots","class":2,"type":9,"requiresLevel":1},
+{"id":415413,"name":"Engrave Helm - Lock and Load","icon":"ability_hunter_lockandload","class":2,"type":1,"requiresLevel":1},
 {"id":415739,"name":"Engrave Chest - Strength of Soul","icon":"spell_holy_greaterblessingofsanctuary","class":5,"type":5,"requiresLevel":1},
 {"id":417046,"name":"Engrave Boots - King of the Jungle","icon":"ability_druid_kingofthejungle","class":1,"type":10,"requiresLevel":1},
 {"id":417141,"name":"Engrave Belt - Berserk","icon":"ability_druid_berserk","class":1,"type":8,"requiresLevel":1},

--- a/proto/hunter.proto
+++ b/proto/hunter.proto
@@ -126,6 +126,8 @@ enum HunterRune {
 	RuneBootsTrapLauncher 				= 409541;
 	RuneBootsDualWieldSpecialization 	= 409687;
 	RuneBootsInvigoration				= 437997;
+
+	RuneHelmLockAndLoad					= 415413;
 }
 
 message Hunter {

--- a/sim/hunter/explosive_trap.go
+++ b/sim/hunter/explosive_trap.go
@@ -17,6 +17,7 @@ func (hunter *Hunter) getExplosiveTrapConfig(rank int, timer *core.Timer) core.S
 	level := [4]int{0, 34, 44, 54}[rank]
 
 	numHits := hunter.Env.GetNumTargets()
+	hasLockAndLoad := hunter.HasRune(proto.HunterRune_RuneHelmLockAndLoad)
 
 	return core.SpellConfig{
 		ActionID:      core.ActionID{SpellID: spellId},
@@ -75,6 +76,10 @@ func (hunter *Hunter) getExplosiveTrapConfig(rank int, timer *core.Timer) core.S
 					curTarget = sim.Environment.NextTargetUnit(curTarget)
 				}
 				spell.AOEDot().ApplyOrReset(sim)
+
+				if hasLockAndLoad {
+					hunter.LockAndLoadAura.Activate(sim)
+				}
 			})
 		},
 	}

--- a/sim/hunter/frost_trap.go
+++ b/sim/hunter/frost_trap.go
@@ -1,0 +1,60 @@
+package hunter
+
+import (
+	"time"
+
+	"github.com/wowsims/sod/sim/core"
+	"github.com/wowsims/sod/sim/core/proto"
+)
+
+func (hunter *Hunter) getFrostTrapConfig(timer *core.Timer) core.SpellConfig {
+
+	hasLockAndLoad := hunter.HasRune(proto.HunterRune_RuneHelmLockAndLoad)
+
+	return core.SpellConfig{
+		ActionID:      core.ActionID{SpellID: 13809},
+		SpellSchool:   core.SpellSchoolFire,
+		DefenseType:   core.DefenseTypeMagic,
+		ProcMask:      core.ProcMaskSpellDamage,
+		Flags:         core.SpellFlagAPL,
+		RequiredLevel: 28,
+		MissileSpeed:  24,
+
+		ManaCost: core.ManaCostOptions{
+			FlatCost: 60,
+		},
+		Cast: core.CastConfig{
+			CD: core.Cooldown{
+				Timer:    timer,
+				Duration: time.Second * 15,
+			},
+			DefaultCast: core.Cast{
+				GCD: core.GCDDefault,
+			},
+			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
+		},
+
+		DamageMultiplier: 1 + 0.15*float64(hunter.Talents.CleverTraps),
+		ThreatMultiplier: 1,
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			spell.WaitTravelTime(sim, func(s *core.Simulation) {
+				if hasLockAndLoad {
+					hunter.LockAndLoadAura.Activate(sim)
+				}
+			})
+		},
+	}
+}
+
+func (hunter *Hunter) registerFrostTrapSpell(timer *core.Timer) {
+	if !hunter.HasRune(proto.HunterRune_RuneBootsTrapLauncher) {
+		return
+	}
+
+	config := hunter.getFrostTrapConfig(timer)
+
+	if config.RequiredLevel <= int(hunter.Level) {
+		hunter.FrostTrap = hunter.GetOrRegisterSpell(config)
+	}
+}

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -48,6 +48,7 @@ type Hunter struct {
 	ExplosiveShot  *core.Spell
 	ExplosiveTrap  *core.Spell
 	ImmolationTrap *core.Spell
+	FrostTrap 	   *core.Spell
 	KillCommand    *core.Spell
 	KillShot       *core.Spell
 	MultiShot      *core.Spell
@@ -117,9 +118,11 @@ func (hunter *Hunter) Initialize() {
 	hunter.registerWingClipSpell()
 
 	fireTraps := hunter.NewTimer()
+	frostTraps := hunter.NewTimer()
 
 	hunter.registerExplosiveTrapSpell(fireTraps)
 	hunter.registerImmolationTrapSpell(fireTraps)
+	hunter.registerFrostTrapSpell(frostTraps)
 
 	hunter.registerKillCommand()
 	hunter.registerRapidFire()

--- a/sim/hunter/immolation_trap.go
+++ b/sim/hunter/immolation_trap.go
@@ -14,6 +14,8 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 	manaCost := [6]float64{0, 50, 90, 135, 190, 245}[rank]
 	level := [6]int{0, 16, 26, 36, 46, 56}[rank]
 
+	hasLockAndLoad := hunter.HasRune(proto.HunterRune_RuneHelmLockAndLoad)
+
 	return core.SpellConfig{
 		ActionID:      core.ActionID{SpellID: spellId},
 		SpellSchool:   core.SpellSchoolFire,
@@ -65,6 +67,10 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 				if result.Landed() {
 					spell.SpellMetrics[target.UnitIndex].Hits--
 					spell.Dot(target).Apply(sim)
+				}
+
+				if hasLockAndLoad {
+					hunter.LockAndLoadAura.Activate(sim)
 				}
 			})
 		},

--- a/sim/hunter/runes.go
+++ b/sim/hunter/runes.go
@@ -39,6 +39,7 @@ func (hunter *Hunter) ApplyRunes() {
 	hunter.applyCobraStrikes()
 	hunter.applyExposeWeakness()
 	hunter.applyInvigoration()
+	hunter.applyLockAndLoad()
 }
 
 func (hunter *Hunter) applyInvigoration() {
@@ -174,6 +175,27 @@ func (hunter *Hunter) applyCobraStrikes() {
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if spell.ProcMask.Matches(core.ProcMaskMeleeSpecial | core.ProcMaskSpellDamage) {
 				aura.RemoveStack(sim)
+			}
+		},
+	})
+}
+
+func (hunter *Hunter) applyLockAndLoad() {
+	if !hunter.HasRune(proto.HunterRune_RuneHelmLockAndLoad){
+		return
+	}
+
+	lockAndLoadMetrics := hunter.Metrics.NewResourceMetrics(core.ActionID{SpellID: 415413}, proto.ResourceType_ResourceTypeMana)
+
+	hunter.LockAndLoadAura = hunter.GetOrRegisterAura(core.Aura{
+		Label:     "Lock And Load",
+		ActionID:  core.ActionID{SpellID: 415413},
+		Duration:  time.Second * 20,
+		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+			if spell.ProcMask.Matches(core.ProcMaskRangedSpecial) && spell.Flags.Matches(core.SpellFlagMeleeMetrics) {
+				aura.Deactivate(sim)
+				hunter.AddMana(sim, spell.DefaultCast.Cost, lockAndLoadMetrics)
+				spell.CD.Reset()
 			}
 		},
 	})

--- a/tools/database/rune_overrides.go
+++ b/tools/database/rune_overrides.go
@@ -21,7 +21,6 @@ var UnimplementedRuneOverrides = []int32{
 
 	// Hunter
 	415428, // Catlike Reflexes
-	415413, // Lock and Load
 	415405, // Rapid Killing
 	428726, // Focus Fire
 	415358, // Raptor Fury


### PR DESCRIPTION
Implementation of the hunter helmet rune `Lock and Load` from the [phase 3 announcement video](https://youtu.be/vDRuPJkGp_I?si=69m92E2KUeYq-r5U&t=389)

Implementation Details:
- Added new aura to hunter.go
- Added rune logic to hunter/runes.go
- Aura is activate after immolation trap, explosive trap, or frost trap are cast
- Aura is uses the OnCastComplete trigger and checks if the cast is a shot ability (determined using a combination of procmask and spell flag)
- When cast is determined to be a shot ability the aura is deactivated, mana is refunded, and spell cooldown is reset

Frost Trap has also been added as a spell! I thought this addition would be necessary since frost traps and fire traps do not share cooldowns and as per the reading of the rune should also trigger lock and load procs. The frost trap spell implementation does not do anything except for cost mana and trigger lock and load.