### PR TITLE
Shaman updates

### DIFF
--- a/proto/shaman.proto
+++ b/proto/shaman.proto
@@ -153,12 +153,6 @@ message ShamanTotems {
 	bool enh_tier_ten_bonus = 11;
 }
 
-enum ShamanShield {
-	NoShield = 0;
-	WaterShield = 1;
-	LightningShield = 2;
-}
-
 enum ShamanSyncType {
   NoSync = 0;
   SyncMainhandOffhandSwings = 1;
@@ -172,8 +166,6 @@ message ElementalShaman {
 
 	// NextIndex: 6
 	message Options {
-		ShamanShield shield = 1;
-		ShamanTotems totems = 3 [deprecated=true];
 	}
 	Options options = 3;
 }
@@ -184,9 +176,7 @@ message EnhancementShaman {
 
 	// NextIndex: 7
 	message Options {
-		ShamanShield shield = 1;
 		ShamanSyncType sync_type = 3;
-		ShamanTotems totems = 6 [deprecated=true];
 	}
 	Options options = 3;
 }
@@ -204,7 +194,6 @@ message RestorationShaman {
 
 	// NextIndex: 8
 	message Options {
-		ShamanShield shield = 1;
 		int32 earth_shield_p_p_m = 5;
 		ShamanTotems totems = 6 [deprecated=true];
 	}

--- a/sim/raid_bench_test.go
+++ b/sim/raid_bench_test.go
@@ -54,15 +54,7 @@ var castersWithElemental = &proto.Party{
 			Equipment: ElementalEquipment,
 			Spec: &proto.Player_ElementalShaman{
 				ElementalShaman: &proto.ElementalShaman{
-					Options: &proto.ElementalShaman_Options{
-						Shield: proto.ShamanShield_WaterShield,
-						Totems: &proto.ShamanTotems{
-							Earth: proto.EarthTotem_TremorTotem,
-							Air:   proto.AirTotem_WindfuryTotem,
-							Fire:  proto.FireTotem_SearingTotem,
-							Water: proto.WaterTotem_ManaSpringTotem,
-						},
-					},
+					Options: &proto.ElementalShaman_Options{},
 				},
 			},
 			Consumes: &proto.Consumes{},
@@ -175,14 +167,7 @@ func BenchmarkSimulate(b *testing.B) {
 							Spec: &proto.Player_EnhancementShaman{
 								EnhancementShaman: &proto.EnhancementShaman{
 									Options: &proto.EnhancementShaman_Options{
-										Shield:   proto.ShamanShield_LightningShield,
 										SyncType: proto.ShamanSyncType_SyncMainhandOffhandSwings,
-										Totems: &proto.ShamanTotems{
-											Earth: proto.EarthTotem_TremorTotem,
-											Air:   proto.AirTotem_WindfuryTotem,
-											Fire:  proto.FireTotem_SearingTotem,
-											Water: proto.WaterTotem_ManaSpringTotem,
-										},
 									},
 								},
 							},

--- a/sim/shaman/chain_lightning.go
+++ b/sim/shaman/chain_lightning.go
@@ -93,11 +93,11 @@ func (shaman *Shaman) newChainLightningSpellConfig(rank int, cdTimer *core.Timer
 		for _, result := range results {
 			spell.DealDamage(sim, result)
 
-			if canOverload && result.Landed() && sim.RandomFloat("CL Overload") <= overloadChance {
+			if canOverload && result.Landed() && sim.Proc(overloadChance, "CL Overload") {
 				shaman.ChainLightningOverload[rank].Cast(sim, result.Target)
 			}
 
-			if hasRollingThunderRune && !isOverload {
+			if hasRollingThunderRune {
 				shaman.rollRollingThunderCharge(sim)
 			}
 		}

--- a/sim/shaman/electric_spell.go
+++ b/sim/shaman/electric_spell.go
@@ -58,8 +58,7 @@ func (shaman *Shaman) newElectricSpellConfig(actionID core.ActionID, baseCost fl
 			},
 		},
 
-		BonusCritRating: 0 +
-			float64(shaman.Talents.TidalMastery)*core.CritRatingPerCritChance +
+		BonusCritRating: float64(shaman.Talents.TidalMastery)*core.CritRatingPerCritChance +
 			float64(shaman.Talents.CallOfThunder)*core.CritRatingPerCritChance,
 
 		CritDamageBonus: shaman.elementalFury(),

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -104,7 +104,7 @@ character_stats_results: {
   final_stats: 453.5784
   final_stats: 309.474
   final_stats: 200.178
-  final_stats: 254
+  final_stats: 238
   final_stats: 0
   final_stats: 40
   final_stats: 0
@@ -141,7 +141,7 @@ character_stats_results: {
   final_stats: 23.25
   final_stats: 0
   final_stats: 0
-  final_stats: 85
+  final_stats: 285
   final_stats: 0
  }
 }
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.23807
+  weights: 0.26915
   weights: 0
-  weights: 1.06563
+  weights: 1.11529
   weights: 0
-  weights: 0.36299
-  weights: 0
-  weights: 0
-  weights: 0.70264
+  weights: 0.37395
   weights: 0
   weights: 0
+  weights: 0.74133
   weights: 0
-  weights: 5.18834
+  weights: 0
+  weights: 0
+  weights: 6.28495
   weights: 0
   weights: 0
   weights: 0
@@ -491,98 +491,98 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-Average-Default"
  value: {
-  dps: 1094.3136
-  tps: 945.52711
+  dps: 1364.20247
+  tps: 1215.90713
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2289.09912
-  tps: 2728.26453
+  dps: 2762.41714
+  tps: 3244.82524
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1031.61929
-  tps: 887.28312
+  dps: 1269.14767
+  tps: 1126.56958
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1095.85925
-  tps: 975.04939
+  dps: 1337.06347
+  tps: 1223.162
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1193.797
-  tps: 1597.24096
+  dps: 1562.99742
+  tps: 2023.52505
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 659.2183
-  tps: 579.6953
+  dps: 826.93627
+  tps: 748.93445
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 712.43701
-  tps: 642.32955
+  dps: 874.47479
+  tps: 808.21986
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2306.82736
-  tps: 2755.46233
+  dps: 2782.54795
+  tps: 3293.79427
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1047.80805
-  tps: 900.80922
+  dps: 1282.34358
+  tps: 1139.02689
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1126.80628
-  tps: 1008.51653
+  dps: 1352.5583
+  tps: 1239.29202
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1189.89073
-  tps: 1606.76128
+  dps: 1531.07497
+  tps: 2003.88383
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 664.04518
-  tps: 584.77402
+  dps: 844.28688
+  tps: 767.16165
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 734.99957
-  tps: 670.46484
+  dps: 899.79789
+  tps: 842.19872
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1082.41269
-  tps: 932.78672
+  dps: 1352.40226
+  tps: 1204.85441
  }
 }

--- a/sim/shaman/elemental/elemental.go
+++ b/sim/shaman/elemental/elemental.go
@@ -24,14 +24,10 @@ func RegisterElementalShaman() {
 }
 
 func NewElementalShaman(character *core.Character, options *proto.Player) *ElementalShaman {
-	eleOptions := options.GetElementalShaman()
-
-	selfBuffs := shaman.SelfBuffs{
-		Shield: eleOptions.Options.Shield,
-	}
+	_ = options.GetElementalShaman()
 
 	ele := &ElementalShaman{
-		Shaman: shaman.NewShaman(character, options.TalentsString, selfBuffs),
+		Shaman: shaman.NewShaman(character, options.TalentsString),
 	}
 
 	// Enable Auto Attacks for this spec

--- a/sim/shaman/elemental/elemental_test.go
+++ b/sim/shaman/elemental/elemental_test.go
@@ -155,9 +155,7 @@ var Phase3Talents = "550031550000151-500203"
 
 var PlayerOptionsAdaptive = &proto.Player_ElementalShaman{
 	ElementalShaman: &proto.ElementalShaman{
-		Options: &proto.ElementalShaman_Options{
-			Shield: proto.ShamanShield_LightningShield,
-		},
+		Options: &proto.ElementalShaman_Options{},
 	},
 }
 
@@ -189,7 +187,7 @@ var Phase3Consumes = core.ConsumesCombo{
 		DefaultPotion:  proto.Potions_GreaterManaPotion,
 		FirePowerBuff:  proto.FirePowerBuff_ElixirOfGreaterFirepower,
 		Food:           proto.Food_FoodNightfinSoup,
-		MainHandImbue:  proto.WeaponImbue_LesserWizardOil,
+		MainHandImbue:  proto.WeaponImbue_FlametongueWeapon,
 		OffHandImbue:   proto.WeaponImbue_LesserWizardOil,
 		SpellPowerBuff: proto.SpellPowerBuff_ArcaneElixir,
 		StrengthBuff:   proto.StrengthBuff_ElixirOfGiants,

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -345,42 +345,42 @@ dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
   dps: 53.91819
-  tps: 182.25551
+  tps: 185.3134
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
   dps: 53.91819
-  tps: 52.81841
+  tps: 52.9713
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 55.8802
-  tps: 52.22945
+  tps: 52.30595
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 33.00976
-  tps: 136.86824
+  dps: 32.37912
+  tps: 136.42412
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 33.00976
-  tps: 32.80049
+  dps: 32.37912
+  tps: 32.16637
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 39.53089
-  tps: 37.39862
+  tps: 37.44862
  }
 }
 dps_results: {
@@ -429,42 +429,42 @@ dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
   dps: 53.59064
-  tps: 182.28518
+  tps: 183.86613
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
   dps: 53.59064
-  tps: 52.5103
+  tps: 52.58935
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 55.36807
-  tps: 51.71732
+  tps: 51.79382
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 32.49606
-  tps: 134.67889
+  dps: 32.29672
+  tps: 134.56212
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 32.49606
-  tps: 32.14539
+  dps: 32.29672
+  tps: 31.80062
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 39.13784
-  tps: 36.99557
+  tps: 37.05557
  }
 }
 dps_results: {
@@ -527,42 +527,42 @@ dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 404.23361
-  tps: 456.42873
+  tps: 456.92492
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 322.33632
-  tps: 370.36065
+  tps: 370.81406
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 398.73485
-  tps: 450.46948
+  tps: 451.75447
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 242.76783
-  tps: 284.06665
+  tps: 284.0768
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 197.09572
-  tps: 235.58782
+  tps: 235.59797
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 237.28202
-  tps: 278.19039
+  tps: 278.20447
  }
 }
 dps_results: {
@@ -611,42 +611,42 @@ dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 412.77284
-  tps: 465.70293
+  tps: 465.94521
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 332.48356
-  tps: 381.40929
+  tps: 381.53332
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 410.98659
-  tps: 464.37346
+  tps: 464.8163
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 246.98561
-  tps: 288.16447
+  tps: 288.37979
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 202.41132
-  tps: 240.93308
+  tps: 241.1484
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 243.11785
-  tps: 284.06041
+  tps: 284.1458
  }
 }
 dps_results: {
@@ -709,42 +709,42 @@ dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 900.07361
-  tps: 681.29564
+  tps: 681.67542
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 733.58814
-  tps: 563.64253
+  tps: 563.94509
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 903.19726
-  tps: 684.93543
+  tps: 685.05297
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 461.81887
-  tps: 366.89275
+  tps: 367.54113
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 391.23584
-  tps: 316.80941
+  tps: 317.45778
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 469.83181
-  tps: 372.60728
+  tps: 373.25728
  }
 }
 dps_results: {
@@ -793,42 +793,42 @@ dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 912.35853
-  tps: 689.99722
+  tps: 690.28556
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 748.68357
-  tps: 572.73294
+  tps: 573.11
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 920.72684
-  tps: 696.28831
+  tps: 696.6889
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
   dps: 467.76505
-  tps: 371.24017
+  tps: 370.61517
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
   dps: 395.9523
-  tps: 318.30932
+  tps: 317.68632
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 474.66197
-  tps: 374.21508
+  tps: 373.76101
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/enhancement.go
+++ b/sim/shaman/enhancement/enhancement.go
@@ -28,12 +28,8 @@ func RegisterEnhancementShaman() {
 func NewEnhancementShaman(character *core.Character, options *proto.Player) *EnhancementShaman {
 	enhOptions := options.GetEnhancementShaman()
 
-	selfBuffs := shaman.SelfBuffs{
-		Shield: enhOptions.Options.Shield,
-	}
-
 	enh := &EnhancementShaman{
-		Shaman: shaman.NewShaman(character, options.TalentsString, selfBuffs),
+		Shaman: shaman.NewShaman(character, options.TalentsString),
 	}
 
 	// Enable Auto Attacks for this spec

--- a/sim/shaman/enhancement/enhancement_test.go
+++ b/sim/shaman/enhancement/enhancement_test.go
@@ -182,12 +182,10 @@ var PlayerOptionsSyncAuto = &proto.Player_EnhancementShaman{
 }
 
 var optionsSyncDelayOffhand = &proto.EnhancementShaman_Options{
-	Shield:   proto.ShamanShield_WaterShield,
 	SyncType: proto.ShamanSyncType_DelayOffhandSwings,
 }
 
 var optionsSyncAuto = &proto.EnhancementShaman_Options{
-	Shield:   proto.ShamanShield_LightningShield,
 	SyncType: proto.ShamanSyncType_Auto,
 }
 

--- a/sim/shaman/flame_shock.go
+++ b/sim/shaman/flame_shock.go
@@ -56,8 +56,8 @@ func (shaman *Shaman) newFlameShockSpellConfig(rank int, shockTimer *core.Timer)
 	)
 
 	if hasBurnRune {
-		spell.DamageMultiplier += 1
-		numTicks += 2
+		spell.DamageMultiplier += BurnFlameShockDamageBonus
+		numTicks += BurnFlameShockBonusTicks
 	}
 
 	spell.SpellCode = SpellCode_ShamanFlameShock
@@ -110,7 +110,7 @@ func (shaman *Shaman) newFlameShockSpellConfig(rank int, shockTimer *core.Timer)
 
 	spell.BonusCoefficient = baseSpellCoeff
 
-	results := make([]*core.SpellResult, min(core.TernaryInt32(hasBurnRune, 5, 1), shaman.Env.GetNumTargets()))
+	results := make([]*core.SpellResult, min(core.TernaryInt32(hasBurnRune, BurnFlameShockTargetCount, 1), shaman.Env.GetNumTargets()))
 
 	spell.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 		for idx := range results {

--- a/sim/shaman/lava_burst.go
+++ b/sim/shaman/lava_burst.go
@@ -7,7 +7,7 @@ import (
 	"github.com/wowsims/sod/sim/core/proto"
 )
 
-func (shaman *Shaman) applyLavaBurst() {
+func (shaman *Shaman) registerLavaBurstSpell() {
 	if !shaman.HasRune(proto.ShamanRune_RuneHandsLavaBurst) {
 		return
 	}

--- a/sim/shaman/lightning_bolt.go
+++ b/sim/shaman/lightning_bolt.go
@@ -72,14 +72,14 @@ func (shaman *Shaman) newLightningBoltSpellConfig(rank int, isOverload bool) cor
 		baseDamage := sim.Roll(baseDamageLow, baseDamageHigh)
 		result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 
-		if hasRollingThunderRune && !isOverload {
+		if hasRollingThunderRune {
 			shaman.rollRollingThunderCharge(sim)
 		}
 
 		spell.WaitTravelTime(sim, func(sim *core.Simulation) {
 			spell.DealDamage(sim, result)
 
-			if canOverload && result.Landed() && sim.RandomFloat("LB Overload") < ShamanOverloadChance {
+			if canOverload && result.Landed() && sim.Proc(ShamanOverloadChance, "LB Overload") {
 				shaman.LightningBoltOverload[rank].Cast(sim, target)
 			}
 		})

--- a/sim/shaman/lightning_shield.go
+++ b/sim/shaman/lightning_shield.go
@@ -20,17 +20,18 @@ var LightningShieldLevel = [LightningShieldRanks + 1]int{0, 8, 16, 24, 32, 40, 4
 
 func (shaman *Shaman) registerLightningShieldSpell() {
 	shaman.LightningShield = make([]*core.Spell, LightningShieldRanks+1)
+	shaman.LightningShieldProcs = make([]*core.Spell, LightningShieldRanks+1)
 
 	for rank := 1; rank <= LightningShieldRanks; rank++ {
-		config := shaman.newLightningShieldSpellConfig(rank)
+		level := LightningShieldLevel[rank]
 
-		if config.RequiredLevel <= int(shaman.Level) {
-			shaman.LightningShield[rank] = shaman.RegisterSpell(config)
+		if level <= int(shaman.Level) {
+			shaman.registerNewLightningShieldSpell(rank)
 		}
 	}
 }
 
-func (shaman *Shaman) newLightningShieldSpellConfig(rank int) core.SpellConfig {
+func (shaman *Shaman) registerNewLightningShieldSpell(rank int) {
 	hasOverchargedRune := shaman.HasRune(proto.ShamanRune_RuneBracersOvercharged)
 	hasRollingThunderRune := shaman.HasRune(proto.ShamanRune_RuneBracersRollingThunder)
 	hasStaticShockRune := shaman.HasRune(proto.ShamanRune_RuneBracersStaticShock)
@@ -44,10 +45,6 @@ func (shaman *Shaman) newLightningShieldSpellConfig(rank int) core.SpellConfig {
 	manaCost := LightningShieldManaCost[rank]
 	level := LightningShieldLevel[rank]
 
-	if level > int(shaman.Level) {
-		return core.SpellConfig{RequiredLevel: level}
-	}
-
 	staticShockProcChance := .06
 
 	baseCharges := int32(3)
@@ -59,7 +56,7 @@ func (shaman *Shaman) newLightningShieldSpellConfig(rank int) core.SpellConfig {
 		maxCharges = 9
 	}
 
-	procSpell := shaman.RegisterSpell(core.SpellConfig{
+	shaman.LightningShieldProcs[rank] = shaman.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: procSpellId},
 		SpellSchool: core.SpellSchoolNature,
 		ProcMask:    core.ProcMaskEmpty,
@@ -70,21 +67,6 @@ func (shaman *Shaman) newLightningShieldSpellConfig(rank int) core.SpellConfig {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeAlwaysHit)
-		},
-	})
-
-	rollingThunder := shaman.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 432129},
-		SpellSchool: core.SpellSchoolNature,
-		DefenseType: core.DefenseTypeMagic,
-		ProcMask:    core.ProcMaskEmpty,
-
-		DamageMultiplier: 1,
-		ThreatMultiplier: 1,
-
-		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			chargeDamage := baseDamage + spellCoeff*procSpell.BonusDamage()
-			spell.CalcAndDealDamage(sim, target, chargeDamage, spell.OutcomeMagicCrit)
 		},
 	})
 
@@ -111,13 +93,13 @@ func (shaman *Shaman) newLightningShieldSpellConfig(rank int) core.SpellConfig {
 
 			if hasStaticShockRune && spell.ProcMask.Matches(core.ProcMaskMelee) && sim.RandomFloat("Static Shock") < staticShockProcChance {
 				aura.RemoveStack(sim)
-				procSpell.Cast(sim, result.Target)
+				shaman.LightningShieldProcs[rank].Cast(sim, result.Target)
 			}
 
 			if hasRollingThunderRune && spell.SpellCode == SpellCode_ShamanEarthShock && aura.GetStacks() > 3 {
 				multiplier := float64(aura.GetStacks() - baseCharges)
-				rollingThunder.DamageMultiplier = multiplier
-				rollingThunder.Cast(sim, result.Target)
+				shaman.RollingThunder.DamageMultiplier = multiplier
+				shaman.RollingThunder.Cast(sim, result.Target)
 				shaman.AddMana(sim, .02*multiplier*shaman.MaxMana(), manaMetrics)
 				aura.SetStacks(sim, baseCharges)
 			}
@@ -135,19 +117,21 @@ func (shaman *Shaman) newLightningShieldSpellConfig(rank int) core.SpellConfig {
 				// Deals damage to all targets within 8 yards and does not lose stacks
 				for _, aoeTarget := range sim.Encounter.TargetUnits {
 					if aoeTarget.DistanceFromTarget <= 8 {
-						procSpell.Cast(sim, aoeTarget)
+						shaman.LightningShieldProcs[rank].Cast(sim, aoeTarget)
 					}
 				}
 			} else {
 				aura.RemoveStack(sim)
-				procSpell.Cast(sim, spell.Unit)
+				shaman.LightningShieldProcs[rank].Cast(sim, spell.Unit)
 			}
 		},
 	})
 
-	return core.SpellConfig{
-		ActionID: core.ActionID{SpellID: spellId},
-		Flags:    core.SpellFlagAPL,
+	shaman.LightningShield[rank] = shaman.RegisterSpell(core.SpellConfig{
+		ActionID:  core.ActionID{SpellID: spellId},
+		SpellCode: SpellCode_LightningShield,
+		ProcMask:  core.ProcMaskEmpty,
+		Flags:     core.SpellFlagAPL,
 
 		RequiredLevel: level,
 		Rank:          rank,
@@ -160,18 +144,13 @@ func (shaman *Shaman) newLightningShieldSpellConfig(rank int) core.SpellConfig {
 				GCD: core.GCDDefault,
 			},
 		},
-		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
-			if shaman.LightningShieldAura != nil {
-				shaman.LightningShieldAura.Deactivate(sim)
+		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+			if shaman.ActiveShieldAura != nil {
+				shaman.ActiveShieldAura.Deactivate(sim)
 			}
-			shaman.LightningShieldAura = aura
-			shaman.LightningShieldAura.Activate(sim)
+			shaman.ActiveShield = spell
+			shaman.ActiveShieldAura = aura
+			shaman.ActiveShieldAura.Activate(sim)
 		},
-	}
-}
-
-func (shaman *Shaman) rollRollingThunderCharge(sim *core.Simulation) {
-	if shaman.LightningShieldAura.IsActive() && sim.RandomFloat("Rolling Thunder") < .30 {
-		shaman.LightningShieldAura.AddStack(sim)
-	}
+	})
 }

--- a/sim/shaman/water_shield.go
+++ b/sim/shaman/water_shield.go
@@ -1,0 +1,51 @@
+package shaman
+
+import (
+	"time"
+
+	"github.com/wowsims/sod/sim/core"
+	"github.com/wowsims/sod/sim/core/proto"
+	"github.com/wowsims/sod/sim/core/stats"
+)
+
+func (shaman *Shaman) registerWaterShieldSpell() {
+	if !shaman.HasRune(proto.ShamanRune_RuneHandsWaterShield) {
+		return
+	}
+
+	passiveMP5Pct := .01
+	onHitManaGainedPct := .04
+
+	manaMetrics := shaman.NewManaMetrics(core.ActionID{SpellID: int32(proto.ShamanRune_RuneHandsWaterShield)})
+	mp5StatDep := shaman.NewDynamicStatDependency(stats.Mana, stats.MP5, passiveMP5Pct)
+
+	aura := shaman.RegisterAura(core.Aura{
+		Label:    "Water Shield",
+		Duration: time.Minute * 10,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			aura.Unit.EnableDynamicStatDep(sim, mp5StatDep)
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			aura.Unit.DisableDynamicStatDep(sim, mp5StatDep)
+		},
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if result.Landed() && spell.ProcMask.Matches(core.ProcMaskDirect) {
+				shaman.AddMana(sim, shaman.MaxMana()*onHitManaGainedPct, manaMetrics)
+			}
+		},
+	})
+
+	shaman.WaterShield = shaman.RegisterSpell(core.SpellConfig{
+		ActionID: core.ActionID{SpellID: int32(proto.ShamanRune_RuneHandsWaterShield)},
+		ProcMask: core.ProcMaskEmpty,
+		Flags:    core.SpellFlagAPL,
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			if shaman.ActiveShieldAura != nil {
+				shaman.ActiveShieldAura.Deactivate(sim)
+			}
+			shaman.ActiveShield = spell
+			shaman.ActiveShieldAura = aura
+			shaman.ActiveShieldAura.Activate(sim)
+		},
+	})
+}

