### PR TITLE
Move shapeshift state to Character and handle consum restrictions

### DIFF
--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -86,6 +86,8 @@ type Character struct {
 	fiftyPercentHasteBuffCD *Timer
 
 	Pets []*Pet // cached in AddPet, for advance()
+
+	ActiveShapeShift *Aura // Some things can't be used in shapeshift forms
 }
 
 func NewCharacter(party *Party, partyIndex int, player *proto.Player) Character {
@@ -629,6 +631,23 @@ func (character *Character) GetConjuredCD() *Timer {
 }
 func (character *Character) GetFiftyPercentHasteBuffCD() *Timer {
 	return character.GetOrInitTimer(&character.fiftyPercentHasteBuffCD)
+}
+
+func (character *Character) IsShapeshifted() bool {
+	return character.ActiveShapeShift != nil
+}
+
+func (character *Character) CancelShapeshift(sim *Simulation) {
+	if character.ActiveShapeShift != nil {
+		character.ActiveShapeShift.Deactivate(sim)
+	}
+}
+
+func (character *Character) SetShapeshift(aura *Aura) {
+	if aura != nil && character.ActiveShapeShift != nil {
+		panic("Tried to set shapeshift while already shapeshifted!")
+	}
+	character.ActiveShapeShift = aura
 }
 
 // Returns the talent tree (0, 1, or 2) of the tree with the most points.

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -529,6 +529,9 @@ func registerExplosivesCD(agent Agent, consumes *proto.Consumes) {
 			Spell:    character.newSapperSpell(sharedTimer),
 			Type:     CooldownTypeDPS | CooldownTypeExplosive,
 			Priority: CooldownPriorityLow + 30,
+			ShouldActivate: func(s *Simulation, c *Character) bool {
+				return !character.IsShapeshifted()
+			},
 		})
 	}
 
@@ -557,6 +560,9 @@ func registerExplosivesCD(agent Agent, consumes *proto.Consumes) {
 			Spell:    filler,
 			Type:     CooldownTypeDPS | CooldownTypeExplosive,
 			Priority: CooldownPriorityLow + 10,
+			ShouldActivate: func(s *Simulation, c *Character) bool {
+				return !character.IsShapeshifted()
+			},
 		})
 	}
 }
@@ -623,6 +629,9 @@ func (character *Character) newBasicExplosiveSpellConfig(sharedTimer *Timer, act
 			SharedCD: Cooldown{
 				Timer:    sharedTimer,
 				Duration: time.Minute,
+			},
+			ModifyCast: func(sim *Simulation, _ *Spell, _ *Cast) {
+				character.CancelShapeshift(sim)
 			},
 		},
 
