### PR TITLE
Improved Imp Fix

### DIFF
--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -151,17 +151,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.28118
+  weights: -1.28778
   weights: 0
-  weights: -0.40387
-  weights: 0
-  weights: 0
+  weights: -0.46832
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.41833
+  weights: 0
+  weights: 0
+  weights: 8.84263
   weights: 7.14591
   weights: 0
   weights: 0
@@ -253,56 +253,56 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1358.92464
+  dps: 1326.62359
   tps: 1130.63521
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1931.88057
+  dps: 1899.41166
   tps: 2647.10542
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1336.3011
+  dps: 1303.99632
   tps: 1107.74441
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1372.16499
+  dps: 1347.10444
   tps: 1182.18086
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1205.01567
+  dps: 1185.88432
   tps: 2070.65628
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 762.38565
+  dps: 743.24933
   tps: 625.78478
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 716.65495
+  dps: 704.87362
   tps: 630.45808
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1357.11546
+  dps: 1324.95274
   tps: 1130.14122
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -151,9 +151,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.00343
+  weights: 0.0029
   weights: 0
-  weights: 0.38462
+  weights: 0.36308
   weights: 0
   weights: 0
   weights: 0
@@ -200,17 +200,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02904
+  weights: 0.02784
   weights: 0
-  weights: 0.14709
-  weights: 0
-  weights: 0
+  weights: 0.13619
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.13054
+  weights: 0
+  weights: 0
+  weights: 3.06661
   weights: 0.16755
   weights: 0
   weights: 0
@@ -249,17 +249,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.71011
+  weights: 8.80691
   weights: 0
-  weights: 0.10675
-  weights: 0
-  weights: 0
+  weights: 0.14571
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 20.04789
+  weights: 0
+  weights: 0
+  weights: 20.05234
   weights: 6.75843
   weights: 0
   weights: 0
@@ -295,168 +295,168 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 126.18948
+  dps: 122.31451
   tps: 94.72223
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 395.93473
+  dps: 392.07622
   tps: 694.34373
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 126.18048
+  dps: 122.301
   tps: 94.55663
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 209.56273
+  dps: 205.64351
   tps: 160.0771
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 302.6133
+  dps: 299.14278
   tps: 677.79138
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 89.15414
+  dps: 85.66284
   tps: 62.58916
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 161.39961
+  dps: 158.88402
   tps: 127.04111
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 126.18048
+  dps: 122.301
   tps: 94.55663
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 149.9613
+  dps: 145.67126
   tps: 78.65772
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 147.03559
+  dps: 142.74374
   tps: 1037.92464
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 147.03559
+  dps: 142.74374
   tps: 74.0336
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 243.6638
+  dps: 239.35189
   tps: 159.62473
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 106.49341
+  dps: 103.69659
   tps: 1016.50172
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 106.49341
+  dps: 103.69659
   tps: 65.48946
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 168.85181
+  dps: 166.00867
   tps: 112.30784
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 147.29884
+  dps: 143.00855
   tps: 74.38425
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1279.97295
+  dps: 1262.81151
   tps: 1111.43375
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2013.17239
+  dps: 1996.03453
   tps: 2502.70732
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1275.97578
+  dps: 1258.8581
   tps: 1107.82719
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1366.18309
+  dps: 1350.71441
   tps: 1217.88406
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1246.72212
+  dps: 1237.79346
   tps: 1865.06428
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 704.04374
+  dps: 695.10717
   tps: 616.87371
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 742.9627
+  dps: 736.50638
   tps: 680.39569
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1272.14272
+  dps: 1255.01937
   tps: 1103.10161
  }
 }

