### PR TITLE
Rename runeAbility() to baseRuneAbilityDamage() for clarity

### DIFF
--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -290,7 +290,7 @@ func (druid *Druid) HasRune(rune proto.DruidRune) bool {
 	return druid.HasRuneById(int32(rune))
 }
 
-func (druid *Druid) runeAbility() float64 {
+func (druid *Druid) baseRuneAbilityDamage() float64 {
 	return 9.183105 + 0.616405*float64(druid.Level) + 0.028608*float64(druid.Level*druid.Level)
 }
 

--- a/sim/druid/starsurge.go
+++ b/sim/druid/starsurge.go
@@ -14,8 +14,8 @@ func (druid *Druid) applyStarsurge() {
 
 	actionID := core.ActionID{SpellID: 417157}
 
-	baseLowDamage := druid.runeAbility() * 2.48
-	baseHighDamage := druid.runeAbility() * 3.04
+	baseLowDamage := druid.baseRuneAbilityDamage() * 2.48
+	baseHighDamage := druid.baseRuneAbilityDamage() * 3.04
 	spellCoeff := .429
 
 	starfireAuraMultiplier := 1 + .80

--- a/sim/druid/sunfire.go
+++ b/sim/druid/sunfire.go
@@ -18,9 +18,9 @@ func (druid *Druid) registerSunfireSpell() {
 	moonfuryMultiplier := druid.MoonfuryDamageMultiplier()
 	impMoonfireMultiplier := druid.ImprovedMoonfireDamageMultiplier()
 
-	baseLowDamage := druid.runeAbility() * 1.3 * moonfuryMultiplier * impMoonfireMultiplier
-	baseHighDamage := druid.runeAbility() * 1.52 * moonfuryMultiplier * impMoonfireMultiplier
-	baseDotDamage := druid.runeAbility() * 0.65 * moonfuryMultiplier * impMoonfireMultiplier
+	baseLowDamage := druid.baseRuneAbilityDamage() * 1.3 * moonfuryMultiplier * impMoonfireMultiplier
+	baseHighDamage := druid.baseRuneAbilityDamage() * 1.52 * moonfuryMultiplier * impMoonfireMultiplier
+	baseDotDamage := druid.baseRuneAbilityDamage() * 0.65 * moonfuryMultiplier * impMoonfireMultiplier
 	spellCoeff := .15
 	spellDotCoeff := .13
 

--- a/sim/hunter/explosive_shot.go
+++ b/sim/hunter/explosive_shot.go
@@ -16,8 +16,8 @@ func (hunter *Hunter) registerExplosiveShotSpell(timer *core.Timer) {
 	actionID := core.ActionID{SpellID: 409552}
 	numHits := hunter.Env.GetNumTargets()
 
-	baseLowDamage := hunter.runeAbility() * 0.36 * 1.15 // Buff from 1/3/2024 - verify with new build and update numbers
-	baseHighDamage := hunter.runeAbility() * 0.54 * 1.15
+	baseLowDamage := hunter.baseRuneAbilityDamage() * 0.36 * 1.15 // Buff from 1/3/2024 - verify with new build and update numbers
+	baseHighDamage := hunter.baseRuneAbilityDamage() * 0.54 * 1.15
 
 	manaCostMultiplier := 1 - 0.02*float64(hunter.Talents.Efficiency)
 	if hunter.HasRune(proto.HunterRune_RuneChestMasterMarksman) {

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -249,7 +249,7 @@ func (hunter *Hunter) HasRune(rune proto.HunterRune) bool {
 	return hunter.HasRuneById(int32(rune))
 }
 
-func (hunter *Hunter) runeAbility() float64 {
+func (hunter *Hunter) baseRuneAbilityDamage() float64 {
 	return 2.976264 + 0.641066*float64(hunter.Level) + 0.022519*float64(hunter.Level*hunter.Level)
 }
 

--- a/sim/mage/arcane_blast.go
+++ b/sim/mage/arcane_blast.go
@@ -16,8 +16,8 @@ func (mage *Mage) registerArcaneBlastSpell() {
 		return
 	}
 
-	baseLowDamage := mage.runeAbility() * 4.53
-	baseHighDamage := mage.runeAbility() * 5.27
+	baseLowDamage := mage.baseRuneAbilityDamage() * 4.53
+	baseHighDamage := mage.baseRuneAbilityDamage() * 5.27
 	spellCoeff := .714
 	castTime := time.Millisecond * 2500
 	manaCost := .07

--- a/sim/mage/arcane_surge.go
+++ b/sim/mage/arcane_surge.go
@@ -13,8 +13,8 @@ func (mage *Mage) registerArcaneSurgeSpell() {
 	}
 
 	actionID := core.ActionID{SpellID: int32(proto.MageRune_RuneLegsArcaneSurge)}
-	baseDamageLow := mage.runeAbility() * 2.26
-	baseDamageHigh := mage.runeAbility() * 2.64
+	baseDamageLow := mage.baseRuneAbilityDamage() * 2.26
+	baseDamageHigh := mage.baseRuneAbilityDamage() * 2.64
 	spellCoeff := .429
 	cooldown := time.Minute * 2
 	auraDuration := time.Second * 8

--- a/sim/mage/balefire_bolt.go
+++ b/sim/mage/balefire_bolt.go
@@ -14,8 +14,8 @@ func (mage *Mage) registerBalefireBoltSpell() {
 		return
 	}
 
-	baseDamageLow := mage.runeAbility() * 2.8
-	baseDamageHigh := mage.runeAbility() * 4.2
+	baseDamageLow := mage.baseRuneAbilityDamage() * 2.8
+	baseDamageHigh := mage.baseRuneAbilityDamage() * 4.2
 	spellCoeff := .857
 	castTime := time.Millisecond * 2500
 	buffDuration := time.Second * 30

--- a/sim/mage/deep_freeze.go
+++ b/sim/mage/deep_freeze.go
@@ -12,8 +12,8 @@ func (mage *Mage) registerDeepFreezeSpell() {
 		return
 	}
 
-	baseDamageLow := mage.runeAbility() * 4.62
-	baseDamageHigh := mage.runeAbility() * 5.38
+	baseDamageLow := mage.baseRuneAbilityDamage() * 4.62
+	baseDamageHigh := mage.baseRuneAbilityDamage() * 5.38
 	spellCoeff := 2.5
 	cooldown := time.Second * 30
 	manaCost := .12

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -14,9 +14,9 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 
 	actionID := core.ActionID{SpellID: int32(proto.MageRune_RuneBeltFrostfireBolt)}
 	// 2024-03-05 tuning SFB +50% base damage and same spell coeff as max rank Fireball
-	baseDamageLow := mage.runeAbility() * 3.87
-	baseDamageHigh := mage.runeAbility() * 4.5
-	baseDotDamage := mage.runeAbility() * .08
+	baseDamageLow := mage.baseRuneAbilityDamage() * 3.87
+	baseDamageHigh := mage.baseRuneAbilityDamage() * 4.5
+	baseDotDamage := mage.baseRuneAbilityDamage() * .08
 	spellCoeff := 1.0
 	castTime := time.Second * 3
 	manaCost := .14

--- a/sim/mage/ice_lance.go
+++ b/sim/mage/ice_lance.go
@@ -11,8 +11,8 @@ func (mage *Mage) registerIceLanceSpell() {
 		return
 	}
 
-	baseDamageLow := mage.runeAbility() * .55
-	baseDamageHigh := mage.runeAbility() * .65
+	baseDamageLow := mage.baseRuneAbilityDamage() * .55
+	baseDamageHigh := mage.baseRuneAbilityDamage() * .65
 	spellCoeff := .143
 	manaCost := .08
 

--- a/sim/mage/living_bomb.go
+++ b/sim/mage/living_bomb.go
@@ -17,8 +17,8 @@ func (mage *Mage) registerLivingBombSpell() {
 	}
 
 	actionID := core.ActionID{SpellID: int32(proto.MageRune_RuneHandsLivingBomb)}
-	baseDotDamage := mage.runeAbility() * .85
-	baseExplosionDamage := mage.runeAbility() * 1.71
+	baseDotDamage := mage.baseRuneAbilityDamage() * .85
+	baseExplosionDamage := mage.baseRuneAbilityDamage() * 1.71
 	dotCoeff := .20
 	explosionCoeff := .40
 	manaCost := .22

--- a/sim/mage/living_flame.go
+++ b/sim/mage/living_flame.go
@@ -16,7 +16,7 @@ func (mage *Mage) registerLivingFlameSpell() {
 		return
 	}
 
-	baseDamage := mage.runeAbility() * 1
+	baseDamage := mage.baseRuneAbilityDamage() * 1
 	spellCoeff := .143
 	manaCost := .11
 	cooldown := time.Second * 30

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -157,6 +157,6 @@ func (mage *Mage) HasRune(rune proto.MageRune) bool {
 	return mage.HasRuneById(int32(rune))
 }
 
-func (mage *Mage) runeAbility() float64 {
+func (mage *Mage) baseRuneAbilityDamage() float64 {
 	return 13.828124 + 0.018012*float64(mage.Level) + 0.044141*float64(mage.Level*mage.Level)
 }

--- a/sim/mage/spellfrost_bolt.go
+++ b/sim/mage/spellfrost_bolt.go
@@ -12,8 +12,8 @@ func (mage *Mage) registerSpellfrostBoltSpell() {
 		return
 	}
 
-	baseDamageLow := mage.runeAbility() * 3.04
-	baseDamageHigh := mage.runeAbility() * 3.55
+	baseDamageLow := mage.baseRuneAbilityDamage() * 3.04
+	baseDamageHigh := mage.baseRuneAbilityDamage() * 3.55
 	spellCoeff := .814
 	castTime := time.Millisecond * 2500
 	manaCost := .12

--- a/sim/priest/mind_sear.go
+++ b/sim/priest/mind_sear.go
@@ -87,8 +87,8 @@ func (priest *Priest) newMindSearSpellConfig(tickIdx int32) core.SpellConfig {
 }
 
 func (priest *Priest) newMindSearTickSpell(numTicks int32) *core.Spell {
-	baseDamageLow := priest.runeAbility() * .7 * priest.darknessDamageModifier()
-	baseDamageHigh := priest.runeAbility() * .78 * priest.darknessDamageModifier()
+	baseDamageLow := priest.baseRuneAbilityDamage() * .7 * priest.darknessDamageModifier()
+	baseDamageHigh := priest.baseRuneAbilityDamage() * .78 * priest.darknessDamageModifier()
 	spellCoeff := 0.15 // classic penalty for mf having a slow effect
 
 	return priest.GetOrRegisterSpell(core.SpellConfig{

--- a/sim/priest/mind_spike.go
+++ b/sim/priest/mind_spike.go
@@ -17,8 +17,8 @@ func (priest *Priest) registerMindSpikeSpell() {
 
 func (priest *Priest) newMindSpikeSpellConfig() core.SpellConfig {
 	// 2024-02-22 tuning 10% buff
-	baseDamageLow := priest.runeAbility() * 1.11 * 1.1
-	baseDamageHigh := priest.runeAbility() * 1.29 * 1.1
+	baseDamageLow := priest.baseRuneAbilityDamage() * 1.11 * 1.1
+	baseDamageHigh := priest.baseRuneAbilityDamage() * 1.29 * 1.1
 	spellCoeff := .429
 	manaCost := .06
 	castTime := time.Millisecond * 1500

--- a/sim/priest/penance.go
+++ b/sim/priest/penance.go
@@ -18,8 +18,8 @@ func (priest *Priest) RegisterPenanceSpell() {
 // https://www.wowhead.com/classic/spell=402284/penance
 // https://www.wowhead.com/classic/news/patch-1-15-build-52124-ptr-datamining-season-of-discovery-runes-336044
 func (priest *Priest) makePenanceSpell(isHeal bool) *core.Spell {
-	baseDamage := priest.runeAbility() * 1.28
-	baseHealing := priest.runeAbilityHealing() * .85
+	baseDamage := priest.baseRuneAbilityDamage() * 1.28
+	baseHealing := priest.baseRuneAbilityDamageHealing() * .85
 	spellCoeff := 0.285
 	manaCost := .16
 	cooldown := time.Second * 12

--- a/sim/priest/priest.go
+++ b/sim/priest/priest.go
@@ -143,11 +143,11 @@ func (priest *Priest) HasRune(rune proto.PriestRune) bool {
 	return priest.HasRuneById(int32(rune))
 }
 
-func (priest *Priest) runeAbility() float64 {
+func (priest *Priest) baseRuneAbilityDamage() float64 {
 	return 9.456667 + 0.635108*float64(priest.Level) + 0.039063*float64(priest.Level*priest.Level)
 }
 
-func (priest *Priest) runeAbilityHealing() float64 {
+func (priest *Priest) baseRuneAbilityDamageHealing() float64 {
 	return 38.258376 + 0.904195*float64(priest.Level) + 0.161311*float64(priest.Level*priest.Level)
 }
 

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -13,8 +13,8 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 	}
 
 	// 2024-02-22 In-game value is ~66% base damage after tuning
-	baseLowDamage := priest.runeAbility() * 0.66 * 5.32 * priest.darknessDamageModifier()
-	baseHighDamage := priest.runeAbility() * 0.66 * 6.2 * priest.darknessDamageModifier()
+	baseLowDamage := priest.baseRuneAbilityDamage() * 0.66 * 5.32 * priest.darknessDamageModifier()
+	baseHighDamage := priest.baseRuneAbilityDamage() * 0.66 * 6.2 * priest.darknessDamageModifier()
 	spellCoeff := 0.429
 	manaCost := .12
 	cooldown := time.Second * 12

--- a/sim/priest/void_plague.go
+++ b/sim/priest/void_plague.go
@@ -17,7 +17,7 @@ func (priest *Priest) getVoidPlagueConfig() core.SpellConfig {
 	cooldown := time.Second * 6
 
 	// 2024-02-22 tuning 10% buff
-	baseTickDamage := priest.runeAbility() * 1.17 * 1.1
+	baseTickDamage := priest.baseRuneAbilityDamage() * 1.17 * 1.1
 	spellCoeff := .166
 
 	return core.SpellConfig{

--- a/sim/rogue/between_the_eyes.go
+++ b/sim/rogue/between_the_eyes.go
@@ -12,8 +12,8 @@ func (rogue *Rogue) registerBetweenTheEyes() {
 		return
 	}
 
-	flatDamage := rogue.runeAbility()
-	comboDamageBonus := rogue.runeAbilityCombo()
+	flatDamage := rogue.baseRuneAbilityDamage()
+	comboDamageBonus := rogue.baseRuneAbilityDamageCombo()
 
 	rogue.BetweenTheEyes = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: int32(proto.RogueRune_RuneBetweenTheEyes)},

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -12,7 +12,7 @@ func (rogue *Rogue) registerEnvenom() {
 		return
 	}
 
-	baseAbilityDamage := rogue.runeAbility()
+	baseAbilityDamage := rogue.baseRuneAbilityDamage()
 
 	rogue.EnvenomAura = rogue.RegisterAura(core.Aura{
 		Label:    "Envenom",

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -19,7 +19,7 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 
 	// waylay := rogue.HasRune(proto.RogueRune_RuneWaylay)
 
-	flatDamageBonus := rogue.runeAbility()
+	flatDamageBonus := rogue.baseRuneAbilityDamage()
 
 	return rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    actionID.WithTag(int32(core.Ternary(isMH, 1, 2))),

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -206,11 +206,11 @@ func (rogue *Rogue) HasRune(rune proto.RogueRune) bool {
 	return rogue.HasRuneById(int32(rune))
 }
 
-func (rogue *Rogue) runeAbility() float64 {
+func (rogue *Rogue) baseRuneAbilityDamage() float64 {
 	return 5.741530 - 0.255683*float64(rogue.Level) + 0.032656*float64(rogue.Level*rogue.Level)
 }
 
-func (rogue *Rogue) runeAbilityCombo() float64 {
+func (rogue *Rogue) baseRuneAbilityDamageCombo() float64 {
 	return 8.740728 - 0.415787*float64(rogue.Level) + 0.051973*float64(rogue.Level*rogue.Level)
 }
 

--- a/sim/shaman/lava_burst.go
+++ b/sim/shaman/lava_burst.go
@@ -20,8 +20,8 @@ func (shaman *Shaman) applyLavaBurst() {
 }
 
 func (shaman *Shaman) newLavaBurstSpellConfig(isOverload bool) core.SpellConfig {
-	baseDamageLow := shaman.runeAbility() * 4.69
-	baseDamageHigh := shaman.runeAbility() * 6.05
+	baseDamageLow := shaman.baseRuneAbilityDamage() * 4.69
+	baseDamageHigh := shaman.baseRuneAbilityDamage() * 6.05
 	spellCoeff := .571
 	castTime := time.Second * 2
 	cooldown := time.Second * 8

--- a/sim/shaman/molten_blast.go
+++ b/sim/shaman/molten_blast.go
@@ -14,8 +14,8 @@ func (shaman *Shaman) applyMoltenBlast() {
 		return
 	}
 
-	baseDamageLow := shaman.runeAbility() * .72
-	baseDamageHigh := shaman.runeAbility() * 1.08
+	baseDamageLow := shaman.baseRuneAbilityDamage() * .72
+	baseDamageHigh := shaman.baseRuneAbilityDamage() * 1.08
 	apCoef := .05
 	cooldown := time.Second * 6
 	manaCost := .18

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -237,7 +237,7 @@ func (shaman *Shaman) HasRune(rune proto.ShamanRune) bool {
 	return shaman.HasRuneById(int32(rune))
 }
 
-func (shaman *Shaman) runeAbility() float64 {
+func (shaman *Shaman) baseRuneAbilityDamage() float64 {
 	return 7.583798 + 0.471881*float64(shaman.Level) + 0.036599*float64(shaman.Level*shaman.Level)
 }
 

--- a/sim/warlock/chaos_bolt.go
+++ b/sim/warlock/chaos_bolt.go
@@ -14,8 +14,8 @@ func (warlock *Warlock) registerChaosBoltSpell() {
 	}
 
 	spellCoeff := 0.714
-	baseLowDamage := warlock.runeAbility() * 5.22
-	baseHighDamage := warlock.runeAbility() * 6.62
+	baseLowDamage := warlock.baseRuneAbilityDamage() * 5.22
+	baseHighDamage := warlock.baseRuneAbilityDamage() * 6.62
 
 	warlock.ChaosBolt = warlock.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 403629},

--- a/sim/warlock/haunt.go
+++ b/sim/warlock/haunt.go
@@ -19,8 +19,8 @@ func (warlock *Warlock) registerHauntSpell() {
 	actionID := core.ActionID{SpellID: 403501}
 
 	spellCoeff := 0.714
-	baseLowDamage := warlock.runeAbility() * 2.51
-	baseHighDamage := warlock.runeAbility() * 2.95
+	baseLowDamage := warlock.baseRuneAbilityDamage() * 2.51
+	baseHighDamage := warlock.baseRuneAbilityDamage() * 2.95
 
 	warlock.HauntDebuffAuras = warlock.NewEnemyAuraArray(func(target *core.Unit, level int32) *core.Aura {
 		return target.GetOrRegisterAura(core.Aura{

--- a/sim/warlock/immolation_aura.go
+++ b/sim/warlock/immolation_aura.go
@@ -13,7 +13,7 @@ func (warlock *Warlock) registerImmolationAuraSpell() {
 	}
 
 	spellCoeff := 0.045
-	baseDamage := warlock.runeAbility() * 0.2
+	baseDamage := warlock.baseRuneAbilityDamage() * 0.2
 
 	immoAuraProc := warlock.GetOrRegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 427725},

--- a/sim/warlock/incinerate.go
+++ b/sim/warlock/incinerate.go
@@ -13,8 +13,8 @@ func (warlock *Warlock) registerIncinerateSpell() {
 		return
 	}
 	spellCoeff := 0.714
-	baseLowDamage := warlock.runeAbility() * 2.22
-	baseHighDamage := warlock.runeAbility() * 2.58
+	baseLowDamage := warlock.baseRuneAbilityDamage() * 2.22
+	baseHighDamage := warlock.baseRuneAbilityDamage() * 2.58
 
 	warlock.IncinerateAura = warlock.RegisterAura(core.Aura{
 		Label:    "Incinerate Aura",

--- a/sim/warlock/shadowflame.go
+++ b/sim/warlock/shadowflame.go
@@ -14,8 +14,8 @@ func (warlock *Warlock) registerShadowflameSpell() {
 
 	baseSpellCoeff := 0.0715
 	dotSpellCoeff := 0.022
-	baseDamage := warlock.runeAbility() * 0.64
-	dotDamage := warlock.runeAbility() * 0.24
+	baseDamage := warlock.baseRuneAbilityDamage() * 0.64
+	dotDamage := warlock.baseRuneAbilityDamage() * 0.24
 
 	fireDot := warlock.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 426325},

--- a/sim/warlock/unstable_affliction.go
+++ b/sim/warlock/unstable_affliction.go
@@ -13,7 +13,7 @@ func (warlock *Warlock) registerUnstableAfflictionSpell() {
 	}
 
 	spellCoeff := 0.2
-	baseDamage := warlock.runeAbility() * 0.6
+	baseDamage := warlock.baseRuneAbilityDamage() * 0.6
 
 	hasPandemicRune := warlock.HasRune(proto.WarlockRune_RuneHelmPandemic)
 

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -183,7 +183,7 @@ func (warlock *Warlock) HasRune(rune proto.WarlockRune) bool {
 	return warlock.HasRuneById(int32(rune))
 }
 
-func (warlock *Warlock) runeAbility() float64 {
+func (warlock *Warlock) baseRuneAbilityDamage() float64 {
 	return 6.568597 + 0.672028*float64(warlock.Level) + 0.031721*float64(warlock.Level*warlock.Level)
 }
 


### PR DESCRIPTION
Following up on https://github.com/wowsims/sod/pull/502#discussion_r1545002515

I decided to not add it to the agent interface but that could be an option to enforce it across sims