### PR TITLE
changed colors and boarders on the timeline

### DIFF
--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -170,14 +170,14 @@ $threat-color: #b56d07;
 }
 .rotation-timeline-cast {
 	position: absolute;
-	background-color: #e5cc80;
+	background-color: rgb(229, 204, 128, 0.7);
 	z-index: 1;
 	display: flex;
 }
 .rotation-timeline-travel-time {
 	position: absolute;
 	height: 24px;
-	background-color: #f9c0ff;
+	background-color: rgb(249, 192, 255, 0.6);
 }
 .rotation-timeline-tick {
 	position: absolute;
@@ -186,7 +186,7 @@ $threat-color: #b56d07;
 	height: 20px;
 	top: 2px;
 	z-index: 2;
-	border: 1px solid grey;
+	border: 3px solid grey;
 }
 .rotation-timeline-tick.outcome-miss {
 	border-color: red;
@@ -202,7 +202,7 @@ $threat-color: #b56d07;
 }
 .rotation-timeline-aura {
 	position: absolute;
-	background-color: blue;
+	background-color: rgba(0, 0, 255, 0.52);
 	opacity: 0.5;
 	height: 20px;
 	top: 2px;
@@ -228,7 +228,7 @@ $threat-color: #b56d07;
 	@include wowhead-background-icon;
 	height: 24px;
 	width: 24px;
-	border: 1px solid grey;
+	border-bottom: 3px solid grey;
 }
 .rotation-timeline-cast.outcome-miss .rotation-timeline-cast-icon {
 	border-color: red;


### PR DESCRIPTION
Added:

- Added opacity to both cast and travel time to make color coding more visible.
- Added opacity to background timeline to make color coding more visible.

Changed:

- Dot tick boarder to bottom and changed the size to 3px
- Spell cast border to bottom and changed the size to 3px
- Attack boarder to bottom and changed the size to 3px

