### PR TITLE
APL Core: Don't run actions when the provided condition evaluates to nil

### DIFF
--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -120,7 +120,7 @@ func (rot *APLRotation) newAPLAction(config *proto.APLAction) *APLAction {
 		impl:      rot.newAPLActionImpl(config),
 	}
 
-	if action.impl == nil {
+	if action.impl == nil || (config.Condition != nil && action.condition == nil) {
 		return nil
 	} else {
 		return action

--- a/sim/core/apl_values_aura.go
+++ b/sim/core/apl_values_aura.go
@@ -14,6 +14,9 @@ type APLValueAuraIsActive struct {
 
 func (rot *APLRotation) newValueAuraIsActive(config *proto.APLValueAuraIsActive) APLValue {
 	aura := rot.GetAPLAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
+	if aura.Get() == nil {
+		return nil
+	}
 	return &APLValueAuraIsActive{
 		aura: aura,
 	}
@@ -22,7 +25,7 @@ func (value *APLValueAuraIsActive) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeBool
 }
 func (value *APLValueAuraIsActive) GetBool(sim *Simulation) bool {
-	return value.aura.Get() != nil && value.aura.Get().IsActive()
+	return value.aura.Get().IsActive()
 }
 func (value *APLValueAuraIsActive) String() string {
 	return fmt.Sprintf("Aura Active(%s)", value.aura.String())


### PR DESCRIPTION
This is a quirk I've noticed with the APL that shows up quite a bit when rune swapping and setting certain aura conditions. In these scenarios where a spell or aura isn't known, the `APLValue` of a condition using that spell/aura ends up being returned as `nil`, which in-turn evaluates to a `nil` condition, aka treated as if there was no condition at all.

### Single-Conditionals

In my mind, when I don't have the Omen of Clarity talent taken (allow clearcasting procs, this condition below should not allow the action to run. The reason it does is that the condition evaluates to nil, so the APL treats it as if it had no condition at all. I don't think it's intuitive that the sim would cast Wrath here.

![image](https://github.com/wowsims/sod/assets/12898988/3809a66e-85d6-477f-bbd2-ac1df9f4f122)

### Any-Ofs

`Any of`s where all conditions (regardless of count) use unavailable spells/auras suffer from the same problem as above and are fixed by this change. In the below screenshot, when I have not taken Omen of Clarity I would expect the sim to not cast Wrath. If, however, at least one condition is still able to be evaluated, then the sim treats the `Any of` the same both before and after these changes - only evaluating the one or more valid conditions.

<img width="1027" alt="image" src="https://github.com/wowsims/sod/assets/12898988/0db84349-ef94-4207-9bf2-cd16ec944fd0">

### All-Ofs

`All of`s are a bit more complicated. Right now the sim treats them the same way as `Any of`s, where an `All of` with only condition using unknown spells/auras will evaluate to `nil` and perform the action. When adding additional conditions, only those conditions are evaluated.

The same changes to `Any of` apply to `All of`, e.g. the below condition will not allow the action to be run.

<img width="979" alt="image" src="https://github.com/wowsims/sod/assets/12898988/9e54d220-90bf-4992-9dd2-9034e1db31b9">

### Other Issues

Where I'm not sure about though is in a scenario like the one below. Right now in the sim, when I do not have the Omen of Clarity Talent this condition will still evaluate to `true` and the sim will cast Wrath. This remains true after these changes as well. This feels incorrect, as my assumption would be that this condition should evaluate to `false` because it's written to assume that all conditions need to be met regardless

<img width="977" alt="image" src="https://github.com/wowsims/sod/assets/12898988/9d4526f0-91c3-4a22-a0b5-c074b2c8d976">