--- a/sim/shaman/water_shield.go
+++ b/sim/shaman/water_shield.go
@@ -13,14 +13,17 @@ func (shaman *Shaman) registerWaterShieldSpell() {
 		return
 	}
 
+	actionID := core.ActionID{SpellID: int32(proto.ShamanRune_RuneHandsWaterShield)}
+
 	passiveMP5Pct := .01
 	onHitManaGainedPct := .04
 
-	manaMetrics := shaman.NewManaMetrics(core.ActionID{SpellID: int32(proto.ShamanRune_RuneHandsWaterShield)})
+	manaMetrics := shaman.NewManaMetrics(actionID)
 	mp5StatDep := shaman.NewDynamicStatDependency(stats.Mana, stats.MP5, passiveMP5Pct)
 
 	aura := shaman.RegisterAura(core.Aura{
 		Label:    "Water Shield",
+		ActionID: actionID,
 		Duration: time.Minute * 10,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			aura.Unit.EnableDynamicStatDep(sim, mp5StatDep)
@@ -36,9 +39,16 @@ func (shaman *Shaman) registerWaterShieldSpell() {
 	})
 
 	shaman.WaterShield = shaman.RegisterSpell(core.SpellConfig{
-		ActionID: core.ActionID{SpellID: int32(proto.ShamanRune_RuneHandsWaterShield)},
+		ActionID: actionID,
 		ProcMask: core.ProcMaskEmpty,
 		Flags:    core.SpellFlagAPL,
+
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: core.GCDDefault,
+			},
+		},
+
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			if shaman.ActiveShieldAura != nil {
 				shaman.ActiveShieldAura.Deactivate(sim)

--- a/sim/web/main_test.go
+++ b/sim/web/main_test.go
@@ -18,9 +18,7 @@ import (
 
 var basicSpec = &proto.Player_ElementalShaman{
 	ElementalShaman: &proto.ElementalShaman{
-		Options: &proto.ElementalShaman_Options{
-			Shield: proto.ShamanShield_WaterShield,
-		},
+		Options: &proto.ElementalShaman_Options{},
 	},
 }
 

--- a/ui/core/components/inputs/totem_inputs.ts
+++ b/ui/core/components/inputs/totem_inputs.ts
@@ -1,158 +1,38 @@
-import { IconEnumPicker } from '../icon_enum_picker.js';
-import { IndividualSimUI } from '../../individual_sim_ui.js';
 import { Player } from '../../player.js';
 import { Spec } from '../../proto/common.js';
-import {
-	AirTotem,
-	EarthTotem,
-	FireTotem,
-	WaterTotem,
-	ShamanTotems,
-} from '../../proto/shaman.js';
-import { ShamanSpecs } from '../../proto_utils/utils.js';
-import { EventID, TypedEvent } from '../../typed_event.js';
-
-import { ContentBlock } from '../content_block.js';
-import { Input } from '../input.js';
-
-export function TotemsSection(parentElem: HTMLElement, simUI: IndividualSimUI<ShamanSpecs>): ContentBlock {
-	let contentBlock = new ContentBlock(parentElem, 'totems-settings', {
-		header: { title: 'Totems' }
-	});
-
-	let totemDropdownGroup = Input.newGroupContainer();
-	totemDropdownGroup.classList.add('totem-dropdowns-container', 'icon-group');
-
-	contentBlock.bodyElement.appendChild(totemDropdownGroup);
-
-	new IconEnumPicker(totemDropdownGroup, simUI.player, {
-		extraCssClasses: [
-			'earth-totem-picker',
-		],
-		numColumns: 1,
-		values: [
-			{ color: '#ffdfba', value: EarthTotem.NoEarthTotem },
-			StrengthOfEarthTotem,
-			StoneskinTotem,
-			TremorTotem,
-		],
-		equals: (a: EarthTotem, b: EarthTotem) => a == b,
-		zeroValue: EarthTotem.NoEarthTotem,
-		changedEvent: (player: Player<ShamanSpecs>) => TypedEvent.onAny([player.specOptionsChangeEmitter, player.levelChangeEmitter]),
-		getValue: (player: Player<ShamanSpecs>) => player.getSpecOptions().totems?.earth || EarthTotem.NoEarthTotem,
-		setValue: (eventID: EventID, player: Player<ShamanSpecs>, newValue: number) => {
-			const newOptions = player.getSpecOptions();
-			if (!newOptions.totems)
-				newOptions.totems = ShamanTotems.create();
-			newOptions.totems!.earth = newValue;
-			player.setSpecOptions(eventID, newOptions);
-		},
-	});
-
-	new IconEnumPicker(totemDropdownGroup, simUI.player, {
-		extraCssClasses: [
-			'fire-totem-picker',
-		],
-		numColumns: 1,
-		values: [
-			{ color: '#ffb3ba', value: FireTotem.NoFireTotem },
-			SearingTotem,
-			FireNovaTotem,
-			MagmaTotem,
-		],
-		equals: (a: FireTotem, b: FireTotem) => a == b,
-		zeroValue: FireTotem.NoFireTotem,
-		changedEvent: (player: Player<ShamanSpecs>) => TypedEvent.onAny([player.specOptionsChangeEmitter, player.levelChangeEmitter]),
-		getValue: (player: Player<ShamanSpecs>) => player.getSpecOptions().totems?.fire || FireTotem.NoFireTotem,
-		setValue: (eventID: EventID, player: Player<ShamanSpecs>, newValue: number) => {
-			const newOptions = player.getSpecOptions();
-			if (!newOptions.totems)
-				newOptions.totems = ShamanTotems.create();
-			newOptions.totems!.fire = newValue;
-			player.setSpecOptions(eventID, newOptions);
-		},
-	});
-
-	new IconEnumPicker(totemDropdownGroup, simUI.player, {
-		extraCssClasses: [
-			'water-totem-picker',
-		],
-		numColumns: 1,
-		values: [
-			{ color: '#bae1ff', value: WaterTotem.NoWaterTotem },
-			HealingStreamTotem,
-			ManaSpringTotem,
-		],
-		equals: (a: WaterTotem, b: WaterTotem) => a == b,
-		zeroValue: WaterTotem.NoWaterTotem,
-		changedEvent: (player: Player<ShamanSpecs>) => TypedEvent.onAny([player.specOptionsChangeEmitter, player.levelChangeEmitter]),
-		getValue: (player: Player<ShamanSpecs>) => player.getSpecOptions().totems?.water || WaterTotem.NoWaterTotem,
-		setValue: (eventID: EventID, player: Player<ShamanSpecs>, newValue: number) => {
-			const newOptions = player.getSpecOptions();
-			if (!newOptions.totems)
-				newOptions.totems = ShamanTotems.create();
-			newOptions.totems!.water = newValue;
-			player.setSpecOptions(eventID, newOptions);
-		},
-	});
-
-	new IconEnumPicker(totemDropdownGroup, simUI.player, {
-		extraCssClasses: [
-			'air-totem-picker',
-		],
-		numColumns: 1,
-		values: [
-			{ color: '#baffc9', value: AirTotem.NoAirTotem },
-			WindfuryTotem,
-			GraceOfAirTotem,
-		],
-		equals: (a: AirTotem, b: AirTotem) => a == b,
-		zeroValue: AirTotem.NoAirTotem,
-		changedEvent: (player: Player<ShamanSpecs>) => TypedEvent.onAny([player.specOptionsChangeEmitter, player.levelChangeEmitter]),
-		getValue: (player: Player<ShamanSpecs>) => player.getSpecOptions().totems?.air || AirTotem.NoAirTotem,
-		setValue: (eventID: EventID, player: Player<ShamanSpecs>, newValue: number) => {
-			const newOptions = player.getSpecOptions();
-			if (!newOptions.totems)
-				newOptions.totems = ShamanTotems.create();
-			newOptions.totems!.air = newValue;
-			player.setSpecOptions(eventID, newOptions);
-		},
-	});
-
-	return contentBlock;
-}
+import { AirTotem, EarthTotem, FireTotem, WaterTotem } from '../../proto/shaman.js';
 
 ///////////////////////////////////////////////////////////////////////////
 //                                 Earth Totems
 ///////////////////////////////////////////////////////////////////////////
 
 export const StoneskinTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 8071, 	minLevel: 4, 	maxLevel: 13 	},
-		{ id: 8154, 	minLevel: 14, maxLevel: 23 	},
-		{ id: 8155, 	minLevel: 24, maxLevel: 33 	},
-		{ id: 10406, 	minLevel: 34, maxLevel: 43 	},
-		{ id: 10407, 	minLevel: 44, maxLevel: 53 	},
-		{ id: 10408, 	minLevel: 54 								},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 8071, minLevel: 4, maxLevel: 13 },
+			{ id: 8154, minLevel: 14, maxLevel: 23 },
+			{ id: 8155, minLevel: 24, maxLevel: 33 },
+			{ id: 10406, minLevel: 34, maxLevel: 43 },
+			{ id: 10407, minLevel: 44, maxLevel: 53 },
+			{ id: 10408, minLevel: 54 },
+		]),
 	value: EarthTotem.StoneskinTotem,
 };
 
 export const StrengthOfEarthTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 8075, 	minLevel: 10, maxLevel: 23 	},
