### PR TITLE
Add "Rune Equipped" APL value

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -81,7 +81,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 69
+// NextIndex: 70
 message APLValue {
     oneof value {
         // Operators
@@ -141,6 +141,9 @@ message APLValue {
         APLValueAuraInternalCooldown aura_internal_cooldown = 39;
         APLValueAuraICDIsReadyWithReactionTime aura_icd_is_ready_with_reaction_time = 51;
         APLValueAuraShouldRefresh aura_should_refresh = 43;
+
+        // Rune values
+        APLValueRuneIsEquipped rune_is_equipped = 69;
 
         // Dot values
         APLValueDotIsActive dot_is_active = 6;
@@ -464,6 +467,10 @@ message APLValueAuraShouldRefresh {
     UnitReference source_unit = 2;
     ActionID aura_id = 1;
     APLValue max_overlap = 3;
+}
+
+message APLValueRuneIsEquipped {
+    ActionID rune_id = 1;
 }
 
 message APLValueDotIsActive {

--- a/sim/core/apl_helpers.go
+++ b/sim/core/apl_helpers.go
@@ -157,6 +157,10 @@ func (rot *APLRotation) GetAPLSpell(spellId *proto.ActionID) *Spell {
 	return spell
 }
 
+func (rot *APLRotation) GetAPLRune(spellId *proto.ActionID) Rune {
+	return RuneFromProto(&proto.SimRune{Id: spellId.GetSpellId()})
+}
+
 func (rot *APLRotation) GetAPLDot(targetUnit UnitReference, spellId *proto.ActionID) *Dot {
 	spell := rot.GetAPLSpell(spellId)
 

--- a/sim/core/apl_value.go
+++ b/sim/core/apl_value.go
@@ -164,6 +164,10 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 	case *proto.APLValue_AuraShouldRefresh:
 		return rot.newValueAuraShouldRefresh(config.GetAuraShouldRefresh())
 
+	// Runes
+	case *proto.APLValue_RuneIsEquipped:
+		return rot.newValueRuneIsEquipped(config.GetRuneIsEquipped())
+
 	// Dots
 	case *proto.APLValue_DotIsActive:
 		return rot.newValueDotIsActive(config.GetDotIsActive())

--- a/sim/core/apl_values_rune.go
+++ b/sim/core/apl_values_rune.go
@@ -29,5 +29,5 @@ func (value *APLValueRuneIsEquipped) GetBool(sim *Simulation) bool {
 	return slices.Contains(value.character.Equipment.GetRuneIds(), value.rune.ID)
 }
 func (value *APLValueRuneIsEquipped) String() string {
-	return fmt.Sprintf("Rune Equipped(%s)", value.rune.ID)
+	return fmt.Sprintf("Rune Equipped(%d)", value.rune.ID)
 }

--- a/sim/core/apl_values_rune.go
+++ b/sim/core/apl_values_rune.go
@@ -1,0 +1,33 @@
+package core
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/wowsims/sod/sim/core/proto"
+)
+
+type APLValueRuneIsEquipped struct {
+	DefaultAPLValueImpl
+	character *Character
+	rune      Rune
+}
+
+func (rot *APLRotation) newValueRuneIsEquipped(config *proto.APLValueRuneIsEquipped) APLValue {
+	character := rot.unit.Env.Raid.GetPlayerFromUnit(rot.unit).GetCharacter()
+	rune := rot.GetAPLRune(config.GetRuneId())
+
+	return &APLValueRuneIsEquipped{
+		character: character,
+		rune:      rune,
+	}
+}
+func (value *APLValueRuneIsEquipped) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeBool
+}
+func (value *APLValueRuneIsEquipped) GetBool(sim *Simulation) bool {
+	return slices.Contains(value.character.Equipment.GetRuneIds(), value.rune.ID)
+}
+func (value *APLValueRuneIsEquipped) String() string {
+	return fmt.Sprintf("Rune Equipped(%s)", value.rune.ID)
+}

--- a/ui/core/components/dropdown_picker.ts
+++ b/ui/core/components/dropdown_picker.ts
@@ -1,29 +1,28 @@
 import { Tooltip } from 'bootstrap';
 
 import { TypedEvent } from '../typed_event.js';
-
 import { Input, InputConfig } from './input.js';
 
 export interface DropdownValueConfig<V> {
-	value: V,
-	submenu?: Array<string | V>,
-	headerText?: string,
-	tooltip?: string,
-	extraCssClasses?: Array<string>,
+	value: V;
+	submenu?: Array<string | V>;
+	headerText?: string;
+	tooltip?: string;
+	extraCssClasses?: Array<string>;
 }
 
 export interface DropdownPickerConfig<ModObject, T, V = T> extends InputConfig<ModObject, T, V> {
 	values: Array<DropdownValueConfig<V>>;
-	equals: (a: V | undefined, b: V | undefined) => boolean,
-	setOptionContent: (button: HTMLButtonElement, valueConfig: DropdownValueConfig<V>, isSelectButton: boolean) => void,
-	createMissingValue?: (val: V) => Promise<DropdownValueConfig<V>>,
-	defaultLabel: string,
+	equals: (a: V | undefined, b: V | undefined) => boolean;
+	setOptionContent: (button: HTMLButtonElement, valueConfig: DropdownValueConfig<V>, isSelectButton: boolean) => void;
+	createMissingValue?: (val: V) => Promise<DropdownValueConfig<V>>;
+	defaultLabel: string;
 }
 
 interface DropdownSubmenu<V> {
-	path: Array<string|V>,
+	path: Array<string | V>;
 
-	listElem: HTMLUListElement,
+	listElem: HTMLUListElement;
 }
 
 /** UI Input that uses a dropdown menu. */
@@ -73,7 +72,7 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		this.submenus = [];
 		valueConfigs.forEach(valueConfig => {
 			const itemElem = document.createElement('li');
-			const containsSubmenuChildren = valueConfigs.some(vc => vc.submenu?.some(e => !(typeof e == 'string') && this.config.equals(e, valueConfig.value)))
+			const containsSubmenuChildren = valueConfigs.some(vc => vc.submenu?.some(e => !(typeof e == 'string') && this.config.equals(e, valueConfig.value)));
 			if (valueConfig.extraCssClasses) {
 				itemElem.classList.add(...valueConfig.extraCssClasses);
 			}
@@ -100,7 +99,7 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 						offset: [0, 10],
 						customClass: 'dropdown-tooltip',
 						html: true,
-						title: valueConfig.tooltip
+						title: valueConfig.tooltip,
 					});
 				}
 
@@ -110,7 +109,7 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 				});
 
 				if (containsSubmenuChildren) {
-					this.createSubmenu((valueConfig.submenu || []).concat([valueConfig.value]), buttonElem, itemElem)
+					this.createSubmenu((valueConfig.submenu || []).concat([valueConfig.value]), buttonElem, itemElem);
 				} else {
 					itemElem.appendChild(buttonElem);
 				}
