### PR TITLE
Make demonic knowledge scaling match in game values

### DIFF
--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.78287
+  weights: 0.3498
   weights: 0
-  weights: 0.53641
-  weights: 0
-  weights: 0
+  weights: 0.85175
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.14158
-  weights: 1.71612
+  weights: 0
+  weights: 0
+  weights: 4.33415
+  weights: 1.63252
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.28778
+  weights: 0.10795
   weights: 0
-  weights: -0.46832
-  weights: 0
-  weights: 0
+  weights: -0.37008
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.84263
-  weights: 7.14591
+  weights: 0
+  weights: 0
+  weights: 10.8692
+  weights: 7.49935
   weights: 0
   weights: 0
   weights: 0
@@ -197,112 +197,112 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-Average-Default"
  value: {
-  dps: 587.64576
-  tps: 556.99508
+  dps: 598.73464
+  tps: 567.32935
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 584.19304
-  tps: 1182.67282
+  dps: 591.15328
+  tps: 1196.1784
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 584.19304
-  tps: 553.31098
+  dps: 591.15328
+  tps: 559.66614
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.81461
-  tps: 532.79021
+  dps: 585.39964
+  tps: 542.89609
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 368.68681
-  tps: 995.09357
+  dps: 373.63797
+  tps: 998.20618
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 368.68681
-  tps: 355.62088
+  dps: 373.63797
+  tps: 360.47239
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 375.50863
-  tps: 349.28049
+  dps: 379.52923
+  tps: 353.1449
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 588.6543
-  tps: 557.82805
+  dps: 601.89986
+  tps: 570.08021
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1326.62359
-  tps: 1130.63521
+  dps: 1354.36862
+  tps: 1153.9304
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1899.41166
-  tps: 2647.10542
+  dps: 1952.20599
+  tps: 2701.44989
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1303.99632
-  tps: 1107.74441
+  dps: 1343.22973
+  tps: 1144.42781
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1347.10444
-  tps: 1182.18086
+  dps: 1374.34558
+  tps: 1206.44251
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1185.88432
-  tps: 2070.65628
+  dps: 1198.98377
+  tps: 2082.05249
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 743.24933
-  tps: 625.78478
+  dps: 753.85192
+  tps: 633.82532
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 704.87362
-  tps: 630.45808
+  dps: 716.68652
+  tps: 639.37389
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1324.95274
-  tps: 1130.14122
+  dps: 1350.88053
+  tps: 1150.95943
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.01331
+  weights: 0.15074
   weights: 0
-  weights: 0.53679
-  weights: 0
-  weights: 0
+  weights: 0.9444
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.40535
-  weights: 2.12408
+  weights: 0
+  weights: 0
+  weights: 5.16824
+  weights: 2.10439
   weights: 0
   weights: 0
   weights: 0
@@ -99,56 +99,56 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 644.30134
-  tps: 535.48342
+  dps: 655.4921
+  tps: 545.9111
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 644.9294
-  tps: 854.2803
+  dps: 656.18105
+  tps: 869.51358
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 644.9294
-  tps: 537.44821
+  dps: 656.18105
+  tps: 548.00703
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 688.36389
-  tps: 577.16233
+  dps: 699.63125
+  tps: 587.86449
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 374.56765
-  tps: 675.01942
+  dps: 377.74705
+  tps: 680.05906
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 374.56765
-  tps: 333.51743
+  dps: 377.74705
+  tps: 336.38272
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 427.48813
-  tps: 369.96447
+  dps: 431.0382
+  tps: 373.24835
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 647.42559
-  tps: 540.37038
+  dps: 659.77487
+  tps: 552.11402
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -200,7 +200,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02784
+  weights: 0.02916
   weights: 0
   weights: 0.13619
   weights: 0
@@ -210,8 +210,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.06661
-  weights: 0.16755
+  weights: 3.12032
+  weights: 0.17147
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.80691
+  weights: -2.79953
   weights: 0
-  weights: 0.14571
-  weights: 0
-  weights: 0
+  weights: 2.88604
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 20.05234
-  weights: 6.75843
+  weights: 0
+  weights: 0
+  weights: 8.96163
+  weights: 5.41451
   weights: 0
   weights: 0
   weights: 0
@@ -351,112 +351,112 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 145.67126
-  tps: 78.65772
+  dps: 147.85594
+  tps: 79.59037
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 142.74374
-  tps: 1037.92464
+  dps: 144.92268
+  tps: 1045.56735
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 142.74374
-  tps: 74.0336
+  dps: 144.92268
+  tps: 74.88232
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 239.35189
-  tps: 159.62473
+  dps: 243.52858
+  tps: 163.02771
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 103.69659
-  tps: 1016.50172
+  dps: 104.87286
+  tps: 1017.4809
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 103.69659
-  tps: 65.48946
+  dps: 104.87286
+  tps: 65.5411
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 166.00867
-  tps: 112.30784
+  dps: 167.8639
+  tps: 113.91043
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 143.00855
-  tps: 74.38425
+  dps: 145.19356
+  tps: 75.24074
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1262.81151
-  tps: 1111.43375
+  dps: 1287.74693
+  tps: 1134.08907
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1996.03453
-  tps: 2502.70732
+  dps: 2034.51456
+  tps: 2541.93019
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1258.8581
-  tps: 1107.82719
+  dps: 1275.03876
+  tps: 1121.36481
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1350.71441
-  tps: 1217.88406
+  dps: 1376.22675
+  tps: 1241.83769
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1237.79346
-  tps: 1865.06428
+  dps: 1258.55476
+  tps: 1886.49774
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 695.10717
-  tps: 616.87371
+  dps: 704.70424
+  tps: 625.35902
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 736.50638
-  tps: 680.39569
+  dps: 745.0004
+  tps: 688.1706
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1255.01937
-  tps: 1103.10161
+  dps: 1289.46603
+  tps: 1135.95401
  }
 }