-		{ id: 8160, 	minLevel: 24, maxLevel: 37 	},
-		{ id: 8161, 	minLevel: 38, maxLevel: 51 	},
-		{ id: 10442, 	minLevel: 52, maxLevel: 59 	},
-		{ id: 25361, 	minLevel: 60 								},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 8075, minLevel: 10, maxLevel: 23 },
+			{ id: 8160, minLevel: 24, maxLevel: 37 },
+			{ id: 8161, minLevel: 38, maxLevel: 51 },
+			{ id: 10442, minLevel: 52, maxLevel: 59 },
+			{ id: 25361, minLevel: 60 },
+		]),
 	value: EarthTotem.StrengthOfEarthTotem,
 };
 
 export const TremorTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 8143, minLevel: 18 },
-	]),
+	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([{ id: 8143, minLevel: 18 }]),
 	value: EarthTotem.TremorTotem,
 };
 
@@ -161,35 +41,38 @@ export const TremorTotem = {
 ///////////////////////////////////////////////////////////////////////////
 
 export const SearingTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 3599, minLevel: 10, maxLevel: 19 },
-		{ id: 6363, minLevel: 20, maxLevel: 29 },
-		{ id: 6364, minLevel: 30, maxLevel: 39 },
-		{ id: 6365, minLevel: 40, maxLevel: 49 },
-		{ id: 10437, minLevel: 50, maxLevel: 59 },
-		{ id: 10438, minLevel: 60 },
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 3599, minLevel: 10, maxLevel: 19 },
+			{ id: 6363, minLevel: 20, maxLevel: 29 },
+			{ id: 6364, minLevel: 30, maxLevel: 39 },
+			{ id: 6365, minLevel: 40, maxLevel: 49 },
+			{ id: 10437, minLevel: 50, maxLevel: 59 },
+			{ id: 10438, minLevel: 60 },
+		]),
 	value: FireTotem.SearingTotem,
 };
 
 export const FireNovaTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 1535, 	minLevel: 12, maxLevel: 21 	},