@@ -130,14 +129,14 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		});
 	}
 
-	private getSubmenu(path: Array<string|V> | undefined): DropdownSubmenu<V> | null {
+	private getSubmenu(path: Array<string | V> | undefined): DropdownSubmenu<V> | null {
 		if (!path) {
 			return null;
 		}
 		return this.submenus.find(submenu => this.equalPaths(submenu.path, path)) || null;
 	}
 
-	private createSubmenu(path: Array<string|V>, buttonElem?: HTMLButtonElement, itemElem?: HTMLLIElement): DropdownSubmenu<V> {
+	private createSubmenu(path: Array<string | V>, buttonElem?: HTMLButtonElement, itemElem?: HTMLLIElement): DropdownSubmenu<V> {
 		const submenu = this.getSubmenu(path);
 		if (submenu) {
 			return submenu;
@@ -187,12 +186,11 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 		return newSubmenu;
 	}
 
-	private equalPaths(a: Array<string|V> | null | undefined, b: Array<string|V> | null | undefined): boolean {
-		return (a?.length || 0) == (b?.length || 0) &&
-			(a || []).every((aVal, i) =>
-				(typeof aVal == 'string')
-					? aVal == (b![i] as string)
-					: this.config.equals(aVal, b![i] as V));
+	private equalPaths(a: Array<string | V> | null | undefined, b: Array<string | V> | null | undefined): boolean {
+		return (
+			(a?.length || 0) == (b?.length || 0) &&
+			(a || []).every((aVal, i) => (typeof aVal == 'string' ? aVal == (b![i] as string) : this.config.equals(aVal, b![i] as V)))
+		);
 	}
 
 	getInputElem(): HTMLElement {
@@ -231,11 +229,11 @@ export class DropdownPicker<ModObject, T, V = T> extends Input<ModObject, T, V> 
 }
 
 export interface TextDropdownValueConfig<T> extends DropdownValueConfig<T> {
-	label: string,
+	label: string;
 }
 
 export interface TextDropdownPickerConfig<ModObject, T> extends Omit<DropdownPickerConfig<ModObject, T>, 'values' | 'setOptionContent'> {
-	values: Array<TextDropdownValueConfig<T>>,
+	values: Array<TextDropdownValueConfig<T>>;
 }
 
 export class TextDropdownPicker<ModObject, T> extends DropdownPicker<ModObject, T> {
@@ -244,7 +242,7 @@ export class TextDropdownPicker<ModObject, T> extends DropdownPicker<ModObject, 
 			...config,
 			setOptionContent: (button: HTMLButtonElement, valueConfig: DropdownValueConfig<T>) => {
 				button.textContent = (valueConfig as TextDropdownValueConfig<T>).label;
-			}
+			},
 		});
 	}
 }

--- a/ui/core/components/individual_sim_ui/apl_helpers.ts
+++ b/ui/core/components/individual_sim_ui/apl_helpers.ts
@@ -303,21 +303,18 @@ export class APLRunePicker extends DropdownPicker<Player<any>, Rune, Rune> {
 			},
 			values: [],
 		});
