### PR TITLE
Prepull Combo Point APL Addition

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -41,7 +41,7 @@ message APLListItem {
     APLAction action = 3; // The action to be performed.
 }
 
-// NextIndex: 23
+// NextIndex: 24
 message APLAction {
     APLValue condition = 1; // If set, action will only execute if value is true or != 0.
 
@@ -71,6 +71,7 @@ message APLAction {
         APLActionTriggerICD trigger_icd = 11;
         APLActionItemSwap item_swap = 17;
         APLActionMove move = 18;
+        APLActionAddComboPoints add_combo_points = 23;
 
         // Class or Spec-specific actions
         APLActionCatOptimalRotationAction cat_optimal_rotation_action = 19;
@@ -245,6 +246,10 @@ message APLActionActivateAura {
 message APLActionActivateAuraWithStacks {
     ActionID aura_id = 1;
     string num_stacks = 2; 
+}
+
+message APLActionAddComboPoints {
+    string num_points = 2; 
 }
 
 message APLActionTriggerICD {

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -183,6 +183,8 @@ func (rot *APLRotation) newAPLActionImpl(config *proto.APLAction) APLActionImpl 
 		return rot.newActionMove(config.GetMove())
 	case *proto.APLAction_CustomRotation:
 		return rot.newActionCustomRotation(config.GetCustomRotation())
+	case *proto.APLAction_AddComboPoints:
+		return rot.newActionAddComboPoints(config.GetAddComboPoints())
 	default:
 		return nil
 	}

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -136,7 +136,46 @@ func (action *APLActionActivateAuraWithStacks) Execute(sim *Simulation) {
 func (action *APLActionActivateAuraWithStacks) String() string {
 	return fmt.Sprintf("Activate Aura(%s) Stacks(%d)", action.aura.ActionID, action.numStacks)
 }
+//START
+type APLActionAddComboPoints struct {
+	defaultAPLActionImpl
+	character *Character
+	numPoints int32
+}
 
+func (rot *APLRotation) newActionAddComboPoints(config *proto.APLActionAddComboPoints) APLActionImpl {
+	character := rot.unit.Env.Raid.GetPlayerFromUnit(rot.unit).GetCharacter()
+	numPoints, err := strconv.Atoi(config.NumPoints)
+	
+	if err != nil {
+		numPoints = 0
+	}
+	return &APLActionAddComboPoints{
+		character: character,
+		numPoints: int32(numPoints),
+	}
+}
+
+func (action *APLActionAddComboPoints) IsReady(sim *Simulation) bool {
+	return true
+}
+
+func (action *APLActionAddComboPoints) Execute(sim *Simulation) {
+	numPoints := strconv.Itoa(int(action.numPoints))
+
+	if sim.Log != nil {
+		action.character.Log(sim, "Adding combo points (%s points)", numPoints)
+	}
+	metrics := action.character.NewComboPointMetrics(ActionID{SpellID: 432264})
+	action.character.AddComboPoints(sim, action.numPoints, metrics)
+}
+
+func (action *APLActionAddComboPoints) String() string {
+	numPoints := strconv.Itoa(int(action.numPoints))
+	return fmt.Sprintf("Add Combo Points(%s)", numPoints)
+}
+
+//END
 type APLActionTriggerICD struct {
 	defaultAPLActionImpl
 	aura *Aura

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -136,7 +136,7 @@ func (action *APLActionActivateAuraWithStacks) Execute(sim *Simulation) {
 func (action *APLActionActivateAuraWithStacks) String() string {
 	return fmt.Sprintf("Activate Aura(%s) Stacks(%d)", action.aura.ActionID, action.numStacks)
 }
-//START
+
 type APLActionAddComboPoints struct {
 	defaultAPLActionImpl
 	character *Character
@@ -175,7 +175,6 @@ func (action *APLActionAddComboPoints) String() string {
 	return fmt.Sprintf("Add Combo Points(%s)", numPoints)
 }
 
-//END
 type APLActionTriggerICD struct {
 	defaultAPLActionImpl
 	aura *Aura

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -4,6 +4,7 @@ import {
 	APLAction,
 	APLActionActivateAura,
 	APLActionActivateAuraWithStacks,
+	APLActionAddComboPoints,
 	APLActionAutocastOtherCooldowns,
 	APLActionCancelAura,
 	APLActionCastPaladinPrimarySeal,
@@ -556,6 +557,21 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 			AplHelpers.stringFieldConfig('numStacks', {
 				label: 'stacks',
 				labelTooltip: 'Desired number of initial aura stacks.',
+			}),
+		],
+	}),
+	['addComboPoints']: inputBuilder({
+		label: 'Add Combo Points',
+		submenu: ['Misc'],
+		shortDescription: 'Add combo points to target.',
+		includeIf: (player: Player<any>, isPrepull: boolean) => isPrepull,
+		newValue: () =>
+			APLActionAddComboPoints.create({
+				numPoints: '1',
+			}),
+		fields: [
+			AplHelpers.stringFieldConfig('numPoints', {
+				labelTooltip: 'Desired number of initial combo points.',
 			}),
 		],
 	}),


### PR DESCRIPTION
Creating ability to add combo points to the APL via Honor Among Thieves.  I had some issues with the log bugging out if sent a nil value for the SpellID so right now it is assigned to HaT.  Haven't touched the APL at all so would appreciate a review.

![image](https://github.com/wowsims/sod/assets/118020821/e1c46da7-9cf7-4a13-9f65-a0ac9a8be8e1)


![image](https://github.com/wowsims/sod/assets/118020821/f37a3b40-b495-4eb0-9c0b-c938c979483a)
