### PR TITLE
Fix Imp. Blizzard and Elune's Fire crashes

### DIFF
--- a/sim/druid/runes.go
+++ b/sim/druid/runes.go
@@ -241,6 +241,9 @@ func (druid *Druid) tryElunesFiresMoonfireExtension(sim *core.Simulation, unit *
 }
 
 func (druid *Druid) tryElunesFiresSunfireExtension(sim *core.Simulation, unit *core.Unit) {
+	if druid.Sunfire == nil {
+		return
+	}
 	if dot := druid.Sunfire.Dot(unit); dot.IsActive() && dot.NumberOfTicks < ElunesFires_MaxSunfireTicks {
 		dot.NumberOfTicks += ElunesFires_BonusSunfireTicks
 		dot.RecomputeAuraDuration()

--- a/sim/mage/blizzard.go
+++ b/sim/mage/blizzard.go
@@ -39,7 +39,7 @@ func (mage *Mage) newBlizzardSpellConfig(rank int) core.SpellConfig {
 
 	var improvedBlizzardProcApplication *core.Spell
 	if mage.Talents.ImprovedBlizzard > 0 {
-		impId := []int32{11185, 12487, 12488}[mage.Talents.ImprovedBlizzard]
+		impId := []int32{0, 11185, 12487, 12488}[mage.Talents.ImprovedBlizzard]
 		auras := mage.NewEnemyAuraArray(func(unit *core.Unit, playerLevel int32) *core.Aura {
 			return unit.GetOrRegisterAura(core.Aura{
 				ActionID: core.ActionID{SpellID: impId},


### PR DESCRIPTION
Fixes crash when Sunfire Rune isn't used for Balance https://github.com/wowsims/sod/issues/703 https://github.com/wowsims/sod/issues/700 https://github.com/wowsims/sod/issues/683 https://github.com/wowsims/sod/issues/707
Fixes crash when Improved Blizzard 3/3 is talented https://github.com/wowsims/sod/issues/684