### PR TITLE
Add APLValue for warlock pet mana

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -82,7 +82,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 70
+// NextIndex: 72
 message APLValue {
     oneof value {
         // Operators
@@ -165,6 +165,8 @@ message APLValue {
         APLValueCatNewSavageRoarDuration cat_new_savage_roar_duration = 61;
         APLValueWarlockShouldRecastDrainSoul warlock_should_recast_drain_soul = 59;
         APLValueWarlockShouldRefreshCorruption warlock_should_refresh_corruption = 60;
+        APLValueWarlockCurrentPetMana warlock_current_pet_mana = 70;
+        APLValueWarlockCurrentPetManaPercent warlock_current_pet_mana_percent = 71;
         APLValueCurrentSealRemainingTime current_seal_remaining_time = 65;
     }
 }
@@ -508,6 +510,12 @@ message APLValueWarlockShouldRecastDrainSoul {
 }
 message APLValueWarlockShouldRefreshCorruption {
     UnitReference target_unit = 1;
+}
+message APLValueWarlockCurrentPetMana {
+    UnitReference source_unit = 1;
+}
+message APLValueWarlockCurrentPetManaPercent {
+    UnitReference source_unit = 1;
 }
 message APLValueCurrentSealRemainingTime {
 }

--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -511,7 +511,6 @@ message APLValueWarlockShouldRefreshCorruption {
     UnitReference target_unit = 1;
 }
 message APLValueWarlockCurrentPetMana {
-    UnitReference source_unit = 1;
 }
 message APLValueCurrentSealRemainingTime {
 }

--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -82,7 +82,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 72
+// NextIndex: 71
 message APLValue {
     oneof value {
         // Operators
@@ -166,7 +166,6 @@ message APLValue {
         APLValueWarlockShouldRecastDrainSoul warlock_should_recast_drain_soul = 59;
         APLValueWarlockShouldRefreshCorruption warlock_should_refresh_corruption = 60;
         APLValueWarlockCurrentPetMana warlock_current_pet_mana = 70;
-        APLValueWarlockCurrentPetManaPercent warlock_current_pet_mana_percent = 71;
         APLValueCurrentSealRemainingTime current_seal_remaining_time = 65;
     }
 }
@@ -512,9 +511,6 @@ message APLValueWarlockShouldRefreshCorruption {
     UnitReference target_unit = 1;
 }
 message APLValueWarlockCurrentPetMana {
-    UnitReference source_unit = 1;
-}
-message APLValueWarlockCurrentPetManaPercent {
     UnitReference source_unit = 1;
 }
 message APLValueCurrentSealRemainingTime {

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -15,6 +15,8 @@ func (warlock *Warlock) NewAPLValue(rot *core.APLRotation, config *proto.APLValu
 		return warlock.newValueWarlockShouldRefreshCorruption(rot, config.GetWarlockShouldRefreshCorruption())
 	case *proto.APLValue_WarlockCurrentPetMana:
 		return warlock.newValueWarlockCurrentPetMana(rot, config.GetWarlockCurrentPetMana())
+	case *proto.APLValue_WarlockCurrentPetManaPercent:
+		return warlock.newValueWarlockCurrentPetManaPercent(rot, config.GetWarlockCurrentPetManaPercent())
 	default:
 		return nil
 	}

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -15,8 +15,6 @@ func (warlock *Warlock) NewAPLValue(rot *core.APLRotation, config *proto.APLValu
 		return warlock.newValueWarlockShouldRefreshCorruption(rot, config.GetWarlockShouldRefreshCorruption())
 	case *proto.APLValue_WarlockCurrentPetMana:
 		return warlock.newValueWarlockCurrentPetMana(rot, config.GetWarlockCurrentPetMana())
-	case *proto.APLValue_WarlockCurrentPetManaPercent:
-		return warlock.newValueWarlockCurrentPetManaPercent(rot, config.GetWarlockCurrentPetManaPercent())
 	default:
 		return nil
 	}
@@ -184,53 +182,5 @@ func (value *APLValueWarlockCurrentPetMana) GetFloat(sim *core.Simulation) float
 	return value.pet.GetPet().CurrentMana()
 }
 func (value *APLValueWarlockCurrentPetMana) String() string {
-	return "Warlock Current Pet Mana()"
-}
-
-type APLValueWarlockCurrentPetManaPercent struct {
-	core.DefaultAPLValueImpl
-	pet core.PetAgent
-}
-
-func (warlock *Warlock) newValueWarlockCurrentPetManaPercent(rot *core.APLRotation, config *proto.APLValueWarlockCurrentPetManaPercent) core.APLValue {
-	unit := rot.GetSourceUnit(config.SourceUnit)
-	if unit.Get() == nil {
-		return nil
-	}
-	pets := unit.Get().PetAgents
-	var pet core.PetAgent
-	for _, pet_agent := range pets {
-		switch pet_agent.GetPet().Name {
-		case "Imp":
-		case "Succubuse":
-		case "Felhunter":
-		case "Voidwalker":
-		case "Felguard":
-			pet = pet_agent
-		}
-	}
-
-	if pet == nil {
-		return nil
-	}
-
-	if pet.GetPet() == nil {
-		return nil
-	}
-	if !pet.GetPet().HasManaBar() {
-		rot.ValidationWarning("%s does not use Mana", pet.GetPet().Label)
-		return nil
-	}
-	return &APLValueWarlockCurrentPetManaPercent{
-		pet: pet,
-	}
-}
-func (value *APLValueWarlockCurrentPetManaPercent) Type() proto.APLValueType {
-	return proto.APLValueType_ValueTypeFloat
-}
-func (value *APLValueWarlockCurrentPetManaPercent) GetFloat(sim *core.Simulation) float64 {
-	return value.pet.GetPet().CurrentManaPercent()
-}
-func (value *APLValueWarlockCurrentPetManaPercent) String() string {
-	return "Warlock Current Pet Mana Percent()"
+	return "Current Pet Mana"
 }

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -192,7 +192,7 @@ type APLValueWarlockCurrentPetManaPercent struct {
 	pet core.PetAgent
 }
 
-func (warlock *Warlock) newValueWarlockCurrentPetManaPercent(rot *core.APLRotation, config *proto.APLValueWarlockCurrentPetMana) core.APLValue {
+func (warlock *Warlock) newValueWarlockCurrentPetManaPercent(rot *core.APLRotation, config *proto.APLValueWarlockCurrentPetManaPercent) core.APLValue {
 	unit := rot.GetSourceUnit(config.SourceUnit)
 	if unit.Get() == nil {
 		return nil

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -144,26 +144,11 @@ func (value *APLValueWarlockShouldRefreshCorruption) String() string {
 
 type APLValueWarlockCurrentPetMana struct {
 	core.DefaultAPLValueImpl
-	pet core.PetAgent
+	pet *WarlockPet
 }
 
 func (warlock *Warlock) newValueWarlockCurrentPetMana(rot *core.APLRotation, config *proto.APLValueWarlockCurrentPetMana) core.APLValue {
-	unit := rot.GetSourceUnit(config.SourceUnit)
-	if unit.Get() == nil {
-		return nil
-	}
-	pets := unit.Get().PetAgents
-	var pet core.PetAgent
-	for _, pet_agent := range pets {
-		switch pet_agent.GetPet().Name {
-		case "Imp":
-		case "Succubuse":
-		case "Felhunter":
-		case "Voidwalker":
-		case "Felguard":
-			pet = pet_agent
-		}
-	}
+	pet := warlock.Pet
 	if pet.GetPet() == nil {
 		return nil
 	}

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -13,6 +13,8 @@ func (warlock *Warlock) NewAPLValue(rot *core.APLRotation, config *proto.APLValu
 		return warlock.newValueWarlockShouldRecastDrainSoul(rot, config.GetWarlockShouldRecastDrainSoul())
 	case *proto.APLValue_WarlockShouldRefreshCorruption:
 		return warlock.newValueWarlockShouldRefreshCorruption(rot, config.GetWarlockShouldRefreshCorruption())
+	case *proto.APLValue_WarlockCurrentPetMana:
+		return warlock.newValueWarlockCurrentPetMana(rot, config.GetWarlockCurrentPetMana())
 	default:
 		return nil
 	}
@@ -138,4 +140,95 @@ func (value *APLValueWarlockShouldRefreshCorruption) GetBool(sim *core.Simulatio
 }
 func (value *APLValueWarlockShouldRefreshCorruption) String() string {
 	return "Warlock Should Refresh Corruption()"
+}
+
+type APLValueWarlockCurrentPetMana struct {
+	core.DefaultAPLValueImpl
+	pet core.PetAgent
+}
+
+func (warlock *Warlock) newValueWarlockCurrentPetMana(rot *core.APLRotation, config *proto.APLValueWarlockCurrentPetMana) core.APLValue {
+	unit := rot.GetSourceUnit(config.SourceUnit)
+	if unit.Get() == nil {
+		return nil
+	}
+	pets := unit.Get().PetAgents
+	var pet core.PetAgent
+	for _, pet_agent := range pets {
+		switch pet_agent.GetPet().Name {
+		case "Imp":
+		case "Succubuse":
+		case "Felhunter":
+		case "Voidwalker":
+		case "Felguard":
+			pet = pet_agent
+		}
+	}
+	if pet.GetPet() == nil {
+		return nil
+	}
+	if !pet.GetPet().HasManaBar() {
+		rot.ValidationWarning("%s does not use Mana", pet.GetPet().Label)
+		return nil
+	}
+	return &APLValueWarlockCurrentPetMana{
+		pet: pet,
+	}
+}
+func (value *APLValueWarlockCurrentPetMana) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeFloat
+}
+func (value *APLValueWarlockCurrentPetMana) GetFloat(sim *core.Simulation) float64 {
+	return value.pet.GetPet().CurrentMana()
+}
+func (value *APLValueWarlockCurrentPetMana) String() string {
+	return "Warlock Current Pet Mana()"
+}
+
+type APLValueWarlockCurrentPetManaPercent struct {
+	core.DefaultAPLValueImpl
+	pet core.PetAgent
+}
+
+func (warlock *Warlock) newValueWarlockCurrentPetManaPercent(rot *core.APLRotation, config *proto.APLValueWarlockCurrentPetMana) core.APLValue {
+	unit := rot.GetSourceUnit(config.SourceUnit)
+	if unit.Get() == nil {
+		return nil
+	}
+	pets := unit.Get().PetAgents
+	var pet core.PetAgent
+	for _, pet_agent := range pets {
+		switch pet_agent.GetPet().Name {
+		case "Imp":
+		case "Succubuse":
+		case "Felhunter":
+		case "Voidwalker":
+		case "Felguard":
+			pet = pet_agent
+		}
+	}
+
+	if pet == nil {
+		return nil
+	}
+
+	if pet.GetPet() == nil {
+		return nil
+	}
+	if !pet.GetPet().HasManaBar() {
+		rot.ValidationWarning("%s does not use Mana", pet.GetPet().Label)
+		return nil
+	}
+	return &APLValueWarlockCurrentPetManaPercent{
+		pet: pet,
+	}
+}
+func (value *APLValueWarlockCurrentPetManaPercent) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeFloat
+}
+func (value *APLValueWarlockCurrentPetManaPercent) GetFloat(sim *core.Simulation) float64 {
+	return value.pet.GetPet().CurrentManaPercent()
+}
+func (value *APLValueWarlockCurrentPetManaPercent) String() string {
+	return "Warlock Current Pet Mana Percent()"
 }

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -64,6 +64,8 @@ import {
 	APLValueTotemRemainingTime,
 	APLValueWarlockShouldRecastDrainSoul,
 	APLValueWarlockShouldRefreshCorruption,
+	APLValueWarlockCurrentPetMana,
+	APLValueWarlockCurrentPetManaPercent,
 } from '../../proto/apl.js';
 import { Class, Spec } from '../../proto/common.js';
 import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
@@ -930,6 +932,22 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 		newValue: APLValueWarlockShouldRefreshCorruption.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
 		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets')],
+	}),
+	warlockCurrentPetMana: inputBuilder({
+		label: 'Pet Mana',
+		submenu: ['Warlock'],
+		shortDescription: 'Amount of currently available pet mana.',
+		newValue: APLValueWarlockCurrentPetMana.create,
+		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
+		fields: [],
+	}),
+	warlockCurrentPetManaPercent: inputBuilder({
+		label: 'Pet Mana (%)',
+		submenu: ['Warlock'],
+		shortDescription: 'Amount of currently available pet mana, as a percentage.',
+		newValue: APLValueWarlockCurrentPetManaPercent.create,
+		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
+		fields: [],
 	}),
 	currentSealRemainingTime: inputBuilder({
 		label: 'Current Seal Remaining Time',

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -65,7 +65,6 @@ import {
 	APLValueWarlockShouldRecastDrainSoul,
 	APLValueWarlockShouldRefreshCorruption,
 	APLValueWarlockCurrentPetMana,
-	APLValueWarlockCurrentPetManaPercent,
 } from '../../proto/apl.js';
 import { Class, Spec } from '../../proto/common.js';
 import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
@@ -938,14 +937,6 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 		submenu: ['Warlock'],
 		shortDescription: 'Amount of currently available pet mana.',
 		newValue: APLValueWarlockCurrentPetMana.create,
-		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
-		fields: [],
-	}),
-	warlockCurrentPetManaPercent: inputBuilder({
-		label: 'Pet Mana (%)',
-		submenu: ['Warlock'],
-		shortDescription: 'Amount of currently available pet mana, as a percentage.',
-		newValue: APLValueWarlockCurrentPetManaPercent.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
 		fields: [],
 	}),


### PR DESCRIPTION
With the changes to lifetap, Warlocks will be wanting to use their pet's mana as a condition for when to lifetap. This enables that ability.
<img width="770" alt="Screen Shot 2024-04-17 at 1 37 06 AM" src="https://github.com/wowsims/sod/assets/1355959/ef2e20fd-1058-483e-a5d2-45ca3d595ef2">
<img width="832" alt="Screen Shot 2024-04-17 at 1 37 00 AM" src="https://github.com/wowsims/sod/assets/1355959/ac3f71c7-035a-475d-9799-fbfc80c8e97d">
