### PR TITLE
Mage: Fix ignite damage scaling

### DIFF
--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.36861
+  weights: 0.38662
   weights: 0
-  weights: 0.41474
+  weights: 0.42477
   weights: 0
-  weights: 0.41474
-  weights: 0
-  weights: 0
+  weights: 0.42477
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.85901
+  weights: 0
+  weights: 0
+  weights: 0.99986
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.65071
+  weights: 0.64333
   weights: 0
-  weights: 0.62141
+  weights: 0.64923
   weights: 0
-  weights: 0.62141
-  weights: 0
-  weights: 0
+  weights: 0.64923
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.00543
-  weights: 3.41309
+  weights: 0
+  weights: 0
+  weights: 6.30887
+  weights: 3.74644
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.36835
+  weights: -0.57217
   weights: 0
-  weights: 0.7768
+  weights: 0.82313
   weights: 0
-  weights: 0.7768
-  weights: 0
-  weights: 0
+  weights: 0.82313
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.31811
+  weights: 0
+  weights: 0
+  weights: 9.50207
   weights: 0
   weights: 0
   weights: 0
@@ -295,294 +295,294 @@ stat_weights_results: {
 dps_results: {
  key: "TestFire-Lvl25-Average-Default"
  value: {
-  dps: 147.10396
-  tps: 106.23506
+  dps: 150.57768
+  tps: 108.66667
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 417.46327
-  tps: 357.66177
+  dps: 423.20224
+  tps: 361.67905
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 146.91183
-  tps: 106.06939
+  dps: 150.49687
+  tps: 108.57892
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 183.5165
-  tps: 134.84311
+  dps: 187.59274
+  tps: 137.69648
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 275.28842
-  tps: 258.08543
+  dps: 276.07551
+  tps: 258.6364
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 96.34161
-  tps: 70.71469
+  dps: 97.18528
+  tps: 71.30526
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 143.39627
-  tps: 108.08809
+  dps: 144.66315
+  tps: 108.97491
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 386.28238
-  tps: 335.87998
+  dps: 391.36962
+  tps: 339.44105
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 140.86542
-  tps: 101.8379
+  dps: 144.15993
+  tps: 104.14406
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 182.89084
-  tps: 135.75328
+  dps: 186.88439
+  tps: 138.54877
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 258.24048
-  tps: 246.35706
+  dps: 259.01457
+  tps: 246.89893
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 90.98418
-  tps: 66.96269
+  dps: 91.76248
+  tps: 67.5075
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 143.88395
-  tps: 108.42051
+  dps: 145.11539
+  tps: 109.28252
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 146.4459
-  tps: 105.74424
+  dps: 149.79501
+  tps: 108.08861
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Average-Default"
  value: {
-  dps: 452.72771
-  tps: 329.57153
+  dps: 472.61407
+  tps: 343.49199
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1461.9081
-  tps: 1258.90867
+  dps: 1491.0005
+  tps: 1279.27334
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 441.93168
-  tps: 322.28604
+  dps: 462.50907
+  tps: 336.69021
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 615.20851
-  tps: 452.3061
+  dps: 642.99646
+  tps: 471.75766
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 967.37327
-  tps: 821.48234
+  dps: 970.87145
+  tps: 823.93107
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 246.03432
-  tps: 179.79132
+  dps: 250.25105
+  tps: 182.74303
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 465.20539
-  tps: 341.22327
+  dps: 473.23244
+  tps: 346.8422
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1425.63395
-  tps: 1228.8834
+  dps: 1453.5201
+  tps: 1248.40371
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 429.63192
-  tps: 313.47924
+  dps: 449.63421
+  tps: 327.48084
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 617.33775
-  tps: 453.7618
+  dps: 645.61685
+  tps: 473.55717
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 942.86076
-  tps: 801.81547
+  dps: 946.06966
+  tps: 804.0617
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 240.52932
-  tps: 175.8393
+  dps: 244.62293
+  tps: 178.70483
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 464.13217
-  tps: 340.38269
+  dps: 472.17655
+  tps: 346.01375
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 454.17602
-  tps: 330.6601
+  dps: 474.07555
+  tps: 344.58978
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Average-Default"
  value: {
-  dps: 767.70499
-  tps: 563.52272
+  dps: 813.73858
+  tps: 595.74624
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1605.15876
-  tps: 1699.03941
+  dps: 1675.32909
+  tps: 1748.15864
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 820.40307
-  tps: 600.92143
+  dps: 869.19522
+  tps: 635.07594
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1059.61688
-  tps: 783.03575
+  dps: 1122.13447
+  tps: 826.79806
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 933.18026
-  tps: 1059.03788
+  dps: 940.18178
+  tps: 1063.93894
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 418.15869
-  tps: 309.38628
+  dps: 426.06005
+  tps: 314.91724
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 747.30781
-  tps: 554.40212
+  dps: 762.04646
+  tps: 564.71918
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1570.89914
-  tps: 1670.03222
+  dps: 1638.59561
+  tps: 1717.41975
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 761.79316
-  tps: 558.83091
+  dps: 807.44512
+  tps: 590.78728
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1073.1189
-  tps: 792.35866
+  dps: 1135.30433
+  tps: 835.88846
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 882.38193
-  tps: 1014.1759
+  dps: 888.80711
+  tps: 1018.67352
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 416.63822
-  tps: 308.3619
+  dps: 424.38578
+  tps: 313.78519
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 757.47433
-  tps: 561.77795
+  dps: 772.14779
+  tps: 572.04937
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 763.6526
-  tps: 560.154
+  dps: 809.31674
+  tps: 592.1189
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -55,16 +55,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.02577
+  weights: 1.10466
   weights: 0
-  weights: 1.02577
-  weights: 0
-  weights: 0
+  weights: 1.10466
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 21.03535
+  weights: 0
+  weights: 0
+  weights: 24.18085
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestFrost-Lvl50-Average-Default"
  value: {
-  dps: 1081.62749
-  tps: 840.11859
+  dps: 1165.20226
+  tps: 923.69336
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1049.2402
-  tps: 1052.29613
+  dps: 1129.19875
+  tps: 1132.25468
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1049.2402
-  tps: 813.99638
+  dps: 1129.19875
+  tps: 893.95493
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1125.91729
-  tps: 862.40948
+  dps: 1206.95595
+  tps: 943.44814
  }
 }
 dps_results: {
@@ -148,22 +148,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1052.69888
-  tps: 1062.08771
+  dps: 1132.64552
+  tps: 1142.03436
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1052.69888
-  tps: 816.79844
+  dps: 1132.64552
+  tps: 896.74508
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1125.55912
-  tps: 863.44967
+  dps: 1208.22189
+  tps: 946.11244
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1053.60252
-  tps: 817.72836
+  dps: 1133.82555
+  tps: 897.9514
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -104,16 +104,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.86528
+  weights: 0.91597
   weights: 0
-  weights: 0.86528
-  weights: 0
-  weights: 0
+  weights: 0.91597
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.54497
-  weights: 2.32126
+  weights: 0
+  weights: 0
+  weights: 2.45333
+  weights: 2.83067
   weights: 0
   weights: 0
   weights: 0
@@ -153,16 +153,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.19261
+  weights: 1.28414
   weights: 0
-  weights: 1.19261
-  weights: 0
-  weights: 0
+  weights: 1.28414
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 17.44263
+  weights: 0
+  weights: 0
+  weights: 19.69772
   weights: 0
   weights: 0
   weights: 0
@@ -197,196 +197,196 @@ stat_weights_results: {
 dps_results: {
  key: "TestFrostFire-Lvl40-Average-Default"
  value: {
-  dps: 600.69062
-  tps: 432.03779
+  dps: 635.28469
+  tps: 456.25364
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1290.48915
-  tps: 1132.54607
+  dps: 1341.70896
+  tps: 1168.39994
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 592.19585
-  tps: 425.87247
+  dps: 625.92359
+  tps: 449.48188
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 636.04759
-  tps: 458.80746
+  dps: 672.55072
+  tps: 484.35965
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 649.12893
-  tps: 591.16559
+  dps: 653.88459
+  tps: 594.49456
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 339.12784
-  tps: 244.5837
+  dps: 345.46303
+  tps: 249.01833
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 446.33596
-  tps: 326.29485
+  dps: 455.08879
+  tps: 332.42183
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1230.05734
-  tps: 1089.09031
+  dps: 1278.26835
+  tps: 1122.83801
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 592.20313
-  tps: 425.95558
+  dps: 625.63879
+  tps: 449.36054
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 634.17757
-  tps: 457.44329
+  dps: 670.78738
+  tps: 483.07015
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 628.22899
-  tps: 577.41023
+  dps: 633.01782
+  tps: 580.76241
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 332.62027
-  tps: 239.98304
+  dps: 338.76954
+  tps: 244.28753
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 446.67496
-  tps: 326.59374
+  dps: 455.47347
+  tps: 332.7527
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 593.35244
-  tps: 426.78021
+  dps: 626.82982
+  tps: 450.21437
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Average-Default"
  value: {
-  dps: 1216.2196
-  tps: 872.93791
+  dps: 1307.86653
+  tps: 937.09076
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2445.23565
-  tps: 2242.66074
+  dps: 2579.77183
+  tps: 2336.83607
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1209.5188
-  tps: 867.93778
+  dps: 1301.23141
+  tps: 932.13661
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1239.22725
-  tps: 883.25261
+  dps: 1330.77359
+  tps: 947.33505
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1304.01568
-  tps: 1342.88708
+  dps: 1316.47843
+  tps: 1351.61101
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 594.0733
-  tps: 432.64011
+  dps: 607.43897
+  tps: 441.99608
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 752.14747
-  tps: 554.82505
+  dps: 768.95462
+  tps: 566.59006
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2440.85715
-  tps: 2242.54608
+  dps: 2575.29192
+  tps: 2336.65041
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1215.41471
-  tps: 871.97251
+  dps: 1307.52924
+  tps: 936.45268
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1245.26582
-  tps: 889.83207
+  dps: 1340.08693
+  tps: 956.20684
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1275.90728
-  tps: 1320.97009
+  dps: 1288.72058
+  tps: 1329.93939
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 605.84833
-  tps: 440.69595
+  dps: 619.6682
+  tps: 450.36986
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 764.14921
-  tps: 562.97972
+  dps: 781.98836
+  tps: 575.46713
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1211.96868
-  tps: 869.57382
+  dps: 1303.59344
+  tps: 933.71116
  }
 }

--- a/sim/mage/ignite.go
+++ b/sim/mage/ignite.go
@@ -45,7 +45,7 @@ func (mage *Mage) applyIgnite() {
 		SpellSchool: core.SpellSchoolFire,
 		DefenseType: core.DefenseTypeMagic,
 		ProcMask:    core.ProcMaskProc,
-		Flags:       SpellFlagMage | core.SpellFlagIgnoreModifiers,
+		Flags:       SpellFlagMage,
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
@@ -74,7 +74,7 @@ func (mage *Mage) procIgnite(sim *core.Simulation, result *core.SpellResult) {
 	newDamage := result.Damage * 0.08 * float64(mage.Talents.Ignite)
 	outstandingDamage := core.TernaryFloat64(dot.IsActive(), dot.SnapshotBaseDamage*float64(dot.NumberOfTicks-dot.TickCount), 0)
 
-	dot.SnapshotAttackerMultiplier = 1
-	dot.SnapshotBaseDamage = (outstandingDamage + newDamage) / float64(IgniteTicks)
+	dot.Snapshot(result.Target, (outstandingDamage+newDamage)/float64(IgniteTicks), false)
+
 	mage.Ignite.Cast(sim, result.Target)
 }

--- a/sim/mage/talents.go
+++ b/sim/mage/talents.go
@@ -101,7 +101,8 @@ func (mage *Mage) applyFireTalents() {
 	if mage.Talents.FirePower > 0 {
 		bonusDamageMultiplierAdditive := 0.02 * float64(mage.Talents.FirePower)
 		mage.OnSpellRegistered(func(spell *core.Spell) {
-			if spell.SpellSchool.Matches(core.SpellSchoolFire) && spell.Flags.Matches(SpellFlagMage) {
+			// Fire Power buffs pretty much all mage fire spells EXCEPT ignite
+			if spell.SpellSchool.Matches(core.SpellSchoolFire) && spell.Flags.Matches(SpellFlagMage) && spell != mage.Ignite {
 				spell.DamageMultiplierAdditive += bonusDamageMultiplierAdditive
 			}
 		})


### PR DESCRIPTION
- Unlike in wrath, ignite IS buffed by caster and target modifiers
- The Fire Power talent should not apply to Ignite