@@ -813,7 +822,7 @@ func makeManaConsumableMCD(itemId int32, character *Character, cdTimer *Timer) M
 		ShouldActivate: func(sim *Simulation, character *Character) bool {
 			// Only pop if we have less than the max mana provided by the potion minus 1mp5 tick.
 			totalRegen := character.ManaRegenPerSecondWhileCasting() * 2
-			return (character.MaxMana()-(character.CurrentMana()+totalRegen) >= maxRoll)
+			return (character.MaxMana()-(character.CurrentMana()+totalRegen) >= maxRoll) && !character.IsShapeshifted()
 		},
 		Spell: character.GetOrRegisterSpell(SpellConfig{
 			ActionID: actionID,
@@ -822,6 +831,9 @@ func makeManaConsumableMCD(itemId int32, character *Character, cdTimer *Timer) M
 				CD: Cooldown{
 					Timer:    cdTimer,
 					Duration: cdDuration,
+				},
+				ModifyCast: func(sim *Simulation, _ *Spell, _ *Cast) {
+					character.CancelShapeshift(sim)
 				},
 			},
 			ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -391,9 +391,6 @@ type PseudoStats struct {
 	// Only used for NPCs, governs variance in enemy auto-attack damage
 	DamageSpread float64
 
-	// Blocks certain cooldowns
-	Shapeshifted bool
-
 	// Weapon Skills
 	UnarmedSkill         float64
 	DaggersSkill         float64

--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -76,7 +76,7 @@ func (moonkin *BalanceDruid) Reset(sim *core.Simulation) {
 	moonkin.Druid.Reset(sim)
 
 	if moonkin.Talents.MoonkinForm {
-		moonkin.Druid.ClearForm(sim)
+		moonkin.CancelShapeshift(sim)
 		moonkin.MoonkinFormAura.Activate(sim)
 	}
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -99,7 +99,7 @@ func (cat *FeralDruid) Initialize() {
 
 func (cat *FeralDruid) Reset(sim *core.Simulation) {
 	cat.Druid.Reset(sim)
-	cat.Druid.ClearForm(sim)
+	cat.Druid.CancelShapeshift(sim)
 	cat.CatFormAura.Activate(sim)
 	cat.readyToShift = false
 	//cat.berserkUsed = false

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -65,7 +65,7 @@ func (cat *FeralDruid) NextRotationAction(sim *core.Simulation, kickAt time.Dura
 
 func (cat *FeralDruid) tryPowershift(sim *core.Simulation) {
 	if cat.InForm(druid.Cat) {
-		cat.ClearForm(sim)
+		cat.CancelShapeshift(sim)
 		cat.TryUseCooldowns(sim)
 	}
 

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -30,18 +30,6 @@ func (druid *Druid) InForm(form DruidForm) bool {
 	return druid.form.Matches(form)
 }
 
-func (druid *Druid) ClearForm(sim *core.Simulation) {
-	if druid.InForm(Cat) {
-		druid.CatFormAura.Deactivate(sim)
-	} else if druid.InForm(Bear) {
-		druid.BearFormAura.Deactivate(sim)
-	} else if druid.InForm(Moonkin) {
-		druid.MoonkinFormAura.Deactivate(sim)
-	}
-	druid.form = Humanoid
-	druid.SetCurrentPowerBar(core.ManaBar)
-}
-
 // TODO: don't hardcode numbers
 func (druid *Druid) GetCatWeapon(level int32) core.Weapon {
 	// Level 25 values
@@ -146,7 +134,7 @@ func (druid *Druid) registerCatFormSpell() {
 		BuildPhase: core.Ternary(druid.StartingForm.Matches(Cat), core.CharacterBuildPhaseBase, core.CharacterBuildPhaseNone),
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			if !druid.Env.MeasuringStats && druid.form != Humanoid {
-				druid.ClearForm(sim)
+				druid.CancelShapeshift(sim)
 			}
 			druid.form = Cat
 			druid.SetCurrentPowerBar(core.EnergyBar)
@@ -155,7 +143,7 @@ func (druid *Druid) registerCatFormSpell() {
 
 			druid.PseudoStats.ThreatMultiplier *= 0.71
 			druid.AddStatDynamic(sim, stats.Dodge, 2*float64(druid.Talents.FelineSwiftness))
-			druid.PseudoStats.Shapeshifted = true
+			druid.SetShapeshift(aura)
 
 			predBonus = druid.GetDynamicPredStrikeStats()
 			druid.AddStatsDynamic(sim, predBonus)
@@ -184,12 +172,13 @@ func (druid *Druid) registerCatFormSpell() {
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			druid.form = Humanoid
+			druid.SetCurrentPowerBar(core.ManaBar)
 
 			druid.AutoAttacks.SetMH(druid.WeaponFromMainHand())
 
 			druid.PseudoStats.ThreatMultiplier /= 0.71
 			druid.AddStatDynamic(sim, stats.Dodge, -2*float64(druid.Talents.FelineSwiftness))
-			druid.PseudoStats.Shapeshifted = false
+			druid.SetShapeshift(nil)
 
 			druid.AddStatsDynamic(sim, predBonus.Invert())
 			druid.AddStatsDynamic(sim, statBonus.Invert())
@@ -431,7 +420,7 @@ func (druid *Druid) registerMoonkinFormSpell() {
 		Duration: core.NeverExpires,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			if !druid.Env.MeasuringStats && druid.form != Humanoid {
-				druid.ClearForm(sim)
+				druid.CancelShapeshift(sim)
 			}
 			druid.form = Moonkin
 

--- a/sim/druid/innervate.go
+++ b/sim/druid/innervate.go
@@ -59,7 +59,6 @@ func (druid *Druid) registerInnervateCD() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
-			druid.ClearForm(sim)
 			innervateAura.Activate(sim)
 		},
 	})


### PR DESCRIPTION
Track shapeshift state on Character as an aura pointer. Use that to handle shapeshift restrictions for consumables.

Also remove Druid.ClearForm() function. Character.CancelShapeshift() replaces it. A form's OnExpire() should handle everything that is needed to "go back to human form". Having to use another function was very counter-intuitive. Only resetting the active power bar was missing from cat form anyway if I haven't missed something.

This does NOT work properly with the "Optimal Rotation Action" for feral. It will use e.g. Dynamite on powershift (because it's not in form at that moment) and never go back into cat. But that rotation needs an update anyway.