-		{ id: 8498, 	minLevel: 22, maxLevel: 31 	},
-		{ id: 8499, 	minLevel: 32, maxLevel: 41 	},
-		{ id: 11314, 	minLevel: 42, maxLevel: 51 	},
-		{ id: 11315, 	minLevel: 52 								},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 1535, minLevel: 12, maxLevel: 21 },
+			{ id: 8498, minLevel: 22, maxLevel: 31 },
+			{ id: 8499, minLevel: 32, maxLevel: 41 },
+			{ id: 11314, minLevel: 42, maxLevel: 51 },
+			{ id: 11315, minLevel: 52 },
+		]),
 	value: FireTotem.FireNovaTotem,
 };
 
 export const MagmaTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 8190, 	minLevel: 26, maxLevel: 35 	},
-		{ id: 10585, 	minLevel: 36, maxLevel: 45 	},
-		{ id: 10586, 	minLevel: 46, maxLevel: 55 	},
-		{ id: 10587, 	minLevel: 56 								},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 8190, minLevel: 26, maxLevel: 35 },
+			{ id: 10585, minLevel: 36, maxLevel: 45 },
+			{ id: 10586, minLevel: 46, maxLevel: 55 },
+			{ id: 10587, minLevel: 56 },
+		]),
 	value: FireTotem.FireNovaTotem,
 };
 
