### PR TITLE
Fix warlock pet mp5 inheritance

### DIFF
--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.53967
+  weights: 1.50891
   weights: 0
-  weights: 2.9153
-  weights: 0
-  weights: 0
+  weights: 2.32483
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 11.56966
-  weights: 7.72247
+  weights: 0
+  weights: 0
+  weights: 12.72584
+  weights: 8.12795
   weights: 0
   weights: 0
   weights: 0
@@ -225,22 +225,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 377.07321
-  tps: 1003.31266
+  dps: 375.7001
+  tps: 1002.85574
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 377.07321
-  tps: 363.68931
+  dps: 375.7001
+  tps: 361.54472
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 380.10121
-  tps: 353.70065
+  dps: 379.90128
+  tps: 352.2943
  }
 }
 dps_results: {
@@ -253,56 +253,56 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1378.67731
-  tps: 1170.64156
+  dps: 1407.90403
+  tps: 1178.51201
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1978.54276
-  tps: 2723.3656
+  dps: 2009.24752
+  tps: 2733.25673
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1366.80085
-  tps: 1158.25072
+  dps: 1388.42013
+  tps: 1159.75553
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1436.89055
-  tps: 1244.52811
+  dps: 1487.03176
+  tps: 1243.95208
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1215.3206
-  tps: 2094.72172
+  dps: 1223.44459
+  tps: 2094.55371
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 760.7607
-  tps: 635.72938
+  dps: 770.68672
+  tps: 641.13099
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 751.33584
-  tps: 655.71664
+  dps: 758.55371
+  tps: 649.74155
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1389.08921
-  tps: 1183.92177
+  dps: 1406.81558
+  tps: 1178.46697
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.74309
+  weights: 7.46111
   weights: 0
-  weights: 0.92235
-  weights: 0
-  weights: 0
+  weights: 0.26886
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 14.9734
-  weights: 7.72797
+  weights: 0
+  weights: 0
+  weights: 13.14487
+  weights: 7.00941
   weights: 0
   weights: 0
   weights: 0
@@ -407,56 +407,56 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1306.47495
-  tps: 1148.86545
+  dps: 1326.14008
+  tps: 1156.15571
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2053.0088
-  tps: 2560.13324
+  dps: 2075.1075
+  tps: 2562.54588
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1304.22093
-  tps: 1149.25913
+  dps: 1312.14252
+  tps: 1142.33031
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1427.01417
-  tps: 1277.19905
+  dps: 1469.40404
+  tps: 1283.47588
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1271.43318
-  tps: 1891.32739
+  dps: 1303.53279
+  tps: 1904.30148
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 722.91023
-  tps: 637.31062
+  dps: 746.04815
+  tps: 639.76967
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 761.69938
-  tps: 688.15459
+  dps: 787.6358
+  tps: 703.23364
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1293.71058
-  tps: 1135.27633
+  dps: 1333.08773
+  tps: 1162.87592
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0029
+  weights: 0.20223
   weights: 0
-  weights: 0.36308
-  weights: 0
-  weights: 0
+  weights: 0.3762
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.23665
+  weights: 0
+  weights: 0
+  weights: 0.23816
   weights: 0
   weights: 0
   weights: 0
@@ -295,57 +295,57 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 122.31451
-  tps: 94.72223
+  dps: 125.24834
+  tps: 94.73149
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 392.07622
-  tps: 694.34373
+  dps: 394.05901
+  tps: 693.41252
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 122.301
-  tps: 94.55663
+  dps: 124.50648
+  tps: 93.81014
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 205.64351
-  tps: 160.0771
+  dps: 213.78234
+  tps: 159.67588
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 299.14278
-  tps: 677.79138
+  dps: 300.56398
+  tps: 677.9282
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 85.66284
-  tps: 62.58916
+  dps: 87.03549
+  tps: 62.64213
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 158.88402
-  tps: 127.04111
+  dps: 165.04308
+  tps: 125.59337
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 122.301
-  tps: 94.55663
+  dps: 124.50648
+  tps: 93.81014
  }
 }
 dps_results: {

--- a/sim/warlock/pet.go
+++ b/sim/warlock/pet.go
@@ -560,7 +560,7 @@ func (warlock *Warlock) makeStatInheritance() core.PetStatInheritance {
 			stats.Intellect:        ownerStats[stats.Intellect] * 0.3,
 			stats.Armor:            ownerStats[stats.Armor] * 0.35,
 			stats.AttackPower:      highestSchoolPower * 0.565,
-			stats.MP5:              ownerStats[stats.MP5] * 0.3,
+			stats.MP5:              ownerStats[stats.Intellect] * 0.315,
 			stats.SpellPower:       ownerStats[stats.SpellPower] * 0.15,
 			stats.SpellDamage:      ownerStats[stats.SpellDamage] * 0.15,
 			stats.FirePower:        ownerStats[stats.FirePower] * 0.15,

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -127,22 +127,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 158.60907
-  tps: 572.07147
+  dps: 158.78158
+  tps: 572.21729
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 127.46521
-  tps: 238.77123
+  dps: 128.74214
+  tps: 239.75308
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 134.89084
-  tps: 254.47979
+  dps: 136.22408
+  tps: 255.00316
  }
 }
 dps_results: {
@@ -169,22 +169,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 158.60907
-  tps: 572.07147
+  dps: 158.78158
+  tps: 572.21729
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 127.46521
-  tps: 238.77123
+  dps: 128.74214
+  tps: 239.75308
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 134.89084
-  tps: 254.47979
+  dps: 136.22408
+  tps: 255.00316
  }
 }
 dps_results: {

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.09994
+  weights: -1.03819
   weights: 0
-  weights: 0.68129
-  weights: 0
-  weights: 0
+  weights: 0.64028
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.06527
-  weights: 3.1656
+  weights: 0
+  weights: 0
+  weights: 3.09141
+  weights: 3.1893
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -9.40684
+  weights: 0.07239
   weights: 0
-  weights: -5.68032
-  weights: 0
-  weights: 0
+  weights: -2.28659
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.52021
-  weights: 5.3481
+  weights: 0
+  weights: 0
+  weights: 5.52568
+  weights: 5.87868
   weights: 0
   weights: 0
   weights: 0
@@ -351,22 +351,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 504.46959
-  tps: 1128.04285
+  dps: 520.95084
+  tps: 1138.44184
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 851.89758
-  tps: 1855.46543
+  dps: 871.38842
+  tps: 1855.90167
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 469.0978
-  tps: 1062.70984
+  dps: 488.59803
+  tps: 1081.15441
  }
 }
 dps_results: {
@@ -379,92 +379,92 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 596.87175
-  tps: 1371.83336
+  dps: 605.92896
+  tps: 1375.27138
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 307.21401
-  tps: 665.16201
+  dps: 311.70442
+  tps: 666.12409
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 309.33175
-  tps: 652.61655
+  dps: 316.74761
+  tps: 650.51142
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 497.66867
-  tps: 1116.67967
+  dps: 516.18895
+  tps: 1130.689
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1329.56022
-  tps: 2191.24494
-  hps: 19.3252
+  dps: 1339.74177
+  tps: 2197.11391
+  hps: 19.38366
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1884.4434
-  tps: 3974.59046
-  hps: 15.20046
+  dps: 1911.83687
+  tps: 4004.30034
+  hps: 15.15675
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1269.10764
-  tps: 2085.30524
-  hps: 15.35873
+  dps: 1276.45672
+  tps: 2079.80624
+  hps: 15.3651
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1212.87989
-  tps: 2042.93608
-  hps: 15.51045
+  dps: 1268.23222
+  tps: 2069.45989
+  hps: 15.46719
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1186.0415
-  tps: 2894.00446
-  hps: 10.225
+  dps: 1201.9215
+  tps: 2897.36173
+  hps: 10.28333
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 721.92322
-  tps: 1148.56177
-  hps: 10.135
+  dps: 742.553
+  tps: 1175.40668
+  hps: 10.405
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 678.21943
-  tps: 1112.91319
-  hps: 10.34167
+  dps: 694.42142
+  tps: 1127.59646
+  hps: 10.575
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1310.22295
-  tps: 2157.65433
-  hps: 19.89144
+  dps: 1309.70147
+  tps: 2146.05966
+  hps: 19.73934
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.23776
+  weights: 0.79378
   weights: 0
-  weights: 1.33685
-  weights: 0
-  weights: 0
+  weights: 1.38359
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.33145
+  weights: 0
+  weights: 0
+  weights: 0.40683
   weights: 0
   weights: 0
   weights: 0
@@ -295,57 +295,57 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 168.76924
-  tps: 273.43016
+  dps: 172.17724
+  tps: 273.5437
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 413.54046
-  tps: 835.72675
+  dps: 417.18418
+  tps: 839.16629
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 160.52439
-  tps: 261.33228
+  dps: 163.73074
+  tps: 260.49625
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 165.95054
-  tps: 293.48082
+  dps: 174.61266
+  tps: 293.72033
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 328.19818
-  tps: 906.90102
+  dps: 329.07408
+  tps: 918.50872
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 104.30653
-  tps: 149.0877
+  dps: 104.20812
+  tps: 146.34627
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 124.07749
-  tps: 221.53736
+  dps: 134.00802
+  tps: 226.1287
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 165.38782
-  tps: 268.62743
+  dps: 168.60192
+  tps: 267.80302
  }
 }
 dps_results: {


### PR DESCRIPTION
So, thorough in game testing has revealed that rather than inheriting a percentage of your personal mp5, the pets are actually scaling mp5 as a percentage of your intellect. This updates the inheritance to the correct value/stat.