### PR TITLE
Core: Add APL "Spell Known" and "Aura Known" values

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -81,7 +81,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 67
+// NextIndex: 69
 message APLValue {
     oneof value {
         // Operators
@@ -121,6 +121,7 @@ message APLValue {
         APLValueAutoSwingTime auto_swing_time = 64;
 
         // Spell values
+        APLValueSpellIsKnown spell_is_known = 68;
         APLValueSpellCanCast spell_can_cast = 19;
         APLValueSpellIsReady spell_is_ready = 20;
         APLValueSpellTimeToReady spell_time_to_ready = 21;
@@ -132,6 +133,7 @@ message APLValue {
         APLValueSpellCurrentCost spell_current_cost = 62;
 
         // Aura values
+        APLValueAuraIsKnown aura_is_known = 67;
         APLValueAuraIsActive aura_is_active = 22;
         APLValueAuraIsActiveWithReactionTime aura_is_active_with_reaction_time = 50;
         APLValueAuraRemainingTime aura_remaining_time = 23;
@@ -394,6 +396,9 @@ message APLValueAutoSwingTime {
     SwingType auto_type = 1;
 }
 
+message APLValueSpellIsKnown {
+    ActionID spell_id = 1;
+}
 message APLValueSpellCanCast {
     ActionID spell_id = 1;
 }
@@ -427,6 +432,10 @@ message APLValueSpellCurrentCost {
     ActionID spell_id = 1;
 }
 
+message APLValueAuraIsKnown {
+    UnitReference source_unit = 2;
+    ActionID aura_id = 1;
+}
 message APLValueAuraIsActive {
     UnitReference source_unit = 2;
     ActionID aura_id = 1;

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -120,6 +120,8 @@ func (rot *APLRotation) newAPLAction(config *proto.APLAction) *APLAction {
 		impl:      rot.newAPLActionImpl(config),
 	}
 
+	fmt.Println(rot.newAPLValue(config.Condition))
+
 	if action.impl == nil {
 		return nil
 	} else {

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -120,8 +120,6 @@ func (rot *APLRotation) newAPLAction(config *proto.APLAction) *APLAction {
 		impl:      rot.newAPLActionImpl(config),
 	}
 
-	fmt.Println(rot.newAPLValue(config.Condition))
-
 	if action.impl == nil {
 		return nil
 	} else {

--- a/sim/core/apl_value.go
+++ b/sim/core/apl_value.go
@@ -125,6 +125,8 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		return rot.newValueAutoSwingTime(config.GetAutoSwingTime())
 
 	// Spells
+	case *proto.APLValue_SpellIsKnown:
+		return rot.newValueSpellIsKnown(config.GetSpellIsKnown())
 	case *proto.APLValue_SpellCanCast:
 		return rot.newValueSpellCanCast(config.GetSpellCanCast())
 	case *proto.APLValue_SpellIsReady:
@@ -141,8 +143,12 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		return rot.newValueSpellIsChanneling(config.GetSpellIsChanneling())
 	case *proto.APLValue_SpellChanneledTicks:
 		return rot.newValueSpellChanneledTicks(config.GetSpellChanneledTicks())
+	case *proto.APLValue_SpellCurrentCost:
+		return rot.newValueSpellCurrentCost(config.GetSpellCurrentCost())
 
 	// Auras
+	case *proto.APLValue_AuraIsKnown:
+		return rot.newValueAuraIsKnown(config.GetAuraIsKnown())
 	case *proto.APLValue_AuraIsActive:
 		return rot.newValueAuraIsActive(config.GetAuraIsActive())
 	case *proto.APLValue_AuraIsActiveWithReactionTime:

--- a/sim/core/apl_values_aura.go
+++ b/sim/core/apl_values_aura.go
@@ -7,6 +7,27 @@ import (
 	"github.com/wowsims/sod/sim/core/proto"
 )
 
+type APLValueAuraIsKnown struct {
+	DefaultAPLValueImpl
+	aura AuraReference
+}
+
+func (rot *APLRotation) newValueAuraIsKnown(config *proto.APLValueAuraIsKnown) APLValue {
+	aura := rot.GetAPLAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
+	return &APLValueAuraIsKnown{
+		aura: aura,
+	}
+}
+func (value *APLValueAuraIsKnown) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeBool
+}
+func (value *APLValueAuraIsKnown) GetBool(sim *Simulation) bool {
+	return value.aura.Get() != nil
+}
+func (value *APLValueAuraIsKnown) String() string {
+	return fmt.Sprintf("Aura Active(%s)", value.aura.String())
+}
+
 type APLValueAuraIsActive struct {
 	DefaultAPLValueImpl
 	aura AuraReference
@@ -14,6 +35,11 @@ type APLValueAuraIsActive struct {
 
 func (rot *APLRotation) newValueAuraIsActive(config *proto.APLValueAuraIsActive) APLValue {
 	aura := rot.GetAPLAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
+
+	if aura.Get() == nil {
+		return nil
+	}
+
 	return &APLValueAuraIsActive{
 		aura: aura,
 	}
@@ -22,7 +48,7 @@ func (value *APLValueAuraIsActive) Type() proto.APLValueType {
 	return proto.APLValueType_ValueTypeBool
 }
 func (value *APLValueAuraIsActive) GetBool(sim *Simulation) bool {
-	return value.aura.Get() != nil && value.aura.Get().IsActive()
+	return value.aura.Get().IsActive()
 }
 func (value *APLValueAuraIsActive) String() string {
 	return fmt.Sprintf("Aura Active(%s)", value.aura.String())

--- a/sim/core/apl_values_operators.go
+++ b/sim/core/apl_values_operators.go
@@ -271,6 +271,7 @@ type APLValueCompare struct {
 
 func (rot *APLRotation) newValueCompare(config *proto.APLValueCompare) APLValue {
 	lhs, rhs := rot.coerceToSameType(rot.newAPLValue(config.Lhs), rot.newAPLValue(config.Rhs))
+
 	if lhs == nil || rhs == nil {
 		return nil
 	}

--- a/sim/core/apl_values_spell.go
+++ b/sim/core/apl_values_spell.go
@@ -7,6 +7,27 @@ import (
 	"github.com/wowsims/sod/sim/core/proto"
 )
 
+type APLValueSpellIsKnown struct {
+	DefaultAPLValueImpl
+	spell *Spell
+}
+
+func (rot *APLRotation) newValueSpellIsKnown(config *proto.APLValueSpellIsKnown) APLValue {
+	spell := rot.GetAPLSpell(config.SpellId)
+	return &APLValueSpellIsKnown{
+		spell: spell,
+	}
+}
+func (value *APLValueSpellIsKnown) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeBool
+}
+func (value *APLValueSpellIsKnown) GetBool(sim *Simulation) bool {
+	return value.spell != nil
+}
+func (value *APLValueSpellIsKnown) String() string {
+	return fmt.Sprintf("Is Known(%s)", value.spell.ActionID)
+}
+
 type APLValueSpellCanCast struct {
 	DefaultAPLValueImpl
 	spell *Spell

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -96,6 +96,55 @@ character_stats_results: {
   final_stats: 89
  }
 }
+character_stats_results: {
+ key: "TestFeral-Lvl50-CharacterStats-Default"
+ value: {
+  final_stats: 311.19
+  final_stats: 281.545
+  final_stats: 405.9
+  final_stats: 125.95
+  final_stats: 164.45
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 30
+  final_stats: 3
+  final_stats: 9.41976
+  final_stats: 0
+  final_stats: 0
+  final_stats: 1577.145
+  final_stats: 3
+  final_stats: 30.46834
+  final_stats: 3
+  final_stats: 0
+  final_stats: 0
+  final_stats: 2673.25
+  final_stats: 0
+  final_stats: 0
+  final_stats: 2693.95
+  final_stats: 127
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 4
+  final_stats: 0
+  final_stats: 0
+  final_stats: 5162.85
+  final_stats: 25.25
+  final_stats: 20.25
+  final_stats: 90.25
+  final_stats: 35.25
+  final_stats: 30.25
+  final_stats: 100
+  final_stats: 0
+  final_stats: 0
+  final_stats: 89
+ }
+}
 stat_weights_results: {
  key: "TestFeral-Lvl25-StatWeights-Default"
  value: {
@@ -166,8 +215,57 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.37386
-  weights: 4.78138
-  weights: 5.71338
+  weights: 4.92015
+  weights: 5.72668
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+ }
+}
+stat_weights_results: {
+ key: "TestFeral-Lvl50-StatWeights-Default"
+ value: {
+  weights: 0.92672
+  weights: 1.24473
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.42124
+  weights: 9.18701
+  weights: 8.14638
   weights: 0
   weights: 0
   weights: 0
@@ -463,287 +561,609 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-BlackfathomElementalist'sHide"
  value: {
-  dps: 590.4259
-  tps: 438.74443
+  dps: 603.7167
+  tps: 448.29579
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-BlackfathomSlayer'sLeather"
  value: {
-  dps: 616.03317
-  tps: 457.33833
+  dps: 626.47379
+  tps: 464.84862
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-AllItems-TwilightInvoker'sVestments"
  value: {
-  dps: 584.90471
-  tps: 434.71437
+  dps: 597.85827
+  tps: 444.03177
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Average-Default"
  value: {
-  dps: 732.27016
-  tps: 538.96713
+  dps: 743.87288
+  tps: 547.29411
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 378.3449
-  tps: 322.45291
+  dps: 380.88169
+  tps: 324.27831
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 378.3449
-  tps: 274.12166
+  dps: 380.88169
+  tps: 275.94706
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 484.90453
-  tps: 360.98487
+  dps: 487.57282
+  tps: 362.97647
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 217.31544
-  tps: 163.03731
+  dps: 218.34669
+  tps: 163.77944
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 217.31544
-  tps: 156.46692
+  dps: 218.34669
+  tps: 157.20905
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 287.28124
-  tps: 214.83448
+  dps: 288.41874
+  tps: 215.6847
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 378.3449
-  tps: 322.45291
+  dps: 380.88169
+  tps: 324.27831
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 378.3449
-  tps: 274.12166
+  dps: 380.88169
+  tps: 275.94706
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 484.90453
-  tps: 360.98487
+  dps: 487.57282
+  tps: 362.97647
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 217.31544
-  tps: 163.03731
+  dps: 218.34669
+  tps: 163.77944
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 217.31544
-  tps: 156.46692
+  dps: 218.34669
+  tps: 157.20905
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 287.28124
-  tps: 214.83448
+  dps: 288.41874
+  tps: 215.6847
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 378.3449
-  tps: 322.45291
+  dps: 380.88169
+  tps: 324.27831
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 378.3449
-  tps: 274.12166
+  dps: 380.88169
+  tps: 275.94706
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 484.90453
-  tps: 360.98487
+  dps: 487.57282
+  tps: 362.97647
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 217.31544
-  tps: 163.03731
+  dps: 218.34669
+  tps: 163.77944
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 217.31544
-  tps: 156.46692
+  dps: 218.34669
+  tps: 157.20905
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 287.28124
-  tps: 214.83448
+  dps: 288.41874
+  tps: 215.6847
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 377.27746
-  tps: 323.42989
+  dps: 379.81425
+  tps: 325.25529
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 377.27746
-  tps: 273.4685
+  dps: 379.81425
+  tps: 275.2939
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 482.78758
-  tps: 359.95028
+  dps: 485.45587
+  tps: 361.94188
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 218.59112
-  tps: 169.3237
+  dps: 219.63237
+  tps: 170.07293
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 218.59112
-  tps: 157.64462
+  dps: 219.63237
+  tps: 158.39385
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 288.21675
-  tps: 216.85853
+  dps: 289.40425
+  tps: 217.74425
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 377.27746
-  tps: 323.42989
+  dps: 379.81425
+  tps: 325.25529
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 377.27746
-  tps: 273.4685
+  dps: 379.81425
+  tps: 275.2939
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 482.78758
-  tps: 359.95028
+  dps: 485.45587
+  tps: 361.94188
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 218.59112
-  tps: 169.3237
+  dps: 219.63237
+  tps: 170.07293
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 218.59112
-  tps: 157.64462
+  dps: 219.63237
+  tps: 158.39385
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 288.21675
-  tps: 216.85853
+  dps: 289.40425
+  tps: 217.74425
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 377.27746
-  tps: 323.42989
+  dps: 379.81425
+  tps: 325.25529
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 377.27746
-  tps: 273.4685
+  dps: 379.81425
+  tps: 275.2939
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 482.78758
-  tps: 359.95028
+  dps: 485.45587
+  tps: 361.94188
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 218.59112
-  tps: 169.3237
+  dps: 219.63237
+  tps: 170.07293
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 218.59112
-  tps: 157.64462
+  dps: 219.63237
+  tps: 158.39385
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-p2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 288.21675
-  tps: 216.85853
+  dps: 289.40425
+  tps: 217.74425
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 399.20828
-  tps: 286.00305
+  dps: 407.72745
+  tps: 292.1164
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-BlackfathomElementalist'sHide"
+ value: {
+  dps: 929.21549
+  tps: 685.97997
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-BlackfathomSlayer'sLeather"
+ value: {
+  dps: 962.19736
+  tps: 709.79895
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-HyperconductiveMender'sMeditation"
+ value: {
+  dps: 756.06961
+  tps: 558.84875
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-HyperconductiveWizard'sAttire"
+ value: {
+  dps: 764.66708
+  tps: 565.94211
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-InsulatedLeathers"
+ value: {
+  dps: 815.8879
+  tps: 602.50193
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-InsulatedSorceror'sLeathers"
+ value: {
+  dps: 763.24657
+  tps: 564.73433
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-IrradiatedGarments"
+ value: {
+  dps: 768.40277
+  tps: 568.24007
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-AllItems-TwilightInvoker'sVestments"
+ value: {
+  dps: 925.3427
+  tps: 683.19951
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Average-Default"
+ value: {
+  dps: 1112.56332
+  tps: 814.62554
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 617.65293
+  tps: 520.64214
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 617.65293
+  tps: 447.23841
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 776.55556
+  tps: 577.90778
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 343.06492
+  tps: 246.45084
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 343.06492
+  tps: 246.45084
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 454.87607
+  tps: 337.27572
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 617.65293
+  tps: 520.64214
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 617.65293
+  tps: 447.23841
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 776.55556
+  tps: 577.90778
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 343.06492
+  tps: 246.45084
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 343.06492
+  tps: 246.45084
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Default-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 454.87607
+  tps: 337.27572
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 617.65293
+  tps: 520.64214
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 617.65293
+  tps: 447.23841
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 776.55556
+  tps: 577.90778
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 343.06492
+  tps: 246.45084
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 343.06492
+  tps: 246.45084
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-NightElf-p2-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 454.87607
+  tps: 337.27572
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 616.11671
+  tps: 519.10898
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 616.11671
+  tps: 446.04047
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 773.56246
+  tps: 575.35473
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 341.73733
+  tps: 245.49741
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 341.73733
+  tps: 245.49741
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 454.7592
+  tps: 337.13844
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 616.11671
+  tps: 519.10898
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 616.11671
+  tps: 446.04047
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 773.56246
+  tps: 575.35473
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 341.73733
+  tps: 245.49741
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 341.73733
+  tps: 245.49741
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Default-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 454.7592
+  tps: 337.13844
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 616.11671
+  tps: 519.10898
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 616.11671
+  tps: 446.04047
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 773.56246
+  tps: 575.35473
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
+ value: {
+  dps: 341.73733
+  tps: 245.49741
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
+ value: {
+  dps: 341.73733
+  tps: 245.49741
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-Settings-Tauren-p2-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
+ value: {
+  dps: 454.7592
+  tps: 337.13844
+ }
+}
+dps_results: {
+ key: "TestFeral-Lvl50-SwitchInFrontOfTarget-Default"
+ value: {
+  dps: 531.9709
+  tps: 381.19166
  }
 }

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -56,6 +56,27 @@ func TestFeral(t *testing.T) {
 			EPReferenceStat: proto.Stat_StatAttackPower,
 			StatsToWeigh:    Stats,
 		},
+		{
+			Class:      proto.Class_ClassDruid,
+			Level:      50,
+			Race:       proto.Race_RaceTauren,
+			OtherRaces: []proto.Race{proto.Race_RaceNightElf},
+
+			Talents:     Phase3Talents,
+			GearSet:     core.GetGearSet("../../../ui/feral_druid/gear_sets", "p2"),
+			Rotation:    core.GetAplRotation("../../../ui/feral_druid/apls", "phase_3"),
+			Buffs:       core.FullBuffsPhase3,
+			Consumes:    Phase3Consumes,
+			SpecOptions: core.SpecOptionsCombo{Label: "Default", SpecOptions: PlayerOptionsMonoCat},
+			OtherSpecOptions: []core.SpecOptionsCombo{
+				{Label: "Default-NoBleed", SpecOptions: PlayerOptionsMonoCatNoBleed},
+				{Label: "Flower-Aoe", SpecOptions: PlayerOptionsFlowerCatAoe},
+			},
+
+			ItemFilter:      ItemFilters,
+			EPReferenceStat: proto.Stat_StatAttackPower,
+			StatsToWeigh:    Stats,
+		},
 	}))
 }
 
@@ -90,6 +111,7 @@ func BenchmarkSimulate(b *testing.B) {
 
 var Phase1Talents = "500005001--05"
 var Phase2Talents = "-550002032320211-05"
+var Phase3Talents = "500005301-5500020323002-05"
 
 var PlayerOptionsMonoCat = &proto.Player_FeralDruid{
 	FeralDruid: &proto.FeralDruid{
@@ -136,11 +158,25 @@ var Phase1Consumes = core.ConsumesCombo{
 var Phase2Consumes = core.ConsumesCombo{
 	Label: "Phase 2 Consumes",
 	Consumes: &proto.Consumes{
-		AgilityElixir: proto.AgilityElixir_ElixirOfAgility,
-		DefaultPotion: proto.Potions_GreaterManaPotion,
-		Food:          proto.Food_FoodSagefishDelight,
-		MainHandImbue: proto.WeaponImbue_WildStrikes,
-		StrengthBuff:  proto.StrengthBuff_ElixirOfOgresStrength,
+		AgilityElixir:     proto.AgilityElixir_ElixirOfAgility,
+		DefaultPotion:     proto.Potions_GreaterManaPotion,
+		DragonBreathChili: true,
+		Food:              proto.Food_FoodSagefishDelight,
+		MainHandImbue:     proto.WeaponImbue_WildStrikes,
+		StrengthBuff:      proto.StrengthBuff_ElixirOfOgresStrength,
+	},
+}
+
+var Phase3Consumes = core.ConsumesCombo{
+	Label: "Phase 3 Consumes",
+	Consumes: &proto.Consumes{
+		AgilityElixir:     proto.AgilityElixir_ElixirOfTheMongoose,
+		DefaultConjured:   proto.Conjured_ConjuredDruidCatnip,
+		DefaultPotion:     proto.Potions_MajorManaPotion,
+		DragonBreathChili: true,
+		Food:              proto.Food_FoodSmokedDesertDumpling,
+		MainHandImbue:     proto.WeaponImbue_WildStrikes,
+		StrengthBuff:      proto.StrengthBuff_ElixirOfGiants,
 	},
 }
 

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -6,6 +6,7 @@ import {
 	APLValueAuraInternalCooldown,
 	APLValueAuraIsActive,
 	APLValueAuraIsActiveWithReactionTime,
+	APLValueAuraIsKnown,
 	APLValueAuraNumStacks,
 	APLValueAuraRemainingTime,
 	APLValueAuraShouldRefresh,
@@ -54,6 +55,7 @@ import {
 	APLValueSpellCPM,
 	APLValueSpellCurrentCost,
 	APLValueSpellIsChanneling,
+	APLValueSpellIsKnown,
 	APLValueSpellIsReady,
 	APLValueSpellTimeToReady,
 	APLValueSpellTravelTime,
@@ -679,6 +681,13 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 	}),
 
 	// Spells
+	spellIsKnown: inputBuilder({
+		label: 'Spell Known',
+		submenu: ['Spell'],
+		shortDescription: '<b>True</b> if the spell is currently known, otherwise <b>False</b>.',
+		newValue: APLValueSpellIsKnown.create,
+		fields: [AplHelpers.actionIdFieldConfig('spellId', 'castable_spells', '')],
+	}),
 	spellCurrentCost: inputBuilder({
 		label: 'Current Cost',
 		submenu: ['Spell'],
@@ -754,6 +763,13 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 	}),
 
 	// Auras
+	auraIsKnown: inputBuilder({
+		label: 'Aura Known',
+		submenu: ['Aura'],
+		shortDescription: '<b>True</b> if the aura is currently known, otherwise <b>False</b>.',
+		newValue: APLValueAuraIsKnown.create,
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources'), AplHelpers.actionIdFieldConfig('auraId', 'auras', 'sourceUnit')],
+	}),
 	auraIsActive: inputBuilder({
 		label: 'Aura Active',
 		submenu: ['Aura'],

--- a/ui/feral_druid/apls/phase_2.apl.json
+++ b/ui/feral_druid/apls/phase_2.apl.json
@@ -10,7 +10,7 @@
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":407988}}}}},"castSpell":{"spellId":{"spellId":407988}}}},
     {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"20"}}}},"castSpell":{"spellId":{"spellId":417045}}}},
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":409828}}}}},"castSpell":{"spellId":{"spellId":409828}}}},
-    {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":16870}}}]}},"castSpell":{"spellId":{"spellId":8992}}}},
+    {"action":{"condition":{"and":{"vals":[{"auraIsKnown":{"auraId":{"spellId":16870}}},{"auraIsActive":{"auraId":{"spellId":16870}}}]}},"castSpell":{"spellId":{"spellId":8992}}}},
     {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentComboPoints":{}},"rhs":{"const":{"val":"5"}}}},{"cmp":{"op":"OpGe","lhs":{"auraRemainingTime":{"auraId":{"spellId":407988}}},"rhs":{"const":{"val":"7"}}}}]}},"castSpell":{"spellId":{"spellId":9493}}}},
     {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":414684}}}}},"castSpell":{"spellId":{"spellId":414684}}}},
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":1823}}}}},"castSpell":{"spellId":{"spellId":1823}}}},

--- a/ui/feral_druid/apls/phase_3.apl.json
+++ b/ui/feral_druid/apls/phase_3.apl.json
@@ -10,7 +10,7 @@
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"spellId":407988}}}}},"castSpell":{"spellId":{"spellId":407988}}}},
     {"action":{"condition":{"cmp":{"op":"OpLe","lhs":{"currentEnergy":{}},"rhs":{"const":{"val":"20"}}}},"castSpell":{"spellId":{"spellId":417045}}}},
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":409828}}}}},"castSpell":{"spellId":{"spellId":409828}}}},
-    {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":16870}}}]}},"castSpell":{"spellId":{"spellId":9829}}}},
+    {"action":{"condition":{"and":{"vals":[{"auraIsKnown":{"auraId":{"spellId":16870}}},{"auraIsActive":{"auraId":{"spellId":16870}}}]}},"castSpell":{"spellId":{"spellId":9829}}}},
     {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentComboPoints":{}},"rhs":{"const":{"val":"5"}}}},{"cmp":{"op":"OpGe","lhs":{"auraRemainingTime":{"auraId":{"spellId":407988}}},"rhs":{"const":{"val":"7"}}}}]}},"castSpell":{"spellId":{"spellId":9752}}}},
     {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":414684}}}}},"castSpell":{"spellId":{"spellId":414684}}}},
     {"action":{"condition":{"not":{"val":{"auraIsActive":{"sourceUnit":{"type":"CurrentTarget"},"auraId":{"spellId":1824}}}}},"castSpell":{"spellId":{"spellId":1824}}}},

--- a/ui/feral_druid/presets.ts
+++ b/ui/feral_druid/presets.ts
@@ -100,10 +100,17 @@ export const TalentsPhase2 = {
 	}),
 };
 
+export const TalentsPhase3 = {
+	name: 'Phase 3',
+	data: SavedTalents.create({
+		talentsString: '500005301-5500020323002-05',
+	}),
+};
+
 export const TalentPresets = {
 	[Phase.Phase1]: [TalentsPhase1],
 	[Phase.Phase2]: [TalentsPhase2],
-	[Phase.Phase3]: [],
+	[Phase.Phase3]: [TalentsPhase3],
 	[Phase.Phase4]: [],
 	[Phase.Phase5]: [],
 };

--- a/ui/feral_druid/sim.ts
+++ b/ui/feral_druid/sim.ts
@@ -125,7 +125,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		// Preset talents that the user can quickly select.
 		talents: [...Presets.TalentPresets[Phase.Phase3], ...Presets.TalentPresets[Phase.Phase2], ...Presets.TalentPresets[Phase.Phase1]],
 		rotations: [
-			Presets.SIMPLE_ROTATION_DEFAULT,
+			// Simple Rotation is broken at the moment
+			// Presets.SIMPLE_ROTATION_DEFAULT,
 			...Presets.APLPresets[Phase.Phase3],
 			...Presets.APLPresets[Phase.Phase2],
 			...Presets.APLPresets[Phase.Phase1],


### PR DESCRIPTION
Resolves https://github.com/wowsims/sod/issues/532

Right now many APLs are mistakenly casting abilities while using rune conditions when a rune isn't equipped because the conditions are evaluated to `nil`. This causes oddities when building around APL conditions for runes and sometimes talents or even gear that has proc auras (https://github.com/wowsims/sod/pull/524).

These new values allow us to ensure that we can write APL actions that are only performed when a certain rune is equipped, talent is known, item is equipped, etc.

I also updated some things for Feral to go along with this