### PR TITLE
Update Focused Attacks to 3 Energy

### DIFF
--- a/sim/rogue/runes.go
+++ b/sim/rogue/runes.go
@@ -79,7 +79,7 @@ func (rogue *Rogue) applyFocusedAttacks() {
 				return
 			}
 			// TODO Check whether certain spells don't trigger this
-			rogue.AddEnergy(sim, 2, energyMetrics)
+			rogue.AddEnergy(sim, 3, energyMetrics)
 		},
 	})
 }


### PR DESCRIPTION
Update the Focused Attacks to grant 3 Energy instead of 2 Energy based on Bluepost here: https://www.bluetracker.gg/wow/topic/us-en/1828382-season-of-discovery-class-tuning-incoming-april-16/