### PR TITLE
Mekkatorque Proc Fix

### DIFF
--- a/sim/common/sod/item_effects/phase_2.go
+++ b/sim/common/sod/item_effects/phase_2.go
@@ -372,9 +372,8 @@ func init() {
 			BonusCoefficient: 0.05,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				spell.CalcAndDealDamage(sim, target, 30, spell.OutcomeMagicHitAndCrit)
-
 				if target.Level <= 45 {
+					spell.CalcAndDealDamage(sim, target, 30, spell.OutcomeMagicHitAndCrit)
 					procAuras.Get(target).Activate(sim)
 				}
 			},


### PR DESCRIPTION
https://sod.warcraftlogs.com/reports/8TbBpznhA9cVXmC6#boss=-2&wipes=2&type=damage-done&source=16
https://sod.warcraftlogs.com/reports/R7aF3pAYVfZ6cJKb#type=damage-done&boss=-2&difficulty=0&source=7

In these logs, Mekkatorque's isn't proccing at all on level 50 mobs; in the sim the proc still does damage but doesn't apply the debuff