-		const updateValues = async () => {
-			const values = Object.values(ItemSlot)
-				.filter(v => typeof v != 'string')
-				.map(slot => player.getRunes(slot as ItemSlot))
-				.flat()
-				.map(rune => {
-					return {
-						value: rune,
-						submenu: [itemTypeNames.get(rune.type) ?? ''],
-					};
-				});
-			this.setOptions(values);
-		};
-		updateValues();
-		TypedEvent.onAny([player.gearChangeEmitter]).on(updateValues);
+
+		const values = Object.values(ItemSlot)
+			.filter(v => typeof v != 'string')
+			.map(slot => player.getRunes(slot as ItemSlot))
+			.flat()
+			.map(rune => {
+				return {
+					value: rune,
+					submenu: [itemTypeNames.get(rune.type) ?? ''],
+				};
+			});
+		this.setOptions(values);
 	}
 }
 

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -46,6 +46,7 @@ import {
 	APLValueOr,
 	APLValueRemainingTime,
 	APLValueRemainingTimePercent,
+	APLValueRuneIsEquipped,
 	APLValueSequenceIsComplete,
 	APLValueSequenceIsReady,
 	APLValueSequenceTimeToReady,
@@ -841,6 +842,15 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 				labelTooltip: 'Maximum amount of time before the aura expires when it may be refreshed.',
 			}),
 		],
+	}),
+
+	// Runes
+	runeIsEquipped: inputBuilder({
+		label: 'Rune Equipped',
+		submenu: ['Rune'],
+		shortDescription: '<b>True</b> if the rune is currently equipped, otherwise <b>False</b>.',
+		newValue: APLValueRuneIsEquipped.create,
+		fields: [AplHelpers.runeFieldConfig('runeId')],
 	}),
 
 	// DoT

--- a/ui/core/proto_utils/names.ts
+++ b/ui/core/proto_utils/names.ts
@@ -1,5 +1,5 @@
 import { ResourceType } from '../proto/api.js';
-import { ArmorType, Class, ItemSlot, Profession, PseudoStat, Race, RangedWeaponType, Stat, WeaponType } from '../proto/common.js';
+import { ArmorType, Class, ItemSlot, ItemType, Profession, PseudoStat, Race, RangedWeaponType, Stat, WeaponType } from '../proto/common.js';
 import { RepFaction, RepLevel, SourceFilterOption } from '../proto/ui.js';
 
 export const armorTypeNames: Map<ArmorType, string> = new Map([
@@ -218,6 +218,23 @@ export function getClassStatName(stat: Stat, playerClass: Class): string {
 		return statName;
 	}
 }
+
+export const itemTypeNames: Map<ItemType, string> = new Map([
+	[ItemType.ItemTypeHead, 'Helm'],
+	[ItemType.ItemTypeNeck, 'Neck'],
+	[ItemType.ItemTypeShoulder, 'Shoulders'],
+	[ItemType.ItemTypeBack, 'Cloak'],
+	[ItemType.ItemTypeChest, 'Chest'],
+	[ItemType.ItemTypeWrist, 'Bracers'],
+	[ItemType.ItemTypeHands, 'Gloves'],
+	[ItemType.ItemTypeWaist, 'Belt'],
+	[ItemType.ItemTypeLegs, 'Pants'],
+	[ItemType.ItemTypeFeet, 'Boots'],
+	[ItemType.ItemTypeFinger, 'Ring'],
+	[ItemType.ItemTypeTrinket, 'Trinket'],
+	[ItemType.ItemTypeWeapon, 'Weapon'],
+	[ItemType.ItemTypeRanged, 'Ranged'],
+]);
 
 export const slotNames: Map<ItemSlot, string> = new Map([
 	[ItemSlot.ItemSlotHead, 'Head'],


### PR DESCRIPTION
resolves https://github.com/wowsims/sod/issues/547 by creating a new "Rune Equipped" option that pulls values directly from the database and internally checks the player's gear for the rune

### Picker
<img width="100%" alt="image" src="https://github.com/wowsims/sod/assets/12898988/c5e0e41f-12fa-44cc-ad3f-9cea1a4175f1">

### Example of rune equipped logic
<img width="100%" alt="image" src="https://github.com/wowsims/sod/assets/12898988/be122c3e-3f44-4eb4-9ca1-91011473d886">
<img width="100%" alt="image" src="https://github.com/wowsims/sod/assets/12898988/2be282af-c4fe-4105-9b0b-7ef81c67f931">

### Exxample of not rune equipped logic
<img width="100%" alt="image" src="https://github.com/wowsims/sod/assets/12898988/3c6f20cf-95e3-4564-b7b8-2231dbb10392">
<img width="100%" alt="image" src="https://github.com/wowsims/sod/assets/12898988/6c222fa8-3453-4415-99f3-86e74cfcca1a">