@@ -198,23 +81,25 @@ export const MagmaTotem = {
 ///////////////////////////////////////////////////////////////////////////
 
 export const HealingStreamTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 5394, 	minLevel: 20, maxLevel: 29 	},
-		{ id: 6375, 	minLevel: 30, maxLevel: 39 	},
-		{ id: 6377, 	minLevel: 40, maxLevel: 49 	},
-		{ id: 10462, 	minLevel: 50, maxLevel: 59 	},
-		{ id: 10463, 	minLevel: 60 								},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 5394, minLevel: 20, maxLevel: 29 },
+			{ id: 6375, minLevel: 30, maxLevel: 39 },
+			{ id: 6377, minLevel: 40, maxLevel: 49 },
+			{ id: 10462, minLevel: 50, maxLevel: 59 },
+			{ id: 10463, minLevel: 60 },
+		]),
 	value: WaterTotem.HealingStreamTotem,
 };
 
 export const ManaSpringTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 5675, 	minLevel: 26, maxLevel: 35 	},
-		{ id: 10495, 	minLevel: 36, maxLevel: 45 	},
-		{ id: 10496, 	minLevel: 46, maxLevel: 55 	},
-		{ id: 10497, 	minLevel: 56 								},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 5675, minLevel: 26, maxLevel: 35 },
+			{ id: 10495, minLevel: 36, maxLevel: 45 },
+			{ id: 10496, minLevel: 46, maxLevel: 55 },
+			{ id: 10497, minLevel: 56 },
+		]),
 	value: WaterTotem.ManaSpringTotem,
 };
 