--- a/sim/warlock/pet_abilities.go
+++ b/sim/warlock/pet_abilities.go
@@ -26,6 +26,10 @@ func (wp *WarlockPet) registerFireboltSpell() {
 	manaCost := [8]float64{0, 10, 20, 35, 50, 70, 95, 115}[rank]
 	level := [8]int{0, 1, 8, 18, 28, 38, 48, 58}[rank]
 
+	improvedImp := []float64{1, 1.1, 1.2, 1.3}[wp.owner.Talents.ImprovedImp]
+	baseDamage[0] *= improvedImp
+	baseDamage[1] *= improvedImp
+
 	wp.primaryAbility = wp.RegisterSpell(core.SpellConfig{
 		ActionID:      core.ActionID{SpellID: spellId},
 		SpellSchool:   core.SpellSchoolFire,
@@ -45,7 +49,7 @@ func (wp *WarlockPet) registerFireboltSpell() {
 			},
 		},
 
-		DamageMultiplier: 1 + 0.1*float64(wp.owner.Talents.ImprovedImp),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 		BonusCoefficient: spellCoeff,
 

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -151,9 +151,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.27694
+  weights: 1.23776
   weights: 0
-  weights: 1.38157
+  weights: 1.33685
   weights: 0
   weights: 0
   weights: 0
@@ -200,17 +200,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.30419
+  weights: 0.30214
   weights: 0
-  weights: 0.71527
-  weights: 0
-  weights: 0
+  weights: 0.69535
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.26554
+  weights: 0
+  weights: 0
+  weights: 6.16673
   weights: 3.05731
   weights: 0
   weights: 0
@@ -249,17 +249,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.57427
+  weights: -0.38226
   weights: 0
-  weights: 5.15938
-  weights: 0
-  weights: 0
+  weights: 5.1846
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.44309
+  weights: 0
+  weights: 0
+  weights: 3.68279
   weights: 5.51983
   weights: 0
   weights: 0
@@ -295,119 +295,119 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 173.37617
+  dps: 168.76924
   tps: 273.43016
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 418.10686
+  dps: 413.54046
   tps: 835.72675
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 165.07847
+  dps: 160.52439
   tps: 261.33228
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 169.64553
+  dps: 165.95054
   tps: 293.48082
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 331.59493
+  dps: 328.19818
   tps: 906.90102
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 107.71298
+  dps: 104.30653
   tps: 149.0877
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 126.50526
+  dps: 124.07749
   tps: 221.53736
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 169.9419
+  dps: 165.38782
   tps: 268.62743
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 497.51526
+  dps: 489.68845
   tps: 1091.55448
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 834.43045
+  dps: 825.8775
   tps: 1804.73476
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 464.10069
+  dps: 456.37426
   tps: 1032.6701
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 468.54613
+  dps: 459.82442
   tps: 996.84462
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 594.13567
+  dps: 588.2139
   tps: 1356.57881
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 304.5766
+  dps: 299.26184
   tps: 646.45412
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 308.62867
+  dps: 303.16004
   tps: 637.76645
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 490.52575
+  dps: 482.596
   tps: 1079.533
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1308.26032
+  dps: 1275.25727
   tps: 2110.90612
   hps: 19.24115
  }
@@ -415,7 +415,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1871.91448
+  dps: 1838.0316
   tps: 3891.92408
   hps: 15.30247
  }
@@ -423,7 +423,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1248.49817
+  dps: 1214.55876
   tps: 1985.67294
   hps: 15.17748
  }
@@ -431,7 +431,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1156.55785
+  dps: 1131.67356
   tps: 1927.44082
   hps: 14.95714
  }
@@ -439,7 +439,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1156.33629
+  dps: 1138.60169
   tps: 2826.80239
   hps: 10.14833
  }
@@ -447,7 +447,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 711.26332
+  dps: 692.98294
   tps: 1119.83465
   hps: 10.25667
  }
@@ -455,7 +455,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 669.88738
+  dps: 655.883
   tps: 1092.02675
   hps: 10.55833
  }
@@ -463,7 +463,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1281.69198
+  dps: 1248.50132
   tps: 2056.865
   hps: 19.46473
  }


### PR DESCRIPTION
[warlock] fix Improved Imp to only affect Firebolt's base damage