### PR TITLE
Remove not needed multischool bitmasks, update warlock and mage

### DIFF
--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -140,14 +140,6 @@ type Spell struct {
 	// Adds a fixed amount of threat to this spell, before multipliers.
 	FlatThreatBonus float64
 
-	initialBonusHitRating           float64
-	initialBonusCritRating          float64
-	initialDamageMultiplier         float64
-	initialDamageMultiplierAdditive float64
-	initialThreatMultiplier         float64
-	initialCritDamageBonus          float64
-	// Note that bonus expertise and armor pen are static, so we don't bother resetting them.
-
 	resultCache SpellResult
 
 	dots   DotArray
@@ -388,20 +380,6 @@ func (spell *Spell) CurCPM(sim *Simulation) float64 {
 }
 
 func (spell *Spell) finalize() {
-	// Assert that user doesn't set dynamic fields during static initialization.
-	if spell.CastTimeMultiplier != 1 {
-		panic(spell.ActionID.String() + " has non-default CastTimeMultiplier during finalize!")
-	}
-	if spell.CostMultiplier != 1 {
-		panic(spell.ActionID.String() + " has non-default CostMultiplier during finalize!")
-	}
-	spell.initialBonusHitRating = spell.BonusHitRating
-	spell.initialBonusCritRating = spell.BonusCritRating
-	spell.initialDamageMultiplier = spell.DamageMultiplier
-	spell.initialDamageMultiplierAdditive = spell.DamageMultiplierAdditive
-	spell.initialThreatMultiplier = spell.ThreatMultiplier
-	spell.initialCritDamageBonus = spell.CritDamageBonus
-
 	if len(spell.splitSpellMetrics) > 1 && spell.ActionID.Tag != 0 {
 		panic(spell.ActionID.String() + " has split metrics and a non-zero tag, can only have one!")
 	}
@@ -418,16 +396,6 @@ func (spell *Spell) reset(_ *Simulation) {
 		}
 	}
 	spell.casts = 0
-
-	// Reset dynamic effects.
-	spell.BonusHitRating = spell.initialBonusHitRating
-	spell.BonusCritRating = spell.initialBonusCritRating
-	spell.CastTimeMultiplier = 1
-	spell.CostMultiplier = 1
-	spell.CritDamageBonus = spell.initialCritDamageBonus
-	spell.DamageMultiplier = spell.initialDamageMultiplier
-	spell.DamageMultiplierAdditive = spell.initialDamageMultiplierAdditive
-	spell.ThreatMultiplier = spell.initialThreatMultiplier
 }
 
 func (spell *Spell) SetMetricsSplit(splitIdx int32) {

--- a/sim/core/spell_school.go
+++ b/sim/core/spell_school.go
@@ -16,46 +16,6 @@ const (
 	SpellSchoolHoly
 	SpellSchoolNature
 	SpellSchoolShadow
-
-	// Physical x Other
-	SpellSchoolSpellstrike  = SpellSchoolPhysical | SpellSchoolArcane
-	SpellSchoolFlamestrike  = SpellSchoolPhysical | SpellSchoolFire
-	SpellSchoolFroststrike  = SpellSchoolPhysical | SpellSchoolFrost
-	SpellSchoolHolystrike   = SpellSchoolPhysical | SpellSchoolHoly
-	SpellSchoolStormstrike  = SpellSchoolPhysical | SpellSchoolNature
-	SpellSchoolShadowstrike = SpellSchoolPhysical | SpellSchoolShadow
-
-	// Arcane x Other
-	SpellSchoolSpellfire   = SpellSchoolArcane | SpellSchoolFire
-	SpellSchoolSpellFrost  = SpellSchoolArcane | SpellSchoolFrost
-	SpellSchoolDivine      = SpellSchoolArcane | SpellSchoolHoly
-	SpellSchoolAstral      = SpellSchoolArcane | SpellSchoolNature
-	SpellSchoolSpellShadow = SpellSchoolArcane | SpellSchoolShadow
-
-	// Fire x Other
-	SpellSchoolFrostfire   = SpellSchoolFire | SpellSchoolFrost
-	SpellSchoolRadiant     = SpellSchoolFire | SpellSchoolHoly
-	SpellSchoolVolcanic    = SpellSchoolFire | SpellSchoolNature
-	SpellSchoolShadowflame = SpellSchoolFire | SpellSchoolShadow
-
-	// Frost x Other
-	SpellSchoolHolyfrost   = SpellSchoolFrost | SpellSchoolHoly
-	SpellSchoolFroststorm  = SpellSchoolFrost | SpellSchoolNature
-	SpellSchoolShadowfrost = SpellSchoolFrost | SpellSchoolShadow
-
-	// Holy x Other
-	SpellSchoolHolystorm = SpellSchoolHoly | SpellSchoolNature
-	SpellSchoolTwilight  = SpellSchoolHoly | SpellSchoolShadow
-
-	// Nature x Other
-	SpellSchoolPlague = SpellSchoolNature | SpellSchoolShadow
-
-	SpellSchoolElemental = SpellSchoolFire | SpellSchoolFrost | SpellSchoolNature
-
-	SpellSchoolAttack = SpellSchoolPhysical |
-		SpellSchoolSpellstrike | SpellSchoolFlamestrike | SpellSchoolFroststrike | SpellSchoolHolystrike | SpellSchoolStormstrike | SpellSchoolShadowstrike
-
-	SpellSchoolMagic = SpellSchoolArcane | SpellSchoolFire | SpellSchoolFrost | SpellSchoolHoly | SpellSchoolNature | SpellSchoolShadow
 )
 
 // Get associated school mask for a school index.

--- a/sim/core/spell_school_test.go
+++ b/sim/core/spell_school_test.go
@@ -218,7 +218,7 @@ func Test_MultiSchoolResistance(t *testing.T) {
 }
 
 func Test_MultiSchoolResistanceArmor(t *testing.T) {
-	ss := SpellSchoolFlamestrike
+	ss := SpellSchoolPhysical | SpellSchoolFire
 	spell := &Spell{
 		SpellSchool:       ss,
 		SchoolIndex:       ss.GetSchoolIndex(),

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -54,7 +54,7 @@ func (druid *Druid) newBloodbarkCleaveItem(itemID int32) {
 
 	damageSpell := druid.RegisterSpell(Any, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 436481},
-		SpellSchool: core.SpellSchoolStormstrike,
+		SpellSchool: core.SpellSchoolPhysical | core.SpellSchoolNature,
 		DefenseType: core.DefenseTypeMelee, // actually has DefenseTypeNone, but is likely using the greatest CritMultiplier available
 		ProcMask:    core.ProcMaskEmpty,
 

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0742
+  weights: 0.07236
   weights: 0
-  weights: 0.337
-  weights: 0.2631
-  weights: 0.0739
-  weights: 0
-  weights: 0
+  weights: 0.30756
+  weights: 0.23413
+  weights: 0.07343
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.49166
+  weights: 0
+  weights: 0
+  weights: 0.44388
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.08758
+  weights: 0.13027
   weights: 0
-  weights: 0.5189
-  weights: 0.5189
-  weights: 0
-  weights: 0
+  weights: 0.47521
+  weights: 0.47521
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.59452
+  weights: 0
+  weights: 0
+  weights: 2.51401
   weights: 0
   weights: 0
   weights: 0
@@ -197,196 +197,196 @@ stat_weights_results: {
 dps_results: {
  key: "TestArcane-Lvl25-Average-Default"
  value: {
-  dps: 147.44792
-  tps: 62.24955
+  dps: 134.6982
+  tps: 57.14949
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 494.56992
-  tps: 263.23636
+  dps: 469.21259
+  tps: 253.17384
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 130.77462
-  tps: 55.58027
+  dps: 117.30771
+  tps: 50.19752
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 167.74243
-  tps: 74.78198
+  dps: 158.39064
+  tps: 71.06136
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 389.12688
-  tps: 221.16001
+  dps: 360.43315
+  tps: 209.68991
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 99.77647
-  tps: 43.18605
+  dps: 87.99677
+  tps: 38.47454
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 128.87812
-  tps: 59.26147
+  dps: 123.46696
+  tps: 57.09886
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 492.61668
-  tps: 262.50307
+  dps: 469.8175
+  tps: 253.45168
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 128.21264
-  tps: 54.55787
+  dps: 115.59265
+  tps: 49.5133
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 168.8717
-  tps: 75.24569
+  dps: 156.39159
+  tps: 70.27072
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 386.87368
-  tps: 220.29041
+  dps: 351.66225
+  tps: 205.95051
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 98.97828
-  tps: 42.86836
+  dps: 85.58427
+  tps: 37.49799
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 126.97831
-  tps: 58.50947
+  dps: 121.54499
+  tps: 56.27231
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 148.55527
-  tps: 62.69031
+  dps: 134.73381
+  tps: 57.17017
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Average-Default"
  value: {
-  dps: 449.64111
-  tps: 187.91892
+  dps: 409.36536
+  tps: 171.66123
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 452.6036
-  tps: 342.36718
+  dps: 408.07801
+  tps: 321.4882
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 452.6036
-  tps: 189.10773
+  dps: 408.07801
+  tps: 171.14405
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 513.25328
-  tps: 219.57973
+  dps: 491.05859
+  tps: 210.61935
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 342.92178
-  tps: 250.82594
+  dps: 305.62775
+  tps: 235.87537
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 342.92178
-  tps: 142.85157
+  dps: 305.62775
+  tps: 127.93231
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 410.17291
-  tps: 175.82778
+  dps: 377.51543
+  tps: 162.76479
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 453.90833
-  tps: 342.98117
+  dps: 411.92155
+  tps: 323.35051
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 453.90833
-  tps: 189.63422
+  dps: 411.92155
+  tps: 172.69771
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 512.16573
-  tps: 219.14466
+  dps: 494.48681
+  tps: 212.01809
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 345.89441
-  tps: 251.9326
+  dps: 303.77797
+  tps: 235.12486
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 345.89441
-  tps: 144.0365
+  dps: 303.77797
+  tps: 127.19187
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 409.58223
-  tps: 175.59151
+  dps: 379.82187
+  tps: 163.68736
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 455.13606
-  tps: 190.12105
+  dps: 417.07912
+  tps: 174.75263
  }
 }

--- a/sim/mage/arcane_blast.go
+++ b/sim/mage/arcane_blast.go
@@ -48,8 +48,8 @@ func (mage *Mage) registerArcaneBlastSpell() {
 			)
 		},
 		OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks int32, newStacks int32) {
-			aura.Refresh(sim)
-			mage.ArcaneBlast.CostMultiplier = 1.75 * float64(newStacks)
+			mage.ArcaneBlast.CostMultiplier -= 1.75 * float64(oldStacks)
+			mage.ArcaneBlast.CostMultiplier += 1.75 * float64(newStacks)
 
 			oldMultiplier := .15 * float64(oldStacks)
 			newMultiplier := .15 * float64(newStacks)

--- a/sim/mage/balefire_bolt.go
+++ b/sim/mage/balefire_bolt.go
@@ -57,7 +57,7 @@ func (mage *Mage) registerBalefireBoltSpell() {
 	mage.BalefireBolt = mage.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: int32(proto.MageRune_RuneBracersBalefireBolt)},
 		SpellCode:   SpellCode_MageBalefireBolt,
-		SpellSchool: core.SpellSchoolSpellfire,
+		SpellSchool: core.SpellSchoolArcane | core.SpellSchoolFire,
 		DefenseType: core.DefenseTypeMagic,
 		ProcMask:    core.ProcMaskSpellDamage,
 		Flags:       SpellFlagMage | core.SpellFlagAPL,

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -27,7 +27,7 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 	mage.FrostfireBolt = mage.RegisterSpell(core.SpellConfig{
 		ActionID:     actionID,
 		SpellCode:    SpellCode_MageFrostfireBolt,
-		SpellSchool:  core.SpellSchoolFrostfire,
+		SpellSchool:  core.SpellSchoolFrost | core.SpellSchoolFire,
 		DefenseType:  core.DefenseTypeMagic,
 		ProcMask:     core.ProcMaskSpellDamage,
 		Flags:        SpellFlagMage | SpellFlagChillSpell | core.SpellFlagAPL,

--- a/sim/mage/living_flame.go
+++ b/sim/mage/living_flame.go
@@ -29,7 +29,7 @@ func (mage *Mage) registerLivingFlameSpell() {
 	mage.LivingFlame = mage.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: int32(proto.MageRune_RuneLegsLivingFlame)},
 		SpellCode:    SpellCode_MageLivingFlame,
-		SpellSchool:  core.SpellSchoolSpellfire,
+		SpellSchool:  core.SpellSchoolArcane | core.SpellSchoolFire,
 		ProcMask:     core.ProcMaskSpellDamage,
 		Flags:        SpellFlagMage | core.SpellFlagAPL | core.SpellFlagPureDot,
 		MissileSpeed: 6.02,

--- a/sim/mage/spellfrost_bolt.go
+++ b/sim/mage/spellfrost_bolt.go
@@ -21,7 +21,7 @@ func (mage *Mage) registerSpellfrostBoltSpell() {
 	mage.SpellfrostBolt = mage.RegisterSpell(core.SpellConfig{
 		ActionID:     core.ActionID{SpellID: int32(proto.MageRune_RuneBeltSpellfrostBolt)},
 		SpellCode:    SpellCode_MageSpellfrostBolt,
-		SpellSchool:  core.SpellSchoolSpellFrost,
+		SpellSchool:  core.SpellSchoolArcane | core.SpellSchoolFrost,
 		DefenseType:  core.DefenseTypeMagic,
 		ProcMask:     core.ProcMaskSpellDamage,
 		Flags:        SpellFlagMage | SpellFlagChillSpell | core.SpellFlagAPL,

--- a/sim/priest/mind_spike.go
+++ b/sim/priest/mind_spike.go
@@ -29,7 +29,7 @@ func (priest *Priest) newMindSpikeSpellConfig() core.SpellConfig {
 
 	return core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: int32(proto.PriestRune_RuneWaistMindSpike)},
-		SpellSchool: core.SpellSchoolShadowfrost,
+		SpellSchool: core.SpellSchoolShadow | core.SpellSchoolFrost,
 		DefenseType: core.DefenseTypeMagic,
 		ProcMask:    core.ProcMaskSpellDamage,
 		Flags:       core.SpellFlagAPL,

--- a/sim/rogue/items.go
+++ b/sim/rogue/items.go
@@ -2,6 +2,7 @@ package rogue
 
 import (
 	"time"
+
 	"github.com/wowsims/sod/sim/core"
 )
 
@@ -14,7 +15,7 @@ func init() {
 
 		spell := character.RegisterSpell(core.SpellConfig{
 			ActionID:    core.ActionID{SpellID: 436477},
-			SpellSchool: core.SpellSchoolShadowstrike,
+			SpellSchool: core.SpellSchoolPhysical | core.SpellSchoolShadow,
 			DefenseType: core.DefenseTypeMagic,
 			ProcMask:    core.ProcMaskSpellDamage,
 			Flags:       core.SpellFlagAPL,

--- a/sim/shaman/items.go
+++ b/sim/shaman/items.go
@@ -28,7 +28,7 @@ func init() {
 
 		spell := character.RegisterSpell(core.SpellConfig{
 			ActionID:    core.ActionID{SpellID: 436413},
-			SpellSchool: core.SpellSchoolPlague,
+			SpellSchool: core.SpellSchoolNature | core.SpellSchoolShadow,
 			DefenseType: core.DefenseTypeMagic,
 			ProcMask:    core.ProcMaskSpellDamage,
 			Flags:       core.SpellFlagAPL,

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.05417
+  weights: 0.61961
   weights: 0
-  weights: 0.76189
-  weights: 0
-  weights: 0
+  weights: 1.78394
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.86454
-  weights: 1.80251
+  weights: 0
+  weights: 0
+  weights: 3.70698
+  weights: 1.72032
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.84563
+  weights: -2.6519
   weights: 0
-  weights: -0.28734
-  weights: 0
-  weights: 0
+  weights: -0.13989
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.54381
-  weights: 7.03765
+  weights: 0
+  weights: 0
+  weights: 11.08217
+  weights: 7.9629
   weights: 0
   weights: 0
   weights: 0
@@ -197,78 +197,78 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-Average-Default"
  value: {
-  dps: 560.71579
-  tps: 544.94284
+  dps: 582.00603
+  tps: 552.52865
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 551.79024
-  tps: 1168.37479
+  dps: 577.00016
+  tps: 921.98427
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 551.79024
-  tps: 536.21612
+  dps: 577.00016
+  tps: 547.71366
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 573.35419
-  tps: 531.20302
+  dps: 580.75229
+  tps: 536.9655
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 336.88598
-  tps: 985.48411
+  dps: 352.83513
+  tps: 702.67394
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 336.88598
-  tps: 345.17878
+  dps: 352.83513
+  tps: 346.30114
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 361.95106
-  tps: 344.30663
+  dps: 367.43566
+  tps: 345.63149
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 563.87564
-  tps: 548.22239
+  dps: 586.97173
+  tps: 558.05166
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1160.8347
-  tps: 1066.92677
+  dps: 1206.83921
+  tps: 1095.10593
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1721.27128
-  tps: 2577.13736
+  dps: 1763.83481
+  tps: 2266.73295
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1156.11528
-  tps: 1062.89655
+  dps: 1198.44991
+  tps: 1088.11258
  }
 }
 dps_results: {
@@ -281,28 +281,28 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 975.70977
-  tps: 1974.84575
+  dps: 1013.94244
+  tps: 1599.52638
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 572.43367
-  tps: 571.7663
+  dps: 609.46185
+  tps: 587.50151
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 670.27546
-  tps: 621.93419
+  dps: 687.46586
+  tps: 629.39836
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1157.5191
-  tps: 1064.67149
+  dps: 1199.47248
+  tps: 1088.59177
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.02694
+  weights: 0.04622
   weights: 0
-  weights: 0.52293
-  weights: 0
-  weights: 0
+  weights: 0.72959
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.43648
-  weights: 2.24429
+  weights: 0
+  weights: 0
+  weights: 6.15229
+  weights: 2.11264
   weights: 0
   weights: 0
   weights: 0
@@ -99,22 +99,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 640.93894
-  tps: 532.2626
+  dps: 660.26564
+  tps: 545.44599
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 638.59925
-  tps: 847.97907
+  dps: 658.95625
+  tps: 749.47482
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 638.59925
-  tps: 530.79855
+  dps: 658.95625
+  tps: 544.39893
  }
 }
 dps_results: {
@@ -127,15 +127,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 372.89583
-  tps: 673.38533
+  dps: 394.47635
+  tps: 534.04926
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 372.89583
-  tps: 331.88334
+  dps: 394.47635
+  tps: 346.28859
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 640.46524
-  tps: 532.61461
+  dps: 657.02061
+  tps: 542.18669
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.00529
+  weights: 0.82452
   weights: 0
-  weights: 0.35717
-  weights: 0
-  weights: 0
+  weights: 1.44086
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22135
+  weights: 0
+  weights: 0
+  weights: 0.48399
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -5.29546
+  weights: -5.51174
   weights: 0
-  weights: 0.29337
-  weights: 0
-  weights: 0
+  weights: 3.46026
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.67145
-  weights: 6.70486
+  weights: 0
+  weights: 0
+  weights: 21.73524
+  weights: 7.39795
   weights: 0
   weights: 0
   weights: 0
@@ -295,22 +295,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 109.45205
-  tps: 94.71819
+  dps: 187.01436
+  tps: 152.92824
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 379.14038
-  tps: 694.42097
+  dps: 458.11861
+  tps: 491.48169
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 109.28935
-  tps: 94.46186
+  dps: 186.81293
+  tps: 152.88937
  }
 }
 dps_results: {
@@ -323,15 +323,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 277.02323
-  tps: 677.67484
+  dps: 347.71836
+  tps: 553.48118
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 63.47365
-  tps: 62.5639
+  dps: 89.84722
+  tps: 78.60906
  }
 }
 dps_results: {
@@ -344,85 +344,85 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 109.28935
-  tps: 94.46186
+  dps: 186.81293
+  tps: 152.88937
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 94.86912
-  tps: 78.26719
+  dps: 94.90711
+  tps: 58.68603
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 94.61695
-  tps: 1040.53846
+  tps: 661.43702
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 94.61695
-  tps: 76.49066
+  tps: 57.53559
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 212.72167
-  tps: 149.517
+  tps: 137.67008
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 47.68452
-  tps: 1016.69201
+  dps: 46.22163
+  tps: 634.41802
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 47.68452
-  tps: 65.67974
+  dps: 46.22163
+  tps: 45.0583
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 120.86908
-  tps: 105.4156
+  tps: 94.84096
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 93.66893
-  tps: 75.74413
+  tps: 56.78905
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1145.86694
-  tps: 1063.4847
+  dps: 1196.54947
+  tps: 1103.55895
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1843.58306
-  tps: 2421.18307
+  dps: 1888.59494
+  tps: 2260.09798
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1135.64036
-  tps: 1052.37847
+  dps: 1185.12764
+  tps: 1091.13996
  }
 }
 dps_results: {
@@ -435,28 +435,28 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1105.05158
-  tps: 1801.30535
+  dps: 1148.53483
+  tps: 1559.67486
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 594.50053
-  tps: 583.89156
+  dps: 641.29658
+  tps: 617.08748
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 729.80042
-  tps: 672.32608
+  dps: 734.32015
+  tps: 676.58838
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1141.97769
-  tps: 1061.03002
+  dps: 1196.81964
+  tps: 1104.97017
  }
 }

--- a/sim/warlock/lifetap.go
+++ b/sim/warlock/lifetap.go
@@ -10,6 +10,10 @@ func (warlock *Warlock) getLifeTapBaseConfig(rank int) core.SpellConfig {
 	level := [7]int{0, 6, 16, 26, 36, 46, 56}[rank]
 
 	actionID := core.ActionID{SpellID: spellId}
+	var manaPetMetrics *core.ResourceMetrics
+	if warlock.Pet != nil {
+		manaPetMetrics = warlock.Pet.NewManaMetrics(actionID)
+	}
 	manaMetrics := warlock.NewManaMetrics(actionID)
 	impLifetap := 1.0 + 0.1*float64(warlock.Talents.ImprovedLifeTap)
 	spellCoef := 0.68
@@ -38,6 +42,9 @@ func (warlock *Warlock) getLifeTapBaseConfig(rank int) core.SpellConfig {
 				restore *= 2
 			}
 			warlock.AddMana(sim, restore, manaMetrics)
+			if warlock.Pet != nil && warlock.Pet.IsActive() {
+				warlock.AddMana(sim, restore, manaPetMetrics)
+			}
 		},
 	}
 }

--- a/sim/warlock/talents.go
+++ b/sim/warlock/talents.go
@@ -35,6 +35,9 @@ func (warlock *Warlock) applyMasterDemonologist() {
 		return
 	}
 
+	hasMeta := warlock.HasRune(proto.WarlockRune_RuneHandsMetamorphosis)
+	threatMultiplier := core.TernaryFloat64(hasMeta, 1+0.04*float64(warlock.Talents.MasterDemonologist), 1-0.04*float64(warlock.Talents.MasterDemonologist))
+
 	masterDemonologistConfig := core.Aura{
 		Label:    "Master Demonologist",
 		ActionID: core.ActionID{SpellID: 23825},
@@ -42,29 +45,29 @@ func (warlock *Warlock) applyMasterDemonologist() {
 		OnGain: func(aura *core.Aura, _ *core.Simulation) {
 			switch warlock.Options.Summon {
 			case proto.WarlockOptions_Imp:
-				aura.Unit.PseudoStats.ThreatMultiplier /= 1 + 0.04*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.ThreatMultiplier *= threatMultiplier
 			case proto.WarlockOptions_Succubus:
 				aura.Unit.PseudoStats.DamageDealtMultiplier *= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
 			case proto.WarlockOptions_Voidwalker:
-				aura.Unit.PseudoStats.DamageTakenMultiplier /= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.DamageTakenMultiplier *= 1 - 0.02*float64(warlock.Talents.MasterDemonologist)
 			case proto.WarlockOptions_Felguard:
-				aura.Unit.PseudoStats.ThreatMultiplier /= 1 + 0.04*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.ThreatMultiplier *= threatMultiplier
 				aura.Unit.PseudoStats.DamageDealtMultiplier *= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
-				aura.Unit.PseudoStats.DamageTakenMultiplier /= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.DamageTakenMultiplier *= 1 - 0.02*float64(warlock.Talents.MasterDemonologist)
 			}
 		},
 		OnExpire: func(aura *core.Aura, _ *core.Simulation) {
 			switch warlock.Options.Summon {
 			case proto.WarlockOptions_Imp:
-				aura.Unit.PseudoStats.ThreatMultiplier *= 1 + 0.04*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.ThreatMultiplier /= threatMultiplier
 			case proto.WarlockOptions_Succubus:
 				aura.Unit.PseudoStats.DamageDealtMultiplier /= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
 			case proto.WarlockOptions_Voidwalker:
-				aura.Unit.PseudoStats.DamageTakenMultiplier *= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.DamageTakenMultiplier /= 1 - 0.02*float64(warlock.Talents.MasterDemonologist)
 			case proto.WarlockOptions_Felguard:
-				aura.Unit.PseudoStats.ThreatMultiplier *= 1 + 0.04*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.ThreatMultiplier /= threatMultiplier
 				aura.Unit.PseudoStats.DamageDealtMultiplier /= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
-				aura.Unit.PseudoStats.DamageTakenMultiplier *= 1 + 0.02*float64(warlock.Talents.MasterDemonologist)
+				aura.Unit.PseudoStats.DamageTakenMultiplier /= 1 - 0.02*float64(warlock.Talents.MasterDemonologist)
 			}
 		},
 	}

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.05811
+  weights: 0.34664
   weights: 0
-  weights: 0.55301
-  weights: 0
-  weights: 0
+  weights: 0.95778
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37886
+  weights: 0
+  weights: 0
+  weights: 0.39045
   weights: 0
   weights: 0
   weights: 0
@@ -99,22 +99,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Average-Default"
  value: {
-  dps: 169.24964
-  tps: 327.14618
+  dps: 172.97668
+  tps: 334.04543
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 205.30973
-  tps: 614.72614
+  dps: 213.27698
+  tps: 490.91904
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 169.28388
-  tps: 326.81245
+  dps: 172.70118
+  tps: 333.60043
  }
 }
 dps_results: {
@@ -127,36 +127,36 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 150.57734
-  tps: 572.14759
+  dps: 157.18291
+  tps: 425.43114
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 120.76033
-  tps: 241.27124
+  dps: 125.77685
+  tps: 247.31992
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 132.40289
-  tps: 254.97457
+  dps: 134.47864
+  tps: 258.27532
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 205.30973
-  tps: 614.72614
+  dps: 213.27698
+  tps: 490.91904
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 169.28388
-  tps: 326.81245
+  dps: 172.70118
+  tps: 333.60043
  }
 }
 dps_results: {
@@ -169,28 +169,28 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 150.57734
-  tps: 572.14759
+  dps: 157.18291
+  tps: 425.43114
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 120.76033
-  tps: 241.27124
+  dps: 125.77685
+  tps: 247.31992
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 132.40289
-  tps: 254.97457
+  dps: 134.47864
+  tps: 258.27532
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 169.36079
-  tps: 326.92781
+  dps: 172.77808
+  tps: 333.71579
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50725
+  weights: 0.00152
   weights: 0
-  weights: 0.85059
-  weights: 0
-  weights: 0
+  weights: 0.75809
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.47202
-  weights: 1.42282
+  weights: 0
+  weights: 0
+  weights: 5.6411
+  weights: 1.42381
   weights: 0
   weights: 0
   weights: 0
@@ -99,22 +99,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 584.24214
-  tps: 1116.89407
+  dps: 593.25287
+  tps: 1135.95962
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 547.63686
-  tps: 1568.37156
+  dps: 559.87198
+  tps: 1417.43692
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 547.63686
-  tps: 1056.47868
+  dps: 559.87198
+  tps: 1079.48166
  }
 }
 dps_results: {
@@ -127,15 +127,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 324.88775
-  tps: 1244.32824
+  dps: 337.44884
+  tps: 1026.42629
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 324.88775
-  tps: 680.77795
+  dps: 337.44884
+  tps: 703.95206
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 581.28522
-  tps: 1109.54967
+  dps: 589.31653
+  tps: 1127.8175
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.55401
+  weights: -0.5272
   weights: 0
-  weights: 1.53324
-  weights: 0
-  weights: 0
+  weights: -0.66798
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.30806
+  weights: 0
+  weights: 0
+  weights: 0.37926
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.17368
+  weights: 0.02884
   weights: 0
-  weights: 0.66735
-  weights: 0
-  weights: 0
+  weights: 0.66741
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.70625
-  weights: 3.45082
+  weights: 0
+  weights: 0
+  weights: 5.82611
+  weights: 3.49205
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.18665
+  weights: 2.17832
   weights: 0
-  weights: 1.08965
-  weights: 0
-  weights: 0
+  weights: 0.9757
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.33965
-  weights: 5.2049
+  weights: 0
+  weights: 0
+  weights: 4.7818
+  weights: 5.29062
   weights: 0
   weights: 0
   weights: 0
@@ -295,22 +295,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 149.04506
-  tps: 273.30978
+  dps: 159.96594
+  tps: 299.94665
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 394.95327
-  tps: 840.73888
+  dps: 393.13636
+  tps: 735.98701
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 140.86581
-  tps: 260.63211
+  dps: 152.1332
+  tps: 286.96194
  }
 }
 dps_results: {
@@ -323,15 +323,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 305.39556
-  tps: 905.7883
+  dps: 309.12065
+  tps: 613.02652
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 81.64355
-  tps: 149.2589
+  dps: 115.74195
+  tps: 225.37488
  }
 }
 dps_results: {
@@ -344,29 +344,29 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 145.73247
-  tps: 267.93209
+  dps: 156.928
+  tps: 294.15414
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 491.652
-  tps: 1087.39383
+  dps: 492.17911
+  tps: 1088.50015
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 818.47632
-  tps: 1781.6558
+  dps: 827.66674
+  tps: 1741.57578
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 452.10374
-  tps: 1023.22741
+  dps: 458.56101
+  tps: 1040.22917
  }
 }
 dps_results: {
@@ -379,15 +379,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 554.04252
-  tps: 1328.99908
+  dps: 562.34922
+  tps: 1229.20793
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 274.03227
-  tps: 632.63519
+  dps: 282.57071
+  tps: 651.69534
  }
 }
 dps_results: {
@@ -400,32 +400,32 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 481.6594
-  tps: 1067.35175
+  dps: 481.7279
+  tps: 1067.26517
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1112.66938
-  tps: 1995.49929
-  hps: 17.11231
+  dps: 1132.49396
+  tps: 2036.64153
+  hps: 17.08832
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1622.41843
-  tps: 3706.02407
-  hps: 14.3812
+  dps: 1664.2649
+  tps: 3470.55268
+  hps: 14.53649
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1046.77327
-  tps: 1880.46016
-  hps: 14.47206
+  dps: 1072.76711
+  tps: 1934.95553
+  hps: 14.47525
  }
 }
 dps_results: {
@@ -439,32 +439,32 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 962.27005
-  tps: 2706.70691
-  hps: 9.65167
+  dps: 973.62058
+  tps: 2314.49832
+  hps: 9.48167
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 537.08905
-  tps: 1029.45698
-  hps: 9.545
+  dps: 555.88396
+  tps: 1057.4909
+  hps: 9.56333
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 592.17307
-  tps: 1048.83522
-  hps: 10.325
+  dps: 597.57427
+  tps: 1053.58216
+  hps: 10.225
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1084.15732
-  tps: 1940.07841
-  hps: 17.41171
+  dps: 1101.3503
+  tps: 1982.62753
+  hps: 17.43357
  }
 }