@@ -223,19 +108,21 @@ export const ManaSpringTotem = {
 ///////////////////////////////////////////////////////////////////////////
 
 export const WindfuryTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 8512, 	minLevel: 32, maxLevel: 41 	},
-		{ id: 10613, 	minLevel: 42, maxLevel: 51 	},
-		{ id: 25359, 	minLevel: 52 								},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 8512, minLevel: 32, maxLevel: 41 },
+			{ id: 10613, minLevel: 42, maxLevel: 51 },
+			{ id: 25359, minLevel: 52 },
+		]),
 	value: AirTotem.WindfuryTotem,
 };
 
 export const GraceOfAirTotem = {
-	actionId: (player: Player<Spec>) => player.getMatchingSpellActionId([
-		{ id: 10627, minLevel: 42, maxLevel: 55 },
-		{ id: 10627, minLevel: 56, maxLevel: 59 },
-		{ id: 25359, minLevel: 60 							},
-	]),
+	actionId: (player: Player<Spec>) =>
+		player.getMatchingSpellActionId([
+			{ id: 10627, minLevel: 42, maxLevel: 55 },
+			{ id: 10627, minLevel: 56, maxLevel: 59 },
+			{ id: 25359, minLevel: 60 },
+		]),
 	value: AirTotem.GraceOfAirTotem,
 };

