### PR TITLE
Add Pet Mana % APLValue

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -82,7 +82,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 71
+// NextIndex: 72
 message APLValue {
     oneof value {
         // Operators
@@ -166,6 +166,7 @@ message APLValue {
         APLValueWarlockShouldRecastDrainSoul warlock_should_recast_drain_soul = 59;
         APLValueWarlockShouldRefreshCorruption warlock_should_refresh_corruption = 60;
         APLValueWarlockCurrentPetMana warlock_current_pet_mana = 70;
+        APLValueWarlockCurrentPetManaPercent warlock_current_pet_mana_percent = 71;
         APLValueCurrentSealRemainingTime current_seal_remaining_time = 65;
     }
 }
@@ -511,6 +512,8 @@ message APLValueWarlockShouldRefreshCorruption {
     UnitReference target_unit = 1;
 }
 message APLValueWarlockCurrentPetMana {
+}
+message APLValueWarlockCurrentPetManaPercent {
 }
 message APLValueCurrentSealRemainingTime {
 }

--- a/sim/warlock/apl_values.go
+++ b/sim/warlock/apl_values.go
@@ -1,6 +1,7 @@
 package warlock
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/wowsims/sod/sim/core"
@@ -15,6 +16,8 @@ func (warlock *Warlock) NewAPLValue(rot *core.APLRotation, config *proto.APLValu
 		return warlock.newValueWarlockShouldRefreshCorruption(rot, config.GetWarlockShouldRefreshCorruption())
 	case *proto.APLValue_WarlockCurrentPetMana:
 		return warlock.newValueWarlockCurrentPetMana(rot, config.GetWarlockCurrentPetMana())
+	case *proto.APLValue_WarlockCurrentPetManaPercent:
+		return warlock.newValueWarlockCurrentPetManaPercent(rot, config.GetWarlockCurrentPetManaPercent())
 	default:
 		return nil
 	}
@@ -168,4 +171,32 @@ func (value *APLValueWarlockCurrentPetMana) GetFloat(sim *core.Simulation) float
 }
 func (value *APLValueWarlockCurrentPetMana) String() string {
 	return "Current Pet Mana"
+}
+
+type APLValueWarlockCurrentPetManaPercent struct {
+	core.DefaultAPLValueImpl
+	pet *WarlockPet
+}
+
+func (warlock *Warlock) newValueWarlockCurrentPetManaPercent(rot *core.APLRotation, config *proto.APLValueWarlockCurrentPetManaPercent) core.APLValue {
+	pet := warlock.Pet
+	if pet.GetPet() == nil {
+		return nil
+	}
+	if !pet.GetPet().HasManaBar() {
+		rot.ValidationWarning("%s does not use Mana", pet.GetPet().Label)
+		return nil
+	}
+	return &APLValueWarlockCurrentPetManaPercent{
+		pet: pet,
+	}
+}
+func (value *APLValueWarlockCurrentPetManaPercent) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeFloat
+}
+func (value *APLValueWarlockCurrentPetManaPercent) GetFloat(sim *core.Simulation) float64 {
+	return value.pet.GetPet().CurrentManaPercent()
+}
+func (value *APLValueWarlockCurrentPetManaPercent) String() string {
+	return fmt.Sprintf("Current Pet Mana %%")
 }

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -65,6 +65,7 @@ import {
 	APLValueWarlockShouldRecastDrainSoul,
 	APLValueWarlockShouldRefreshCorruption,
 	APLValueWarlockCurrentPetMana,
+	APLValueWarlockCurrentPetManaPercent,
 } from '../../proto/apl.js';
 import { Class, Spec } from '../../proto/common.js';
 import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
@@ -937,6 +938,14 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 		submenu: ['Warlock'],
 		shortDescription: 'Amount of currently available pet mana.',
 		newValue: APLValueWarlockCurrentPetMana.create,
+		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
+		fields: [],
+	}),
+	warlockCurrentPetManaPercent: inputBuilder({
+		label: 'Pet Mana (%)',
+		submenu: ['Warlock'],
+		shortDescription: 'Amount of currently available pet mana, as a percentage.',
+		newValue: APLValueWarlockCurrentPetManaPercent.create,
 		includeIf: (player: Player<any>, _isPrepull: boolean) => player.getClass() == Class.ClassWarlock,
 		fields: [],
 	}),


### PR DESCRIPTION
Adds Pet mana as a percentage for warlocks as an APLValue as requested by Niche.