### PR TITLE
Add clearer min level requirement error

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -488,7 +488,7 @@ func JudgementOfTheCrusaderAura(caster *Unit, target *Unit, level int32, mult fl
 
 func MekkatorqueFistDebuffAura(target *Unit, playerLevel int32) *Aura {
 	if playerLevel < 40 {
-		return nil
+		panic("Mekkatorque's Arcano-Shredder requires level 40+")
 	}
 
 	spellID := 434841
@@ -1157,7 +1157,7 @@ func AncientCorrosivePoisonAura(target *Unit) *Aura {
 
 func SerpentsStrikerFistDebuffAura(target *Unit, playerLevel int32) *Aura {
 	if playerLevel < 50 {
-		return nil
+		panic("Serpent's Striker requires level 50+")
 	}
 
 	spellID := 447894

--- a/ui/core/constants/tooltips.ts
+++ b/ui/core/constants/tooltips.ts
@@ -1,11 +1,21 @@
-export const BUFFS_SECTION = 'Buffs provided by other party/raid members. Note only the highest available buff rank will be applied, if possible, based on level selected';
+export const BUFFS_SECTION =
+	'Buffs provided by other party/raid members. Note only the highest available buff rank will be applied, if possible, based on level selected';
 export const WORLD_BUFFS_SECTION = 'World Buffs obtained from various sources across Azeroth.';
 export const DEBUFFS_SECTION = 'Debuffs applied by other raid members.';
-export const COOLDOWNS_SECTION = 'Specify cooldown timings, in seconds. Cooldowns will be used as soon as possible after their specified timings. When not specified, cooldowns will be used when ready and it is sensible to do so.<br><br>Multiple timings can be provided by separating with commas. Any cooldown usages after the last provided timing will use the default logic.';
-export const BLESSINGS_SECTION = 'Specify Paladin Blessings for each role, in order of priority. Blessings in the 1st column will be used if there is at least 1 Paladin in the raid, 2nd column if at least 2, etc.';
+export const COOLDOWNS_SECTION =
+	'Specify cooldown timings, in seconds. Cooldowns will be used as soon as possible after their specified timings. When not specified, cooldowns will be used when ready and it is sensible to do so.<br><br>Multiple timings can be provided by separating with commas. Any cooldown usages after the last provided timing will use the default logic.';
+export const BLESSINGS_SECTION =
+	'Specify Paladin Blessings for each role, in order of priority. Blessings in the 1st column will be used if there is at least 1 Paladin in the raid, 2nd column if at least 2, etc.';
 
-export const BASIC_BIS_DISCLAIMER = '<p>Preset gear lists are intended as rough approximations of BIS, and will often not be the absolute highest-DPS setup for you. Your optimal gear setup will depend on many factors; that\'s why we have a sim!</p><p>Items may also be omitted from the presets if they are highly contested and clearly better utilized on other classes, to encourage equitable gearing for the raid as a whole.</p>';
+export const BASIC_BIS_DISCLAIMER =
+	"<p>Preset gear lists are intended as rough approximations of BIS, and will often not be the absolute highest-DPS setup for you. Your optimal gear setup will depend on many factors; that's why we have a sim!</p><p>Items may also be omitted from the presets if they are highly contested and clearly better utilized on other classes, to encourage equitable gearing for the raid as a whole.</p>";
 
-export const HEALING_SIM_DISCLAIMER = '*** WARNING - USE AT YOUR OWN RISK ***\n\nThe entire concept of a healing sim is EXPERIMENTAL. All results should be taken with an EXTREMELY large grain of salt.\n\nThis tool is currently more similar to a spreadsheet than a true sim. Options for specifying incoming damage profiles in order to have proper reactive rotations have not yet been added.';
+export const HEALING_SIM_DISCLAIMER =
+	'*** WARNING - USE AT YOUR OWN RISK ***\n\nThe entire concept of a healing sim is EXPERIMENTAL. All results should be taken with an EXTREMELY large grain of salt.\n\nThis tool is currently more similar to a spreadsheet than a true sim. Options for specifying incoming damage profiles in order to have proper reactive rotations have not yet been added.';
 
-export const TOO_MANY_TALENT_POINTS = "More talent points spent than current level selected."
+export const UNSPECT_TALENT_POINTS_WARNING = 'Unspent talent points.';
+export const TOO_MANY_TALENT_POINTS_WARNING = 'More talent points spent than current level selected.';
+
+export const TITANS_GRIP_WARNING = "Dual wielding two-handed weapon(s) without Titan's Grip spec.";
+
+export const GEAR_MIN_LEVEL_WARNING = (playerLevel: number) => `Wearing gear with a minumum level requirement above level ${playerLevel}.`;

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -220,9 +220,9 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 					// Just return here, so we don't show a warning during page load.
 					return '';
 				} else if (talentPoints < this.player.getLevel() - 9) {
-					return 'Unspent talent points.';
+					return Tooltips.UNSPECT_TALENT_POINTS_WARNING;
 				} else if (talentPoints > this.player.getLevel() - 9) {
-					return Tooltips.TOO_MANY_TALENT_POINTS;
+					return Tooltips.TOO_MANY_TALENT_POINTS_WARNING;
 				} else {
 					return '';
 				}
@@ -237,7 +237,23 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 						this.player.getEquippedItem(ItemSlot.ItemSlotOffHand) != null) ||
 						this.player.getEquippedItem(ItemSlot.ItemSlotOffHand)?.item.handType == HandType.HandTypeTwoHand)
 				) {
-					return "Dual wielding two-handed weapon(s) without Titan's Grip spec.";
+					return Tooltips.TITANS_GRIP_WARNING;
+				} else {
+					return '';
+				}
+			},
+		});
+		this.addWarning({
+			updateOn: TypedEvent.onAny([this.player.gearChangeEmitter]),
+			getContent: () => {
+				const playerLevel = player.getLevel();
+				if (
+					this.player
+						.getGear()
+						.asArray()
+						.filter(item => item != null && item.item.requiresLevel < playerLevel)
+				) {
+					return Tooltips.GEAR_MIN_LEVEL_WARNING(playerLevel);
 				} else {
 					return '';
 				}


### PR DESCRIPTION
We've had a number of issues (e.g. https://github.com/wowsims/sod/issues/650) with mekkatorque's and serpent's strider's level requirements in `debuffs.go` I don't love that we use these honestly, so another alternative to the panics is to just remove them altogether.

I added a warning when the player has gear equipped with a higher level requirement
<img width="304" alt="image" src="https://github.com/wowsims/sod/assets/12898988/5687c034-ee30-453b-a44c-fdd1ba4642dd">

And the error now looks like this instead of a completely garbled mess
<img width="393" alt="image" src="https://github.com/wowsims/sod/assets/12898988/6cfe738a-688b-42cc-ac26-582de9a65210">

I still don't really like this so I'm also open to just removing the level requirements