--- a/ui/elemental_shaman/presets.ts
+++ b/ui/elemental_shaman/presets.ts
@@ -120,7 +120,7 @@ export const DefaultConsumes = Consumes.create({
 	enchantedSigil: EnchantedSigil.LivingDreamsSigil,
 	firePowerBuff: FirePowerBuff.ElixirOfFirepower,
 	food: Food.FoodNightfinSoup,
-	mainHandImbue: WeaponImbue.LesserWizardOil,
+	mainHandImbue: WeaponImbue.FlametongueWeapon,
 	offHandImbue: WeaponImbue.LesserWizardOil,
 	spellPowerBuff: SpellPowerBuff.ArcaneElixir,
 	strengthBuff: StrengthBuff.ElixirOfGiants,

--- a/ui/elemental_shaman/sim.ts
+++ b/ui/elemental_shaman/sim.ts
@@ -27,8 +27,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecElementalShaman, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
-		Stat.StatAttackPower,
-		Stat.StatStrength,
 	],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
@@ -45,8 +43,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecElementalShaman, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
-		Stat.StatAttackPower,
-		Stat.StatStrength,
 	],
 	modifyDisplayStats: (player: Player<Spec.SpecElementalShaman>) => {
 		let stats = new Stats();
@@ -71,8 +67,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecElementalShaman, {
 			[Stat.StatSpellCrit]: 7.91,
 			[Stat.StatSpellHaste]: 7.28,
 			[Stat.StatMP5]: 0.02,
-			[Stat.StatAttackPower]: 0.31,
-			[Stat.StatStrength]: 0.68,
 		}),
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,