--- a/sim/warlock/unstable_affliction.go
+++ b/sim/warlock/unstable_affliction.go
@@ -13,7 +13,7 @@ func (warlock *Warlock) registerUnstableAfflictionSpell() {
 	}
 
 	spellCoeff := 0.2
-	baseDamage := warlock.baseRuneAbilityDamage() * 0.6
+	baseDamage := warlock.baseRuneAbilityDamage() * 0.6 * 2.2
 
 	hasPandemicRune := warlock.HasRune(proto.WarlockRune_RuneHelmPandemic)
 

--- a/sim/warrior/items.go
+++ b/sim/warrior/items.go
@@ -49,7 +49,7 @@ func init() {
 
 		spell := character.RegisterSpell(core.SpellConfig{
 			ActionID:    actionId,
-			SpellSchool: core.SpellSchoolShadowstrike,
+			SpellSchool: core.SpellSchoolPhysical | core.SpellSchoolShadow,
 			ProcMask:    core.ProcMaskSpellDamage,
 			Flags:       core.SpellFlagAPL,
 


### PR DESCRIPTION
Removed some old code that is no longer needed:
- Removed multischool bitmasks as they are making it harder for people that dont know the specific names to work with multi school names
- Old spell value snapshoting - this is no longer be needed as all dynamic changes are handled by auras which are deactivated at end of iterations
- Mage Arcane Blast mana cost increase fixed
- Latest warlock updates