### PR TITLE
Fixed Strength of Earth Aura ID

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1619,7 +1619,7 @@ func StrengthOfEarthTotemAura(unit *Unit, level int32, multiplier float64) *Aura
 	spellId := map[int32]int32{
 		25: 8162,
 		40: 8163,
-		50: 8835,
+		50: 8163,
 		60: 25362,
 	}[level]
 	duration := time.Minute * 2


### PR DESCRIPTION
Strength of Earth buff aura was using id 8835 (which is grace of air).

https://www.wowhead.com/classic/spell=8163/strength-of-earth
https://www.wowhead.com/classic/spell=8835/grace-of-air-totem

![image](https://github.com/wowsims/sod/assets/34491263/e2ee71eb-c775-42a2-8a70-14c78b291eb6)