--- a/ui/enhancement_shaman/sim.ts
+++ b/ui/enhancement_shaman/sim.ts
@@ -117,9 +117,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 		itemSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand],
 		note: 'Swap items are given the highest available rank of Rockbiter Weapon',
 	},
-	customSections: [
-		// TotemsSection,
-	],
+	customSections: [],
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.
 		showExecuteProportion: false,

--- a/ui/restoration_shaman/presets.ts
+++ b/ui/restoration_shaman/presets.ts
@@ -1,18 +1,7 @@
-import {
-	Consumes,
-	Flask,
-	Food,
-	WeaponImbue,
-} from '../core/proto/common.js';
-import { SavedTalents } from '../core/proto/ui.js';
-
-import {
-	RestorationShaman_Options as RestorationShamanOptions,
-	ShamanShield,
-} from '../core/proto/shaman.js';
-
 import * as PresetUtils from '../core/preset_utils.js';
-
+import { Consumes, Flask, Food, WeaponImbue } from '../core/proto/common.js';
+import { RestorationShaman_Options as RestorationShamanOptions } from '../core/proto/shaman.js';
+import { SavedTalents } from '../core/proto/ui.js';
 import BlankGear from './gear_sets/blank.gear.json';
 
 // Preset options for this spec.
@@ -37,7 +26,6 @@ export const RaidHealingTalents = {
 };
 
 export const DefaultOptions = RestorationShamanOptions.create({
-	shield: ShamanShield.WaterShield,
 	earthShieldPPM: 0,
 });
 

--- a/ui/restoration_shaman/sim.ts
+++ b/ui/restoration_shaman/sim.ts
@@ -1,4 +1,3 @@
-import { TotemsSection } from '../core/components/inputs/totem_inputs.js';
 import * as OtherInputs from '../core/components/other_inputs.js';
 import * as Mechanics from '../core/constants/mechanics.js';
 import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.js';
@@ -86,7 +85,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationShaman, {
 	otherInputs: {
 		inputs: [OtherInputs.TankAssignment],
 	},
-	customSections: [TotemsSection],
+	customSections: [],
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.
 		showExecuteProportion: false,


### PR DESCRIPTION
- General Changes
  - Removed shield and totem protos in favor of rotational usage
  - Created generic `ActiveShield` and `ActiveShieldAura` fields to track shields
- Rolling Thunder rune changes:
  - Can now proc charges from LB and CL overloads
  - Proc chance increased to 50%
  - Separated out the rolling thunder spell from the lightning shield code and it's now its own spell that deals damage by grabbing the corresponding damage information for the active lightning shield aura
- Burn rune changes:
  - Having flametongue weapon active on either weapon now increases spell damage by 4 * player level
- Water Shield rune changes:
  - Now a proper spell and aura