### PR TITLE
Fix APLActionChangeTarget

### DIFF
--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -15,11 +15,15 @@ type APLActionChangeTarget struct {
 }
 
 func (rot *APLRotation) newActionChangeTarget(config *proto.APLActionChangeTarget) APLActionImpl {
+	if config.NewTarget == nil {
+		return nil
+	}
 	newTarget := rot.GetSourceUnit(config.NewTarget)
 	if newTarget.Get() == nil {
 		return nil
 	}
 	return &APLActionChangeTarget{
+		unit:      rot.unit,
 		newTarget: newTarget,
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/wowsims/sod/issues/398

Also return nil for change target actions to current target because they don't do anything.