--- a/sim/warlock/runes.go
+++ b/sim/warlock/runes.go
@@ -172,7 +172,7 @@ func (warlock *Warlock) applyDemonicKnowledge() {
 		Duration: core.NeverExpires,
 
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			warlock.demonicKnowledgeSp = (warlock.Pet.GetStat(stats.Stamina) + warlock.Pet.GetStat(stats.Intellect)) * 0.1
+			warlock.demonicKnowledgeSp = (warlock.Pet.GetStat(stats.Stamina) + warlock.Pet.GetStat(stats.Intellect)) * 0.12
 			warlock.AddStatDynamic(sim, stats.SpellPower, warlock.demonicKnowledgeSp)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.53787
+  weights: 0.11029
   weights: 0
-  weights: 0.96167
-  weights: 0
-  weights: 0
+  weights: 0.40845
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.33785
-  weights: 1.43985
+  weights: 0
+  weights: 0
+  weights: 6.4248
+  weights: 1.49799
   weights: 0
   weights: 0
   weights: 0
@@ -99,56 +99,56 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 584.14614
-  tps: 1116.55471
+  dps: 595.65356
+  tps: 1142.61143
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 547.58615
-  tps: 1566.83604
+  dps: 559.95417
+  tps: 1599.42562
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 547.58615
-  tps: 1054.63536
+  dps: 559.95417
+  tps: 1083.55832
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.45826
-  tps: 1105.46708
+  dps: 585.79062
+  tps: 1131.21821
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 324.88775
-  tps: 1244.32824
+  dps: 328.98486
+  tps: 1246.16221
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 324.88775
-  tps: 680.77795
+  dps: 328.98486
+  tps: 690.61761
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 348.78087
-  tps: 721.48947
+  dps: 352.74924
+  tps: 730.55989
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 580.66325
-  tps: 1110.11424
+  dps: 594.40653
+  tps: 1139.19022
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.30214
+  weights: 0.35158
   weights: 0
-  weights: 0.69535
-  weights: 0
-  weights: 0
+  weights: 0.66799
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.16673
-  weights: 3.05731
+  weights: 0
+  weights: 0
+  weights: 6.02367
+  weights: 3.14437
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.38226
+  weights: -1.3246
   weights: 0
-  weights: 5.1846
-  weights: 0
-  weights: 0
+  weights: 1.63974
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.68279
-  weights: 5.51983
+  weights: 0
+  weights: 0
+  weights: 4.25444
+  weights: 6.2618
   weights: 0
   weights: 0
   weights: 0
@@ -351,120 +351,120 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 489.68845
-  tps: 1091.55448
+  dps: 501.59249
+  tps: 1120.94831
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 825.8775
-  tps: 1804.73476
+  dps: 847.33327
+  tps: 1844.06872
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 456.37426
-  tps: 1032.6701
+  dps: 464.76164
+  tps: 1051.35759
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 459.82442
-  tps: 996.84462
+  dps: 471.12595
+  tps: 1024.26014
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 588.2139
-  tps: 1356.57881
+  dps: 594.16616
+  tps: 1367.80567
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 299.26184
-  tps: 646.45412
+  dps: 306.7561
+  tps: 665.27677
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 303.16004
-  tps: 637.76645
+  dps: 308.30462
+  tps: 650.14512
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 482.596
-  tps: 1079.533
+  dps: 494.53293
+  tps: 1108.80093
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1275.25727
-  tps: 2110.90612
-  hps: 19.24115
+  dps: 1301.56578
+  tps: 2159.22546
+  hps: 19.2738
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1838.0316
-  tps: 3891.92408
-  hps: 15.30247
+  dps: 1872.49134
+  tps: 3955.07317
+  hps: 15.19136
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1214.55876
-  tps: 1985.67294
-  hps: 15.17748
+  dps: 1250.69869
+  tps: 2055.66475
+  hps: 15.35508
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1131.67356
-  tps: 1927.44082
+  dps: 1154.1029
+  tps: 1968.20354
   hps: 14.95714
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1138.60169
-  tps: 2826.80239
-  hps: 10.14833
+  dps: 1158.43785
+  tps: 2859.14027
+  hps: 10.27667
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 692.98294
-  tps: 1119.83465
-  hps: 10.25667
+  dps: 703.36383
+  tps: 1139.8556
+  hps: 10.20167
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 655.883
-  tps: 1092.02675
-  hps: 10.55833
+  dps: 662.61416
+  tps: 1102.67544
+  hps: 10.525
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1248.50132
-  tps: 2056.865
-  hps: 19.46473
+  dps: 1267.37011
+  tps: 2097.51103
+  hps: 19.53577
  }
 }


### PR DESCRIPTION
In-game buffs indicate Demonic Knowledge actually scales as 12% of pet stamina + intellect, rather than the 10% the tooltip indicates. Updating to reflect actual game values.