### PR TITLE
Fixed Focus Fire to only apply frenzy stacks from offensive pet abili…

### DIFF
--- a/sim/hunter/focus_fire.go
+++ b/sim/hunter/focus_fire.go
@@ -60,7 +60,7 @@ func (hunter *Hunter) registerFocusFireSpell() {
 			aura.Activate(sim)
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if spell.ProcMask.Matches(core.ProcMaskMeleeMHAuto) {
+			if spell.ProcMask.Matches(core.ProcMaskMeleeMHSpecial | core.ProcMaskSpellDamage) {
 				if !hunterPetFrenzyAura.IsActive() {
 					hunterPetFrenzyAura.Activate(sim)
 				}


### PR DESCRIPTION
Looks like focus fire frenzy stacks are only built from offensive pet abilities.

Cat:
- Casts: https://vanilla.warcraftlogs.com/reports/v2jcNatBHJzy3CMf#fight=3&type=casts&source=21&view=events
- Frenzy Stacks:https://vanilla.warcraftlogs.com/reports/v2jcNatBHJzy3CMf#fight=3&type=auras&source=21&view=events&ability=428728
- Frenzy stacks are only stacked by claw and bite in this log

Wind Serpent:
- Casts: https://vanilla.warcraftlogs.com/reports/MmZz7XdyYb8QpqfH#fight=9&type=casts&source=23&view=events
- Frenzy Stacks: https://vanilla.warcraftlogs.com/reports/MmZz7XdyYb8QpqfH#fight=9&type=auras&source=23&view=events&ability=428728
- Frenzy stacks are only stacked by LB, spell takes too much focus to refresh frenzy stacks and so frenzy stacks consistently reset from 1 to 0