### PR TITLE
Binary Resist Changes

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -396,31 +396,22 @@ func JudgementOfWisdomAura(target *Unit, level int32) *Aura {
 				return // Phantom spells (Romulo's, Lightning Capacitor, etc.) don't proc JoW.
 			}
 
-			procChance := 0.5
-			if spell.ProcMask.Matches(ProcMaskWhiteHit | ProcMaskRanged) {
-				// Apparently ranged/melee can still proc on miss
-				if sim.RandomFloat("JoW Proc") > procChance {
-					return
-				}
-			} else { // spell casting
-				if !spell.ProcMask.Matches(ProcMaskDirect) {
-					return
-				}
-
-				if !result.Landed() {
-					return
-				}
-
-				if sim.RandomFloat("jow") > procChance {
-					return
-				}
+			if !spell.ProcMask.Matches(ProcMaskDirect) {
+				return
 			}
 
-			if unit.JowManaMetrics == nil {
-				unit.JowManaMetrics = unit.NewManaMetrics(actionID)
+			// melee auto attacks don't even need to land
+			if !result.Landed() && !spell.ProcMask.Matches(ProcMaskMeleeWhiteHit) {
+				return
 			}
-			// JoW returns flat mana
-			unit.AddMana(sim, jowMana, unit.JowManaMetrics)
+
+			if sim.RandomFloat("jow") < 0.5 {
+				if unit.JowManaMetrics == nil {
+					unit.JowManaMetrics = unit.NewManaMetrics(actionID)
+				}
+				// JoW returns flat mana
+				unit.AddMana(sim, jowMana, unit.JowManaMetrics)
+			}
 		},
 	})
 }

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -52,8 +52,6 @@ const (
 	ProcMaskProc
 	// Mask for FT weapon and rogue poisons, seems to be spell procs from a weapon imbue
 	ProcMaskWeaponProc
-	// Mind Flay - currently used by "Arcane Missiles" and "Mind Sear", but does nothing
-	ProcMaskNotInSpellbook
 )
 
 const (

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.04034
+  weights: 0.04907
   weights: 0
-  weights: 0.48914
-  weights: 0
-  weights: 0
+  weights: 0.4928
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.7335
+  weights: 0
+  weights: 0
+  weights: 0.74466
   weights: 0
   weights: 0
   weights: 0.00087
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.19472
+  weights: 0.41252
   weights: 0
-  weights: 0.77253
-  weights: 0
-  weights: 0
+  weights: 0.77621
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.27801
-  weights: 3.40348
+  weights: 0
+  weights: 0
+  weights: 5.92635
+  weights: 3.35802
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.41448
+  weights: 0.37925
   weights: 0
-  weights: 0.99852
-  weights: 0
-  weights: 0
+  weights: 1.00355
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 7.50625
-  weights: 7.37154
+  weights: 0
+  weights: 0
+  weights: 8.58919
+  weights: 7.98469
   weights: 0
   weights: 0
   weights: 0
@@ -295,294 +295,294 @@ stat_weights_results: {
 dps_results: {
  key: "TestBalance-Lvl25-Average-Default"
  value: {
-  dps: 173.14987
-  tps: 175.36161
+  dps: 174.6471
+  tps: 176.85884
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 171.23096
-  tps: 213.60055
+  dps: 173.05772
+  tps: 215.42731
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 171.23096
-  tps: 173.34944
+  dps: 173.05772
+  tps: 175.1762
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 171.34913
-  tps: 175.709
+  dps: 173.04282
+  tps: 177.4027
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 119.13658
-  tps: 158.15025
+  dps: 120.65595
+  tps: 159.66962
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 119.13658
-  tps: 121.08727
+  dps: 120.65595
+  tps: 122.60664
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 119.78197
-  tps: 124.14185
+  dps: 121.41241
+  tps: 125.77228
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 170.83244
-  tps: 216.24017
+  dps: 172.63156
+  tps: 218.03929
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 170.83244
-  tps: 173.10282
+  dps: 172.63156
+  tps: 174.90195
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 171.11958
-  tps: 175.47946
+  dps: 172.78797
+  tps: 177.14785
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 119.12793
-  tps: 166.12442
+  dps: 120.60277
+  tps: 167.59926
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 119.12793
-  tps: 121.47776
+  dps: 120.60277
+  tps: 122.95259
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 119.69951
-  tps: 124.05938
+  dps: 121.32995
+  tps: 125.68982
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 172.08363
-  tps: 174.39669
+  dps: 173.91922
+  tps: 176.23229
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Average-Default"
  value: {
-  dps: 559.023
-  tps: 569.56144
+  dps: 562.50253
+  tps: 573.0434
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 530.46018
-  tps: 711.45233
+  dps: 534.54528
+  tps: 715.53743
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 530.46018
-  tps: 539.50979
+  dps: 534.54528
+  tps: 543.59489
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 546.44375
-  tps: 558.56157
+  dps: 547.15539
+  tps: 559.27321
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 403.90932
-  tps: 484.07529
+  dps: 406.07193
+  tps: 486.23789
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 403.90932
-  tps: 407.91762
+  dps: 406.07193
+  tps: 410.08023
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 445.18922
-  tps: 451.89672
+  dps: 446.11764
+  tps: 452.82514
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 529.82259
-  tps: 710.87761
+  dps: 534.13658
+  tps: 715.19161
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 529.82259
-  tps: 538.87534
+  dps: 534.13658
+  tps: 543.18933
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 546.44375
-  tps: 558.56157
+  dps: 547.15539
+  tps: 559.27321
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 402.18428
-  tps: 482.35024
+  dps: 405.0556
+  tps: 485.22157
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 402.18428
-  tps: 406.19258
+  dps: 405.0556
+  tps: 409.0639
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 442.60611
-  tps: 449.31361
+  dps: 444.09543
+  tps: 450.80293
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 555.13005
-  tps: 565.67974
+  dps: 557.92003
+  tps: 568.43949
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Average-Default"
  value: {
-  dps: 962.34418
-  tps: 980.19756
+  dps: 967.77445
+  tps: 985.66079
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 906.72166
-  tps: 1240.84897
+  dps: 909.73953
+  tps: 1243.86684
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 906.72166
-  tps: 923.42802
+  dps: 909.73953
+  tps: 926.44589
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 908.29047
-  tps: 919.1038
+  dps: 911.33844
+  tps: 922.15177
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 642.83942
-  tps: 878.9893
+  dps: 646.87034
+  tps: 883.02022
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 642.83942
-  tps: 654.64692
+  dps: 646.87034
+  tps: 658.67783
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 672.431
-  tps: 690.53143
+  dps: 676.05413
+  tps: 694.15456
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 905.53404
-  tps: 1239.50802
+  dps: 908.74397
+  tps: 1242.71795
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 905.53404
-  tps: 922.23274
+  dps: 908.74397
+  tps: 925.44267
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 905.24833
-  tps: 916.06167
+  dps: 908.2963
+  tps: 919.10964
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 642.61516
-  tps: 883.86199
+  dps: 645.9841
+  tps: 887.23093
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 642.61516
-  tps: 654.6775
+  dps: 645.9841
+  tps: 658.04644
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 672.431
-  tps: 690.53143
+  dps: 676.05413
+  tps: 694.15456
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 956.4188
-  tps: 974.3243
+  dps: 964.43198
+  tps: 982.29611
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -197,8 +197,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.83466
-  weights: 0.70667
+  weights: 0.83398
+  weights: 0.79587
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +214,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.36483
-  weights: 5.01
-  weights: 5.73988
+  weights: 0.36453
+  weights: 4.4971
+  weights: 5.70423
   weights: 0
   weights: 0
   weights: 0
@@ -561,8 +561,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-Average-Default"
  value: {
-  dps: 757.7518
-  tps: 557.27136
+  dps: 757.63455
+  tps: 557.18859
  }
 }
 dps_results: {
@@ -828,7 +828,7 @@ dps_results: {
  key: "TestFeral-Lvl50-Average-Default"
  value: {
   dps: 1788.11828
-  tps: 1288.25756
+  tps: 1288.27458
  }
 }
 dps_results: {
@@ -1087,6 +1087,6 @@ dps_results: {
  key: "TestFeral-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
   dps: 1257.66486
-  tps: 900.87475
+  tps: 900.75661
  }
 }

--- a/sim/druid/hurricane.go
+++ b/sim/druid/hurricane.go
@@ -49,7 +49,7 @@ func (druid *Druid) newHurricaneSpellConfig(rank int, cooldownTimer *core.Timer)
 		ActionID:    core.ActionID{SpellID: spellId},
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagOmen | core.SpellFlagChanneled | core.SpellFlagAPL,
+		Flags:       SpellFlagOmen | core.SpellFlagChanneled | core.SpellFlagBinary | core.SpellFlagAPL,
 
 		RequiredLevel: level,
 		Rank:          rank,

--- a/sim/druid/starsurge.go
+++ b/sim/druid/starsurge.go
@@ -55,7 +55,7 @@ func (druid *Druid) applyStarsurge() {
 		SpellSchool: core.SpellSchoolArcane,
 		DefenseType: core.DefenseTypeMagic,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagOmen | core.SpellFlagAPL | core.SpellFlagResetAttackSwing,
+		Flags:       SpellFlagOmen | core.SpellFlagResetAttackSwing | core.SpellFlagBinary | core.SpellFlagAPL,
 
 		MissileSpeed: 24,
 

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -296,35 +296,35 @@ dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
   dps: 881.70072
-  tps: 269.19297
+  tps: 269.14481
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Average-Default"
  value: {
   dps: 890.11337
-  tps: 276.70789
+  tps: 276.70079
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 1464.56788
-  tps: 876.68942
+  tps: 874.98882
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 791.41004
-  tps: 209.2048
+  tps: 209.04424
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 823.92648
-  tps: 222.03572
+  tps: 222.03145
  }
 }
 dps_results: {
@@ -351,22 +351,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 577.05116
-  tps: 545.55505
+  dps: 577.50244
+  tps: 544.44313
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 511.14155
-  tps: 247.59356
+  dps: 511.32371
+  tps: 247.48554
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 558.83009
-  tps: 263.20106
+  tps: 263.37981
  }
 }
 dps_results: {
@@ -393,15 +393,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 499.79841
-  tps: 472.17271
+  dps: 498.44692
+  tps: 467.32556
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 499.79841
-  tps: 203.93277
+  dps: 498.44692
+  tps: 203.15725
  }
 }
 dps_results: {
@@ -435,22 +435,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 775.29292
-  tps: 855.05657
+  dps: 772.37916
+  tps: 855.73279
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 690.47923
-  tps: 421.50582
+  dps: 689.55277
+  tps: 419.58639
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 755.83576
-  tps: 458.7959
+  tps: 459.2912
  }
 }
 dps_results: {
@@ -478,21 +478,21 @@ dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 1469.11014
-  tps: 866.0723
+  tps: 864.05308
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 799.57609
-  tps: 205.26343
+  tps: 205.13135
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 836.54024
-  tps: 224.6846
+  tps: 224.61319
  }
 }
 dps_results: {
@@ -519,22 +519,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 585.00068
-  tps: 542.20461
+  dps: 585.86071
+  tps: 540.22777
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 519.24873
-  tps: 244.07107
+  dps: 520.04602
+  tps: 244.19948
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 569.35821
-  tps: 260.13239
+  tps: 260.31114
  }
 }
 dps_results: {
@@ -561,22 +561,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 511.20066
-  tps: 463.91844
+  dps: 509.26826
+  tps: 462.68426
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 511.20066
-  tps: 202.21592
+  dps: 509.26826
+  tps: 198.86451
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 565.60642
-  tps: 231.77404
+  tps: 231.88404
  }
 }
 dps_results: {
@@ -603,22 +603,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 777.91387
-  tps: 851.61312
+  dps: 778.45074
+  tps: 852.62043
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 699.22122
-  tps: 416.26531
+  dps: 697.05218
+  tps: 416.11353
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 763.24432
-  tps: 453.7872
+  tps: 454.26948
  }
 }
 dps_results: {
@@ -646,6 +646,6 @@ dps_results: {
  key: "TestBM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 845.13271
-  tps: 254.25443
+  tps: 254.26152
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -296,35 +296,35 @@ dps_results: {
  key: "TestMM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
   dps: 343.35205
-  tps: 181.62681
+  tps: 181.63106
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Average-Default"
  value: {
   dps: 346.7395
-  tps: 183.67844
+  tps: 183.67756
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 728.68419
-  tps: 909.05343
+  dps: 728.45731
+  tps: 907.08471
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 628.83691
-  tps: 492.80929
+  dps: 629.24385
+  tps: 492.81586
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 657.14862
-  tps: 520.88072
+  tps: 521.2567
  }
 }
 dps_results: {
@@ -351,22 +351,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 733.29199
-  tps: 905.57355
+  dps: 735.9402
+  tps: 907.19964
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 635.43406
-  tps: 492.33854
+  dps: 636.19259
+  tps: 492.67145
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 664.08296
-  tps: 519.56815
+  tps: 519.91663
  }
 }
 dps_results: {
@@ -394,6 +394,6 @@ dps_results: {
  key: "TestMM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 331.24478
-  tps: 168.96888
+  tps: 168.97313
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -296,35 +296,35 @@ dps_results: {
  key: "TestSV-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
   dps: 871.65888
-  tps: 298.97345
+  tps: 299.02302
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
   dps: 880.64502
-  tps: 306.04843
+  tps: 306.04782
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 1452.20162
-  tps: 884.98953
+  tps: 884.53704
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 744.20111
-  tps: 210.80062
+  tps: 210.79418
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 757.08428
-  tps: 222.69373
+  tps: 222.58687
  }
 }
 dps_results: {
@@ -352,21 +352,21 @@ dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 1463.58141
-  tps: 881.05066
+  tps: 880.80374
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 753.7747
-  tps: 212.31422
+  tps: 212.25886
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 767.6757
-  tps: 226.46557
+  tps: 226.16248
  }
 }
 dps_results: {
@@ -394,6 +394,6 @@ dps_results: {
  key: "TestSV-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 830.50991
-  tps: 282.42453
+  tps: 282.42899
  }
 }

--- a/sim/hunter/chimera_shot.go
+++ b/sim/hunter/chimera_shot.go
@@ -27,7 +27,7 @@ func (hunter *Hunter) registerChimeraShotSpell() {
 		SpellSchool:  core.SpellSchoolNature,
 		DefenseType:  core.DefenseTypeRanged,
 		ProcMask:     core.ProcMaskRangedSpecial,
-		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagAPL | core.SpellFlagIgnoreResists,
+		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreResists | core.SpellFlagAPL,
 		CastType:     proto.CastType_CastTypeRanged,
 		MissileSpeed: 24,
 

--- a/sim/hunter/explosive_shot.go
+++ b/sim/hunter/explosive_shot.go
@@ -28,7 +28,7 @@ func (hunter *Hunter) registerExplosiveShotSpell(timer *core.Timer) {
 		SpellSchool:  core.SpellSchoolFire,
 		DefenseType:  core.DefenseTypeRanged,
 		ProcMask:     core.ProcMaskRangedSpecial,
-		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagAPL | core.SpellFlagIgnoreResists | core.SpellFlagBinary,
+		Flags:        core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreResists | core.SpellFlagAPL,
 		CastType:     proto.CastType_CastTypeRanged,
 		MissileSpeed: 24,
 

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -55,16 +55,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.99564
+  weights: 1.02577
   weights: 0
-  weights: 0.99564
-  weights: 0
-  weights: 0
+  weights: 1.02577
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 23.461
+  weights: 0
+  weights: 0
+  weights: 21.03535
   weights: 0
   weights: 0
   weights: 0
@@ -99,98 +99,98 @@ stat_weights_results: {
 dps_results: {
  key: "TestFrost-Lvl50-Average-Default"
  value: {
-  dps: 1038.72911
-  tps: 807.31678
+  dps: 1081.62749
+  tps: 840.11859
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1011.79909
-  tps: 1023.8986
+  dps: 1049.2402
+  tps: 1052.29613
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1011.79909
-  tps: 785.59885
+  dps: 1049.2402
+  tps: 813.99638
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1080.766
-  tps: 828.76009
+  dps: 1125.91729
+  tps: 862.40948
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 577.50312
-  tps: 648.56379
+  dps: 601.46833
+  tps: 666.58376
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 577.50312
-  tps: 446.5064
+  dps: 601.46833
+  tps: 464.52637
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 626.32601
-  tps: 478.48887
+  dps: 656.66436
+  tps: 501.46815
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1011.21442
-  tps: 1030.6001
+  dps: 1052.69888
+  tps: 1062.08771
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1011.21442
-  tps: 785.31083
+  dps: 1052.69888
+  tps: 816.79844
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1075.70172
-  tps: 826.35294
+  dps: 1125.55912
+  tps: 863.44967
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 582.76623
-  tps: 652.26779
+  dps: 604.72437
+  tps: 668.87897
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 582.76623
-  tps: 450.13669
+  dps: 604.72437
+  tps: 466.74787
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 630.87975
-  tps: 482.74877
+  dps: 658.60427
+  tps: 503.75821
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1014.90845
-  tps: 788.15085
+  dps: 1053.60252
+  tps: 817.72836
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -104,16 +104,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.83485
+  weights: 0.86528
   weights: 0
-  weights: 0.83485
-  weights: 0
-  weights: 0
+  weights: 0.86528
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.42248
-  weights: 2.49845
+  weights: 0
+  weights: 0
+  weights: 2.54497
+  weights: 2.32126
   weights: 0
   weights: 0
   weights: 0
@@ -153,16 +153,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.15706
+  weights: 1.19261
   weights: 0
-  weights: 1.15706
-  weights: 0
-  weights: 0
+  weights: 1.19261
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 12.85894
+  weights: 0
+  weights: 0
+  weights: 17.44263
   weights: 0
   weights: 0
   weights: 0
@@ -197,196 +197,196 @@ stat_weights_results: {
 dps_results: {
  key: "TestFrostFire-Lvl40-Average-Default"
  value: {
-  dps: 581.22242
-  tps: 418.41004
+  dps: 600.69062
+  tps: 432.03779
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1275.71596
-  tps: 1122.20484
+  dps: 1290.48915
+  tps: 1132.54607
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 576.52639
-  tps: 414.90385
+  dps: 592.19585
+  tps: 425.87247
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 622.97977
-  tps: 449.65998
+  dps: 636.04759
+  tps: 458.80746
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 640.51364
-  tps: 585.13489
+  dps: 649.12893
+  tps: 591.16559
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 330.51004
-  tps: 238.55124
+  dps: 339.12784
+  tps: 244.5837
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 432.90781
-  tps: 316.89515
+  dps: 446.33596
+  tps: 326.29485
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1213.25707
-  tps: 1077.33012
+  dps: 1230.05734
+  tps: 1089.09031
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 574.13723
-  tps: 413.30945
+  dps: 592.20313
+  tps: 425.95558
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 620.3024
-  tps: 447.73066
+  dps: 634.17757
+  tps: 457.44329
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 620.00686
-  tps: 571.65474
+  dps: 628.22899
+  tps: 577.41023
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 322.42367
-  tps: 232.84542
+  dps: 332.62027
+  tps: 239.98304
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 430.94942
-  tps: 315.58586
+  dps: 446.67496
+  tps: 326.59374
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 576.29474
-  tps: 414.83981
+  dps: 593.35244
+  tps: 426.78021
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Average-Default"
  value: {
-  dps: 1175.39492
-  tps: 844.35957
+  dps: 1216.2196
+  tps: 872.93791
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2405.76638
-  tps: 2215.06846
+  dps: 2445.23565
+  tps: 2242.66074
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1166.47658
-  tps: 837.80823
+  dps: 1209.5188
+  tps: 867.93778
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1202.74559
-  tps: 857.68642
+  dps: 1239.22725
+  tps: 883.25261
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1287.95736
-  tps: 1331.64001
+  dps: 1304.01568
+  tps: 1342.88708
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 579.46593
-  tps: 422.41245
+  dps: 594.0733
+  tps: 432.64011
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 736.71211
-  tps: 544.0578
+  dps: 752.14747
+  tps: 554.82505
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2404.57849
-  tps: 2217.13872
+  dps: 2440.85715
+  tps: 2242.54608
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1172.86388
-  tps: 842.19717
+  dps: 1215.41471
+  tps: 871.97251
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1197.29228
-  tps: 856.28475
+  dps: 1245.26582
+  tps: 889.83207
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1256.94223
-  tps: 1307.67455
+  dps: 1275.90728
+  tps: 1320.97009
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 588.28343
-  tps: 428.40803
+  dps: 605.84833
+  tps: 440.69595
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 748.93125
-  tps: 552.35215
+  dps: 764.14921
+  tps: 562.97972
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1168.83468
-  tps: 839.36158
+  dps: 1211.96868
+  tps: 869.57382
  }
 }

--- a/sim/mage/arcane_missiles.go
+++ b/sim/mage/arcane_missiles.go
@@ -112,7 +112,7 @@ func (mage *Mage) getArcaneMissilesTickSpell(rank int) *core.Spell {
 		ActionID:     core.ActionID{SpellID: spellId}.WithTag(1),
 		SpellSchool:  core.SpellSchoolArcane,
 		DefenseType:  core.DefenseTypeMagic,
-		ProcMask:     core.ProcMaskProc | core.ProcMaskNotInSpellbook,
+		ProcMask:     core.ProcMaskProc,
 		Flags:        SpellFlagMage,
 		MissileSpeed: 20,
 

--- a/sim/mage/blast_wave.go
+++ b/sim/mage/blast_wave.go
@@ -45,7 +45,7 @@ func (mage *Mage) newBlastWaveSpellConfig(rank int, cooldownTimer *core.Timer) c
 		SpellSchool: core.SpellSchoolFire,
 		DefenseType: core.DefenseTypeMagic,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       SpellFlagMage | core.SpellFlagAPL,
+		Flags:       SpellFlagMage | core.SpellFlagBinary | core.SpellFlagAPL,
 
 		RequiredLevel: level,
 		Rank:          rank,

--- a/sim/mage/frostbolt.go
+++ b/sim/mage/frostbolt.go
@@ -42,7 +42,7 @@ func (mage *Mage) getFrostboltConfig(rank int) core.SpellConfig {
 		SpellSchool:  core.SpellSchoolFrost,
 		DefenseType:  core.DefenseTypeMagic,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        core.SpellFlagAPL | SpellFlagMage | SpellFlagChillSpell,
+		Flags:        SpellFlagMage | SpellFlagChillSpell | core.SpellFlagBinary | core.SpellFlagAPL,
 		MissileSpeed: 28,
 
 		RequiredLevel: level,

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -30,7 +30,7 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 		SpellSchool:  core.SpellSchoolFrost | core.SpellSchoolFire,
 		DefenseType:  core.DefenseTypeMagic,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage | SpellFlagChillSpell | core.SpellFlagAPL,
+		Flags:        SpellFlagMage | SpellFlagChillSpell | core.SpellFlagBinary | core.SpellFlagAPL,
 		MissileSpeed: 28,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/mage/spellfrost_bolt.go
+++ b/sim/mage/spellfrost_bolt.go
@@ -24,7 +24,7 @@ func (mage *Mage) registerSpellfrostBoltSpell() {
 		SpellSchool:  core.SpellSchoolArcane | core.SpellSchoolFrost,
 		DefenseType:  core.DefenseTypeMagic,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        SpellFlagMage | SpellFlagChillSpell | core.SpellFlagAPL,
+		Flags:        SpellFlagMage | SpellFlagChillSpell | core.SpellFlagBinary | core.SpellFlagAPL,
 		MissileSpeed: 28,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -296,7 +296,7 @@ dps_results: {
  key: "TestRetribution-Lvl40-Average-Default"
  value: {
   dps: 613.56673
-  tps: 627.72424
+  tps: 627.72637
  }
 }
 dps_results: {
@@ -387,6 +387,6 @@ dps_results: {
  key: "TestRetribution-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 579.44516
-  tps: 593.49222
+  tps: 593.48173
  }
 }

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -100,7 +100,7 @@ dps_results: {
  key: "TestShockadin-Lvl40-Average-Default"
  value: {
   dps: 562.11413
-  tps: 580.147
+  tps: 580.15107
  }
 }
 dps_results: {
@@ -191,6 +191,6 @@ dps_results: {
  key: "TestShockadin-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 544.98167
-  tps: 563.27287
+  tps: 563.29815
  }
 }

--- a/sim/priest/mind_flay.go
+++ b/sim/priest/mind_flay.go
@@ -62,7 +62,7 @@ func (priest *Priest) newMindFlaySpellConfig(rank int, tickIdx int32) core.Spell
 		SpellSchool: core.SpellSchoolShadow,
 		DefenseType: core.DefenseTypeMagic,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       flags,
+		Flags:       flags | core.SpellFlagBinary,
 
 		RequiredLevel: level,
 		Rank:          rank,

--- a/sim/priest/mind_sear.go
+++ b/sim/priest/mind_sear.go
@@ -95,7 +95,7 @@ func (priest *Priest) newMindSearTickSpell(numTicks int32) *core.Spell {
 		ActionID:    core.ActionID{SpellID: 413260}.WithTag(numTicks),
 		SpellSchool: core.SpellSchoolShadow,
 		DefenseType: core.DefenseTypeMagic,
-		ProcMask:    core.ProcMaskProc | core.ProcMaskNotInSpellbook,
+		ProcMask:    core.ProcMaskProc,
 
 		BonusHitRating:  1, // Not an independent hit once initial lands
 		BonusCritRating: priest.forceOfWillCritRating(),

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.10666
+  weights: 0.14668
   weights: 0
-  weights: 0.28452
-  weights: 0
-  weights: 0
+  weights: 0.28605
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.17769
   weights: 0
   weights: 0
-  weights: 0.30541
+  weights: 0.17957
+  weights: 0
+  weights: 0
+  weights: 0.3124
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.81778
+  weights: 0.33431
   weights: 0
-  weights: 0.51376
-  weights: 0
-  weights: 0
+  weights: 0.51621
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.51376
   weights: 0
-  weights: 0.06924
-  weights: 1.02922
+  weights: 0
+  weights: 0.51621
+  weights: 0
+  weights: 0.07317
+  weights: 1.1325
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0337
+  weights: 1.96565
   weights: 0
-  weights: 0.67873
-  weights: 0
-  weights: 0
+  weights: 0.68241
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.67873
   weights: 0
-  weights: 4.77096
-  weights: 4.19825
+  weights: 0
+  weights: 0.68241
+  weights: 0
+  weights: 5.36394
+  weights: 4.14187
   weights: 0
   weights: 0
   weights: 0
@@ -295,308 +295,308 @@ stat_weights_results: {
 dps_results: {
  key: "TestShadow-Lvl25-Average-Default"
  value: {
-  dps: 111.4814
-  tps: 112.15852
+  dps: 112.5162
+  tps: 113.19199
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 113.75464
-  tps: 204.07439
+  dps: 114.70186
+  tps: 205.02945
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 113.75464
-  tps: 114.46829
+  dps: 114.70186
+  tps: 115.42335
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 169.32683
-  tps: 171.1089
+  dps: 170.30284
+  tps: 172.08491
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 70.82603
-  tps: 157.24498
+  dps: 71.5162
+  tps: 157.92852
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 70.82603
-  tps: 74.18059
+  dps: 71.5162
+  tps: 74.86412
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 117.15591
-  tps: 123.30265
+  dps: 118.28337
+  tps: 124.45612
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 111.49276
-  tps: 200.6371
+  dps: 112.56598
+  tps: 201.74112
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 111.49276
-  tps: 112.18051
+  dps: 112.56598
+  tps: 113.28452
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 170.01478
-  tps: 171.79685
+  dps: 170.57249
+  tps: 172.35457
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 69.58789
-  tps: 154.87894
+  dps: 70.2662
+  tps: 155.55247
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 69.58789
-  tps: 72.85954
+  dps: 70.2662
+  tps: 73.53307
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 116.49588
-  tps: 122.3179
+  dps: 116.96213
+  tps: 122.7982
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 111.49276
-  tps: 112.18051
+  dps: 112.56598
+  tps: 113.28452
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Average-Default"
  value: {
-  dps: 458.32583
-  tps: 364.53009
+  dps: 460.32726
+  tps: 366.2166
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 466.16899
-  tps: 685.96463
+  dps: 469.3017
+  tps: 688.18841
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 466.16899
-  tps: 371.12694
+  dps: 469.3017
+  tps: 373.66422
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 548.19781
-  tps: 443.81738
+  dps: 550.45756
+  tps: 445.75673
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 268.48685
-  tps: 407.66635
+  dps: 269.66613
+  tps: 408.71311
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 268.48685
-  tps: 202.97622
+  dps: 269.66613
+  tps: 204.02298
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 455.60916
-  tps: 350.39892
+  dps: 457.66279
+  tps: 352.40477
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 458.63118
-  tps: 675.60497
+  dps: 462.62787
+  tps: 679.35945
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 458.63118
-  tps: 364.41433
+  dps: 462.62787
+  tps: 367.80306
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 547.69277
-  tps: 444.38292
+  dps: 549.12367
+  tps: 445.63186
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 263.05257
-  tps: 400.41841
+  dps: 264.03854
+  tps: 401.28275
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 263.05257
-  tps: 198.14128
+  dps: 264.03854
+  tps: 199.00562
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 456.52491
-  tps: 350.17745
+  dps: 458.23657
+  tps: 351.7959
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 458.63118
-  tps: 364.41433
+  dps: 462.62787
+  tps: 367.80306
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Average-Default"
  value: {
-  dps: 815.80966
-  tps: 707.52033
-  hps: 11.856
+  dps: 820.3427
+  tps: 711.34673
+  hps: 11.86533
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 820.21232
-  tps: 1160.06978
-  hps: 12.2529
+  dps: 821.77512
+  tps: 1159.04855
+  hps: 12.14816
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 820.21232
-  tps: 711.3817
-  hps: 12.2529
+  dps: 821.77512
+  tps: 712.4758
+  hps: 12.14816
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 924.56985
-  tps: 791.50595
+  dps: 929.8198
+  tps: 796.14874
   hps: 14.42388
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 337.34661
-  tps: 540.98779
+  dps: 339.26823
+  tps: 542.67908
   hps: 5.99595
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 337.34661
-  tps: 295.22923
+  dps: 339.26823
+  tps: 296.92051
   hps: 5.99595
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 640.28546
-  tps: 549.28547
+  dps: 643.57641
+  tps: 552.32739
   hps: 11.38002
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 812.79891
-  tps: 1148.64078
-  hps: 12.38488
+  dps: 817.94495
+  tps: 1154.14673
+  hps: 12.4163
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 812.79891
-  tps: 704.84601
-  hps: 12.38488
+  dps: 817.94495
+  tps: 709.24679
+  hps: 12.4163
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 923.01088
-  tps: 790.80544
+  dps: 930.82372
+  tps: 797.59326
   hps: 14.42388
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 329.68758
-  tps: 531.1632
+  dps: 331.14784
+  tps: 532.30961
   hps: 6.00898
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 329.68758
-  tps: 288.6093
+  dps: 331.14784
+  tps: 289.75571
   hps: 6.00898
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 639.344
-  tps: 548.33146
+  dps: 643.88073
+  tps: 551.90422
   hps: 11.4241
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 812.79891
-  tps: 704.84601
-  hps: 12.38488
+  dps: 817.94495
+  tps: 709.24679
+  hps: 12.4163
  }
 }

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -24,7 +24,7 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 		SpellSchool: core.SpellSchoolShadow,
 		DefenseType: core.DefenseTypeMagic,
 		ProcMask:    core.ProcMaskSpellDamage,
-		Flags:       core.SpellFlagAPL,
+		Flags:       core.SpellFlagBinary | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: manaCost,

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -32,7 +32,7 @@ func (rogue *Rogue) registerEnvenom() {
 		SpellSchool:  core.SpellSchoolNature,
 		DefenseType:  core.DefenseTypeMelee,
 		ProcMask:     core.ProcMaskMeleeMHSpecial,
-		Flags:        rogue.finisherFlags() | SpellFlagColdBlooded | core.SpellFlagBinary | core.SpellFlagPoison,
+		Flags:        rogue.finisherFlags() | SpellFlagColdBlooded | core.SpellFlagIgnoreResists | core.SpellFlagPoison,
 		MetricSplits: 6,
 
 		EnergyCost: core.EnergyCostOptions{

--- a/sim/shaman/earth_shock.go
+++ b/sim/shaman/earth_shock.go
@@ -45,6 +45,8 @@ func (shaman *Shaman) newEarthShockSpellConfig(rank int, shockTimer *core.Timer)
 		shockTimer,
 	)
 
+	spell.Flags |= core.SpellFlagBinary
+
 	spell.SpellCode = SpellCode_ShamanEarthShock
 	spell.RequiredLevel = level
 	spell.Rank = rank

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.36751
+  weights: 0.81901
   weights: 0
-  weights: 0.87784
+  weights: 0.87695
   weights: 0
-  weights: 0.28538
-  weights: 0
-  weights: 0
-  weights: 0.59245
+  weights: 0.28448
   weights: 0
   weights: 0
-  weights: 6.84078
-  weights: 3.67407
+  weights: 0.59247
+  weights: 0
+  weights: 0
+  weights: 7.66812
+  weights: 3.88437
   weights: 0
   weights: 0
   weights: 0
@@ -393,8 +393,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Average-Default"
  value: {
-  dps: 645.64802
-  tps: 554.96071
+  dps: 645.62635
+  tps: 554.94995
  }
 }
 dps_results: {
@@ -484,15 +484,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 646.09568
-  tps: 555.45632
+  dps: 645.82497
+  tps: 555.07746
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Average-Default"
  value: {
-  dps: 1425.91073
-  tps: 1204.62914
+  dps: 1425.90476
+  tps: 1204.62214
  }
 }
 dps_results: {
@@ -583,6 +583,6 @@ dps_results: {
  key: "TestElemental-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
   dps: 1404.21642
-  tps: 1184.96068
+  tps: 1185.06245
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.575
+  weights: 0.57568
   weights: 0
-  weights: 0.9914
+  weights: 0.9933
   weights: 0
-  weights: 0.29861
-  weights: 0
-  weights: 0
-  weights: 0.6928
+  weights: 0.29809
   weights: 0
   weights: 0
+  weights: 0.69521
   weights: 0
-  weights: 7.70658
+  weights: 0
+  weights: 0
+  weights: 7.73953
   weights: 0
   weights: 0
   weights: 0
@@ -491,98 +491,98 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-Average-Default"
  value: {
-  dps: 1425.90476
-  tps: 1204.62214
+  dps: 1427.08483
+  tps: 1207.0795
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1827.57684
-  tps: 2199.27107
+  dps: 1829.67738
+  tps: 2203.21008
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1027.98091
-  tps: 877.34841
+  dps: 1031.4823
+  tps: 882.83631
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1379.62987
-  tps: 1205.73474
+  dps: 1378.90488
+  tps: 1202.94081
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 874.35915
-  tps: 1243.67238
+  dps: 874.67848
+  tps: 1244.77857
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 621.61216
-  tps: 542.65665
+  dps: 624.0454
+  tps: 546.1781
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 770.55361
-  tps: 686.30297
+  dps: 769.37306
+  tps: 683.9218
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1838.69714
-  tps: 2212.04806
+  dps: 1840.27598
+  tps: 2216.27875
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1044.46289
-  tps: 890.8599
+  dps: 1045.57083
+  tps: 893.67133
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1409.75197
-  tps: 1233.10592
+  dps: 1412.75348
+  tps: 1237.01733
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 866.11205
-  tps: 1237.56475
+  dps: 867.89344
+  tps: 1240.66768
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 625.52727
-  tps: 547.56776
+  dps: 625.79469
+  tps: 548.40235
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 803.18367
-  tps: 720.99767
+  dps: 803.25517
+  tps: 723.78173
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1404.21642
-  tps: 1185.06245
+  dps: 1408.23204
+  tps: 1189.6215
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -197,16 +197,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl40-StatWeights-Default"
  value: {
-  weights: 1.04432
-  weights: 0.5756
+  weights: 1.04448
+  weights: 0.59383
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43412
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.43431
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +210,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.47469
-  weights: 2.65766
-  weights: 8.41278
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.47476
+  weights: 2.71787
+  weights: 8.3659
   weights: 0
   weights: 0
   weights: 0
@@ -246,7 +246,7 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.59411
+  weights: 1.59406
   weights: 0.85655
   weights: 0
   weights: 0
@@ -263,8 +263,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.67092
-  weights: 8.80046
+  weights: 0.6709
+  weights: 9.01344
   weights: 11.67612
   weights: 0
   weights: 0
@@ -477,8 +477,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
-  dps: 875.25277
-  tps: 925.70519
+  dps: 875.27447
+  tps: 925.73855
  }
 }
 dps_results: {
@@ -653,14 +653,14 @@ dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 811.70204
-  tps: 859.17312
+  tps: 859.16095
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Average-Default"
  value: {
-  dps: 1833.11938
-  tps: 1346.62972
+  dps: 1833.09807
+  tps: 1346.62817
  }
 }
 dps_results: {
@@ -835,6 +835,6 @@ dps_results: {
  key: "TestEnhancement-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
   dps: 1703.21447
-  tps: 1253.75162
+  tps: 1253.80248
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -198,11 +198,11 @@ stat_weights_results: {
  key: "TestEnhancement-Lvl40-StatWeights-Default"
  value: {
   weights: 1.04448
-  weights: 0.59383
+  weights: 0.57471
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43431
+  weights: 0.43588
   weights: 0
   weights: 0
   weights: 0
@@ -215,8 +215,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.47476
-  weights: 2.71787
-  weights: 8.3659
+  weights: 2.77313
+  weights: 8.30828
   weights: 0
   weights: 0
   weights: 0
@@ -246,16 +246,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.59406
-  weights: 0.85655
+  weights: 1.59559
+  weights: 0.85632
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.45954
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.46169
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +259,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.6709
-  weights: 9.01344
-  weights: 11.67612
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.67155
+  weights: 8.97264
+  weights: 11.84038
   weights: 0
   weights: 0
   weights: 0
@@ -477,364 +477,364 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
-  dps: 875.27447
-  tps: 925.73855
+  dps: 876.44744
+  tps: 928.13969
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 405.75928
-  tps: 457.91714
+  dps: 405.40214
+  tps: 458.15344
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 322.0504
-  tps: 368.7043
+  dps: 323.54607
+  tps: 372.0865
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 397.2156
-  tps: 448.41024
+  dps: 399.93373
+  tps: 453.01332
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 243.32363
-  tps: 284.17221
+  dps: 243.12007
+  tps: 284.45272
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 196.22442
-  tps: 233.26512
+  dps: 197.46294
+  tps: 235.98991
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 235.49039
-  tps: 274.98862
+  dps: 237.65387
+  tps: 278.60081
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 405.75928
-  tps: 457.42095
+  dps: 405.40214
+  tps: 457.65724
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 322.0504
-  tps: 368.25089
+  dps: 323.54607
+  tps: 371.63309
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 397.2156
-  tps: 447.12525
+  dps: 399.93373
+  tps: 451.72834
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 243.32363
-  tps: 284.16206
+  dps: 243.12007
+  tps: 284.44257
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 196.22442
-  tps: 233.25496
+  dps: 197.46294
+  tps: 235.97976
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 235.49039
-  tps: 274.97455
+  dps: 237.65387
+  tps: 278.58674
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 413.73181
-  tps: 466.50333
+  dps: 413.94817
+  tps: 467.18052
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 332.20341
-  tps: 380.03392
+  dps: 333.65927
+  tps: 382.77037
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 409.89697
-  tps: 462.72052
+  dps: 412.165
+  tps: 466.05468
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 247.19371
-  tps: 288.27961
+  dps: 247.34275
+  tps: 288.76062
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 201.52274
-  tps: 239.19192
+  dps: 202.77392
+  tps: 241.53479
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 241.76896
-  tps: 281.98974
+  dps: 243.4897
+  tps: 284.54214
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 413.73181
-  tps: 466.26104
+  dps: 413.94817
+  tps: 466.93823
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 332.20341
-  tps: 379.90988
+  dps: 333.65927
+  tps: 382.64633
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 409.89697
-  tps: 462.27768
+  dps: 412.165
+  tps: 465.61185
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 247.19371
-  tps: 288.06429
+  dps: 247.34275
+  tps: 288.5453
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 201.52274
-  tps: 238.9766
+  dps: 202.77392
+  tps: 241.31947
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 241.76896
-  tps: 281.90436
+  dps: 243.4897
+  tps: 284.45676
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 811.70204
-  tps: 859.16095
+  dps: 812.21777
+  tps: 860.67178
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Average-Default"
  value: {
-  dps: 1833.09807
-  tps: 1346.62817
+  dps: 1835.99535
+  tps: 1350.70363
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 905.76062
-  tps: 683.74621
+  dps: 907.61475
+  tps: 686.95422
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 736.94754
-  tps: 564.35283
+  dps: 739.87147
+  tps: 568.34342
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 907.60887
-  tps: 686.33606
+  dps: 910.27301
+  tps: 690.00599
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 463.04335
-  tps: 367.14396
+  dps: 464.09972
+  tps: 369.13772
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 390.79133
-  tps: 315.59148
+  dps: 392.91105
+  tps: 318.63042
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 470.34121
-  tps: 372.33169
+  dps: 471.89676
+  tps: 374.70275
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 905.76062
-  tps: 683.36643
+  dps: 907.61475
+  tps: 686.57443
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 736.94754
-  tps: 564.05027
+  dps: 739.87147
+  tps: 568.04087
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 907.60887
-  tps: 686.21853
+  dps: 910.27301
+  tps: 689.88846
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 463.04335
-  tps: 366.49559
+  dps: 464.09972
+  tps: 368.48935
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 390.79133
-  tps: 314.94311
+  dps: 392.91105
+  tps: 317.98205
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 470.34121
-  tps: 371.68169
+  dps: 471.89676
+  tps: 374.05275
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 918.02481
-  tps: 692.56877
+  dps: 919.61231
+  tps: 695.36321
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 752.83999
-  tps: 574.09341
+  dps: 754.79704
+  tps: 577.38943
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 922.64121
-  tps: 695.95573
+  dps: 927.7665
+  tps: 701.61666
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 468.62337
-  tps: 370.05898
+  dps: 469.90911
+  tps: 372.11601
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 396.11558
-  tps: 316.30694
+  dps: 397.60834
+  tps: 318.84555
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 473.65185
-  tps: 371.68054
+  dps: 476.68822
+  tps: 375.17939
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 918.02481
-  tps: 692.28042
+  dps: 919.61231
+  tps: 695.07487
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 752.83999
-  tps: 573.71635
+  dps: 754.79704
+  tps: 577.01237
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 922.64121
-  tps: 695.55514
+  dps: 927.7665
+  tps: 701.21607
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 468.62337
-  tps: 370.68398
+  dps: 469.90911
+  tps: 372.74101
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 396.11558
-  tps: 316.92994
+  dps: 397.60834
+  tps: 319.46855
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 473.65185
-  tps: 372.1346
+  dps: 476.68822
+  tps: 375.63345
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1703.21447
-  tps: 1253.80248
+  dps: 1706.42273
+  tps: 1258.01373
  }
 }

--- a/sim/shaman/lava_lash.go
+++ b/sim/shaman/lava_lash.go
@@ -27,7 +27,7 @@ func (shaman *Shaman) applyLavaLash() {
 		SpellSchool: core.SpellSchoolFire,
 		DefenseType: core.DefenseTypeMelee,
 		ProcMask:    core.ProcMaskMeleeOHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagAPL | core.SpellFlagIgnoreResists,
+		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreResists | core.SpellFlagAPL,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: manaCost,

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.586
+  weights: -0.78287
   weights: 0
-  weights: 0.60283
-  weights: 0
-  weights: 0
+  weights: 0.53641
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.84907
-  weights: 1.68968
+  weights: 0
+  weights: 0
+  weights: 4.14158
+  weights: 1.71612
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -2.35267
+  weights: -1.28118
   weights: 0
-  weights: -0.89174
-  weights: 0
-  weights: 0
+  weights: -0.40387
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 10.21444
-  weights: 7.03887
+  weights: 0
+  weights: 0
+  weights: 9.41833
+  weights: 7.14591
   weights: 0
   weights: 0
   weights: 0
@@ -197,112 +197,112 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-Average-Default"
  value: {
-  dps: 582.44309
-  tps: 551.7459
+  dps: 587.64576
+  tps: 556.99508
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 580.37593
-  tps: 1178.90409
+  dps: 584.19304
+  tps: 1182.67282
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 580.37593
-  tps: 549.54225
+  dps: 584.19304
+  tps: 553.31098
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 573.35419
-  tps: 531.20302
+  dps: 574.81461
+  tps: 532.79021
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 366.37289
-  tps: 992.90309
+  dps: 368.68681
+  tps: 995.09357
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 366.37289
-  tps: 353.43041
+  dps: 368.68681
+  tps: 355.62088
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 371.93756
-  tps: 345.68177
+  dps: 375.50863
+  tps: 349.28049
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 584.47867
-  tps: 553.94148
+  dps: 588.6543
+  tps: 557.82805
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1349.80343
-  tps: 1121.46825
+  dps: 1358.92464
+  tps: 1130.63521
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1923.93764
-  tps: 2640.24953
+  dps: 1931.88057
+  tps: 2647.10542
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1327.36639
-  tps: 1098.42208
+  dps: 1336.3011
+  tps: 1107.74441
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1364.09611
-  tps: 1174.66417
+  dps: 1372.16499
+  tps: 1182.18086
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1199.74265
-  tps: 2065.5737
+  dps: 1205.01567
+  tps: 2070.65628
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 756.90611
-  tps: 620.33701
+  dps: 762.38565
+  tps: 625.78478
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 713.08959
-  tps: 625.55194
+  dps: 716.65495
+  tps: 630.45808
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1349.68158
-  tps: 1122.6454
+  dps: 1357.11546
+  tps: 1130.14122
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.02694
+  weights: -0.01331
   weights: 0
-  weights: 0.52293
-  weights: 0
-  weights: 0
+  weights: 0.53679
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.43648
-  weights: 2.24429
+  weights: 0
+  weights: 0
+  weights: 5.40535
+  weights: 2.12408
   weights: 0
   weights: 0
   weights: 0
@@ -99,56 +99,56 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 640.93894
-  tps: 532.2626
+  dps: 644.30134
+  tps: 535.48342
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 638.59925
-  tps: 847.97907
+  dps: 644.9294
+  tps: 854.2803
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 638.59925
-  tps: 530.79855
+  dps: 644.9294
+  tps: 537.44821
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 684.20165
-  tps: 573.43809
+  dps: 688.36389
+  tps: 577.16233
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 372.89583
-  tps: 673.38533
+  dps: 374.56765
+  tps: 675.01942
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 372.89583
-  tps: 331.88334
+  dps: 374.56765
+  tps: 333.51743
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 424.56437
-  tps: 367.19565
+  dps: 427.48813
+  tps: 369.96447
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 640.46524
-  tps: 532.61461
+  dps: 647.42559
+  tps: 540.37038
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -249,17 +249,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.58443
+  weights: 8.71011
   weights: 0
-  weights: -0.40299
-  weights: 0
-  weights: 0
+  weights: 0.10675
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 18.60859
+  weights: 0
+  weights: 0
+  weights: 20.04789
   weights: 6.75843
   weights: 0
   weights: 0
@@ -407,56 +407,56 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1274.01513
-  tps: 1105.49072
+  dps: 1279.97295
+  tps: 1111.43375
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2008.91374
-  tps: 2498.5711
+  dps: 2013.17239
+  tps: 2502.70732
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1269.46251
-  tps: 1101.6938
+  dps: 1275.97578
+  tps: 1107.82719
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1355.28402
-  tps: 1206.89145
+  dps: 1366.18309
+  tps: 1217.88406
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1244.84907
-  tps: 1863.07487
+  dps: 1246.72212
+  tps: 1865.06428
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 700.43582
-  tps: 613.31335
+  dps: 704.04374
+  tps: 616.87371
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 736.3066
-  tps: 673.9714
+  dps: 742.9627
+  tps: 680.39569
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1263.80119
-  tps: 1094.5225
+  dps: 1272.14272
+  tps: 1103.10161
  }
 }

--- a/sim/warlock/haunt.go
+++ b/sim/warlock/haunt.go
@@ -41,7 +41,7 @@ func (warlock *Warlock) registerHauntSpell() {
 		SpellSchool:  core.SpellSchoolShadow,
 		DefenseType:  core.DefenseTypeMagic,
 		ProcMask:     core.ProcMaskSpellDamage,
-		Flags:        core.SpellFlagAPL | core.SpellFlagResetAttackSwing,
+		Flags:        core.SpellFlagAPL | core.SpellFlagBinary | core.SpellFlagResetAttackSwing,
 		MissileSpeed: 20,
 
 		ManaCost: core.ManaCostOptions{

--- a/sim/warlock/immolate.go
+++ b/sim/warlock/immolate.go
@@ -26,7 +26,7 @@ func (warlock *Warlock) getImmolateConfig(rank int) core.SpellConfig {
 		SpellSchool:   core.SpellSchoolFire,
 		DefenseType:   core.DefenseTypeMagic,
 		ProcMask:      core.ProcMaskSpellDamage,
-		Flags:         core.SpellFlagAPL | core.SpellFlagResetAttackSwing | SpellFlagLoF,
+		Flags:         core.SpellFlagAPL | core.SpellFlagResetAttackSwing | core.SpellFlagBinary | SpellFlagLoF,
 		Rank:          rank,
 		RequiredLevel: level,
 

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50725
+  weights: 0.53787
   weights: 0
-  weights: 0.85059
-  weights: 0
-  weights: 0
+  weights: 0.96167
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.47202
-  weights: 1.42282
+  weights: 0
+  weights: 0
+  weights: 6.33785
+  weights: 1.43985
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 584.24214
-  tps: 1116.89407
+  dps: 584.14614
+  tps: 1116.55471
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 547.63686
-  tps: 1568.37156
+  dps: 547.58615
+  tps: 1566.83604
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 547.63686
-  tps: 1056.47868
+  dps: 547.58615
+  tps: 1054.63536
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 574.45826
-  tps: 1105.34333
+  tps: 1105.46708
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 581.28522
-  tps: 1109.54967
+  dps: 580.66325
+  tps: 1110.11424
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.06131
+  weights: 0.30419
   weights: 0
-  weights: 0.68312
-  weights: 0
-  weights: 0
+  weights: 0.71527
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.85171
-  weights: 3.47578
+  weights: 0
+  weights: 0
+  weights: 6.26554
+  weights: 3.05731
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.12958
+  weights: -2.31662
   weights: 0
-  weights: -0.7384
-  weights: 0
-  weights: 0
+  weights: -1.32874
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.60993
-  weights: 5.54624
+  weights: 0
+  weights: 0
+  weights: 5.60008
+  weights: 4.98735
   weights: 0
   weights: 0
   weights: 0
@@ -351,8 +351,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 497.20922
-  tps: 1090.42155
+  dps: 497.51526
+  tps: 1091.55448
  }
 }
 dps_results: {
@@ -400,71 +400,71 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 485.20365
-  tps: 1067.35323
+  dps: 490.52575
+  tps: 1079.533
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1300.50316
-  tps: 2099.75615
-  hps: 17.93389
+  dps: 1306.33724
+  tps: 2108.73553
+  hps: 17.9557
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1864.3347
-  tps: 3879.90481
+  dps: 1871.91448
+  tps: 3891.92408
   hps: 15.30247
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1244.03308
-  tps: 1979.99722
+  dps: 1248.49817
+  tps: 1985.67294
   hps: 15.17748
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1152.16879
-  tps: 1920.02313
+  dps: 1156.55785
+  tps: 1927.44082
   hps: 14.95714
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1151.75558
-  tps: 2820.01412
+  dps: 1156.33629
+  tps: 2826.80239
   hps: 10.14833
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 706.79341
-  tps: 1113.00347
+  dps: 711.26332
+  tps: 1119.83465
   hps: 10.25667
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 666.6289
-  tps: 1087.2358
+  dps: 669.88738
+  tps: 1092.02675
   hps: 10.55833
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1280.03569
-  tps: 2066.74092
-  hps: 18.04198
+  dps: 1283.59166
+  tps: 2061.87471
+  hps: 18.25283
  }
 }

--- a/sim/warlock/unstable_affliction.go
+++ b/sim/warlock/unstable_affliction.go
@@ -22,7 +22,7 @@ func (warlock *Warlock) registerUnstableAfflictionSpell() {
 		SpellSchool: core.SpellSchoolShadow,
 		ProcMask:    core.ProcMaskSpellDamage,
 		DefenseType: core.DefenseTypeMagic,
-		Flags:       core.SpellFlagAPL | SpellFlagHaunt | core.SpellFlagResetAttackSwing | core.SpellFlagPureDot,
+		Flags:       core.SpellFlagAPL | SpellFlagHaunt | core.SpellFlagBinary | core.SpellFlagResetAttackSwing | core.SpellFlagPureDot,
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.15,


### PR DESCRIPTION
[core] removed non-effective ProcMaskNotInSpellbook
[core] changed JoW proc conditions (needs to either land or be a melee auto attack)

[druid] Hurricane and Starsurge are now binary
[mage] Blast Wave, Frostbolt, Frostfire Bolt, and Spellfrost Bolt are now binary 
[priest] Mind Flay and Shadow Word: Death are now binary 
[warlock] Haunt, Unstable Affliction, and Immolate (!) are now binary