### PR TITLE
Implement druid Idol of the Dream

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
 # Install node
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+source $HOME/.bashrc
 nvm install 19.8.0
 
 # Install the npm package dependencies using node

--- a/sim/core/test_suite.go
+++ b/sim/core/test_suite.go
@@ -283,7 +283,7 @@ func RunTestSuite(t *testing.T, suiteName string, generators []TestGenerator) {
 	testSuite.Done(t)
 
 	if t.Failed() {
-		t.Log("One or more tests failed! If the changes are intentional, update the expected results with 'make test && make update-tests'. Otherwise go fix your bugs!")
+		t.Log("One or more tests failed! If the changes are intentional, update the expected results with 'make test ; make update-tests'. Otherwise go fix your bugs!")
 	}
 }
 

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -246,8 +246,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.39911
-  weights: 1.61572
+  weights: 1.4087
+  weights: 1.625
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.58885
-  weights: 14.47168
-  weights: 12.58816
+  weights: 0.59289
+  weights: 14.52767
+  weights: 12.66655
   weights: 0
   weights: 0
   weights: 0
@@ -827,260 +827,260 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-Average-Default"
  value: {
-  dps: 1788.11828
-  tps: 1288.25756
+  dps: 1798.74485
+  tps: 1295.80243
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1164.27805
-  tps: 1061.39738
+  dps: 1174.54447
+  tps: 1068.68654
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1164.27805
-  tps: 838.45086
+  dps: 1174.54447
+  tps: 845.74001
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1351.92892
-  tps: 964.7187
+  dps: 1364.11285
+  tps: 973.36929
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 492.61547
-  tps: 466.08902
+  dps: 496.48714
+  tps: 468.8379
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 492.61547
-  tps: 355.71033
+  dps: 496.48714
+  tps: 358.45922
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 657.37287
-  tps: 479.3639
+  dps: 662.62728
+  tps: 483.09453
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1164.27805
-  tps: 1061.39738
+  dps: 1174.54447
+  tps: 1068.68654
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1164.27805
-  tps: 838.45086
+  dps: 1174.54447
+  tps: 845.74001
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1351.92892
-  tps: 964.7187
+  dps: 1364.11285
+  tps: 973.36929
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 492.61547
-  tps: 466.08902
+  dps: 496.48714
+  tps: 468.8379
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 492.61547
-  tps: 355.71033
+  dps: 496.48714
+  tps: 358.45922
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 657.37287
-  tps: 479.3639
+  dps: 662.62728
+  tps: 483.09453
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1164.27805
-  tps: 1061.39738
+  dps: 1174.54447
+  tps: 1068.68654
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1164.27805
-  tps: 838.45086
+  dps: 1174.54447
+  tps: 845.74001
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1351.92892
-  tps: 964.7187
+  dps: 1364.11285
+  tps: 973.36929
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 492.61547
-  tps: 466.08902
+  dps: 496.48714
+  tps: 468.8379
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 492.61547
-  tps: 355.71033
+  dps: 496.48714
+  tps: 358.45922
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 657.37287
-  tps: 479.3639
+  dps: 662.62728
+  tps: 483.09453
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1160.89961
-  tps: 1058.8359
+  dps: 1171.13514
+  tps: 1066.10312
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1160.89961
-  tps: 836.04416
+  dps: 1171.13514
+  tps: 843.31139
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1347.21815
-  tps: 961.37406
+  dps: 1359.35297
+  tps: 969.98977
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 490.48858
-  tps: 461.86546
+  dps: 494.33953
+  tps: 464.59963
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 490.48858
-  tps: 354.04226
+  dps: 494.33953
+  tps: 356.77643
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 658.33227
-  tps: 479.40659
+  dps: 663.59805
+  tps: 483.14529
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1160.89961
-  tps: 1058.8359
+  dps: 1171.13514
+  tps: 1066.10312
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1160.89961
-  tps: 836.04416
+  dps: 1171.13514
+  tps: 843.31139
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1347.21815
-  tps: 961.37406
+  dps: 1359.35297
+  tps: 969.98977
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 490.48858
-  tps: 461.86546
+  dps: 494.33953
+  tps: 464.59963
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 490.48858
-  tps: 354.04226
+  dps: 494.33953
+  tps: 356.77643
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 658.33227
-  tps: 479.40659
+  dps: 663.59805
+  tps: 483.14529
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1160.89961
-  tps: 1058.8359
+  dps: 1171.13514
+  tps: 1066.10312
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1160.89961
-  tps: 836.04416
+  dps: 1171.13514
+  tps: 843.31139
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1347.21815
-  tps: 961.37406
+  dps: 1359.35297
+  tps: 969.98977
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 490.48858
-  tps: 461.86546
+  dps: 494.33953
+  tps: 464.59963
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 490.48858
-  tps: 354.04226
+  dps: 494.33953
+  tps: 356.77643
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 658.33227
-  tps: 479.40659
+  dps: 663.59805
+  tps: 483.14529
  }
 }
 dps_results: {

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -16,6 +16,7 @@ const (
 	Catnip                    = 213407
 	IdolOfWrath               = 216490
 	BloodBarkCrusher          = 216499
+	IdolOfTheDream	          = 220606
 	RitualistsHammer          = 221446
 )
 

--- a/sim/druid/shred.go
+++ b/sim/druid/shred.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (druid *Druid) registerShredSpell() {
-	shredDamageMultiplier := 3.0
+	shredDamageMultiplier := 1.0 + 2.0 * core.Ternary(druid.Ranged().ID == IdolOfTheDream, 1.02, 1.0)
 
 	flatDamageBonus := map[int32]float64{
 		25: 54.0,


### PR DESCRIPTION
* Implement Idol of the Dream (https://www.wowhead.com/classic/item=220606/idol-of-the-dream)
* NIT: update README instructions sections on setting up the project to remind user to source bashrc after installing NVM (the install command does not do that implicitly; you need to either source bashrc or open new terminal session)
* NIT: update test output after failed tests from `make test && make update-tests` to `make test ; make update-tests`, since when the tests fail, the `&&` condition will not be run. I think the idea should be to run update-tests also when the tests fail, so the result files can be updated with new values


About the idol - Idol tooltip says it increases Shred damage by 2%, but looking at the Shred skill tooltip with and without the idol, the damage effectiveness changes from 300% to 304%:
![image](https://github.com/wowsims/sod/assets/47057857/0a71d3f7-9897-413e-854b-375dd7c747ca)
![image](https://github.com/wowsims/sod/assets/47057857/70ebc8ab-4bb3-48aa-a6dc-12da828a566d)


For the implementation I took inspiration from wrath idol code - https://github.com/wowsims/sod/blob/1363b8a1e4ea6eb6243664e9b7e0c0c15c422e4e/sim/druid/wrath.go#L70