### PR TITLE
Buffs and consums rework

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -308,6 +308,9 @@ enum Potions {
 	GreaterManaPotion = 3;
 	SuperiorManaPotion = 4;
 	MajorManaPotion = 5;
+	RagePotion = 6;
+	GreatRagePotion = 7;
+	MightyRagePotion = 8;
 }
 
 enum Conjured {

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -510,7 +510,7 @@ enum SaygesFortune {
 }
 
 // Buffs that affect the entire raid.
-// NextIndex: 38
+// NextIndex: 40
 message RaidBuffs {
 	// +Stats
 	TristateEffect gift_of_the_wild = 1;
@@ -548,6 +548,7 @@ message RaidBuffs {
 
 	// Resistances
 	bool shadow_protection = 16;
+	bool shadow_resistance_aura = 39;
 	bool nature_resistance_totem = 17;
 	bool aspect_of_the_wild = 18;
 	bool frost_resistance_aura = 19;
@@ -575,6 +576,7 @@ message RaidBuffs {
 	int32 demonic_pact = 32;
 	bool horn_of_lordaeron = 33;
 	bool aspect_of_the_lion = 34;
+	bool commanding_shout = 38;
 }
 
 // Buffs that affect a single party.

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -656,7 +656,7 @@ message Consumes {
 	bool bogling_root = 19 [deprecated=true];
 }
 
-// NextIndex: 33
+// NextIndex: 35
 message Debuffs {
 	bool judgement_of_wisdom = 1;
 	bool judgement_of_light = 2;
@@ -695,6 +695,7 @@ message Debuffs {
 	TristateEffect demoralizing_shout = 15;
 
 	TristateEffect thunder_clap = 16;
+	bool waylay = 34;
 
 	bool insect_swarm = 17;
 	bool scorpid_sting = 18;

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -311,6 +311,8 @@ enum Potions {
 	RagePotion = 6;
 	GreatRagePotion = 7;
 	MightyRagePotion = 8;
+	LesserStoneshieldPotion = 9;
+	GreaterStoneshieldPotion = 10;
 }
 
 enum Conjured {

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -335,6 +335,15 @@ enum Flask {
 	FlaskOfEverlastingNightmares = 6;
 }
 
+enum Alcohol {
+	AlcoholUnknown = 0;
+	AlcoholRumseyRumBlackLabel = 1;
+	AlcoholGordokGreenGrog = 2;
+	AlcoholRumseyRumDark = 3;
+	AlcoholRumseyRumLight = 4;
+	AlcoholKreegsStoutBeatdown = 5;
+}
+
 enum AgilityElixir {
 	AgilityElixirUnknown = 0;
 	ElixirOfTheMongoose = 1;
@@ -342,6 +351,21 @@ enum AgilityElixir {
 	ElixirOfLesserAgility = 3;
 	ScrollOfAgility = 4;
 	ElixirOfAgility = 5;
+}
+
+enum ArmorElixir {
+	ArmorElixirUnknown = 0;
+	ElixirOfSuperiorDefense = 1;
+	ElixirOfGreaterDefense = 2;
+	ElixirOfDefense = 3;
+	ElixirOfMinorDefense = 4;
+	ScrollOfProtection = 5;
+}
+
+enum HealthElixir {
+	HealthElixirUnknown = 0;
+	ElixirOfFortitude = 1;
+	ElixirOfMinorFortitude = 2;
 }
 
 enum ManaRegenElixir {
@@ -592,7 +616,7 @@ message IndividualBuffs {
 	bool fervor_of_the_temple_explorer = 18;
 }
 
-// NextIndex: 28
+// NextIndex: 31
 message Consumes {
 	Flask flask = 1;
 	Food food = 2;
@@ -617,6 +641,9 @@ message Consumes {
 	bool dragon_breath_chili = 24;
 	MiscConsumes misc_consumes = 26;
 	ZanzaBuff zanza_buff = 27;
+	ArmorElixir armor_elixir = 28;
+	HealthElixir health_elixir = 29;
+	Alcohol alcohol = 30;
 
 	AtalaiMojo atalai_mojo = 25 [deprecated=true];
 	bool bogling_root = 19 [deprecated=true];

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -45,6 +45,7 @@ const (
 	ScrollOfSpirit
 	ScrollOfStrength
 	ScrollOfStamina
+	ScrollOfProtection
 )
 
 var LevelToBuffRank = map[BuffName]map[int32]int32{
@@ -443,6 +444,20 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 		},
 		60: stats.Stats{
 			stats.Strength: 17,
+		},
+	},
+	ScrollOfProtection: {
+		25: stats.Stats{
+			stats.BonusArmor: 120,
+		},
+		40: stats.Stats{
+			stats.BonusArmor: 180,
+		},
+		50: stats.Stats{
+			stats.BonusArmor: 240,
+		},
+		60: stats.Stats{
+			stats.BonusArmor: 240,
 		},
 	},
 }

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -670,12 +670,11 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 	}
 
 	// TODO: Classic
-	if individualBuffs.BlessingOfSanctuary {
-		character.PseudoStats.DamageTakenMultiplier *= 0.97
-		BlessingOfSanctuaryAura(character)
-	}
-
-	// TODO: Classic
+	/*	if individualBuffs.BlessingOfSanctuary {
+			character.PseudoStats.DamageTakenMultiplier *= 0.97
+			BlessingOfSanctuaryAura(character)
+		}
+	*/
 	if raidBuffs.DevotionAura != proto.TristateEffect_TristateEffectMissing {
 		updateStats := BuffSpellByLevel[DevotionAura][level]
 		if raidBuffs.DevotionAura == proto.TristateEffect_TristateEffectImproved {
@@ -741,6 +740,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 		character.AddStat(stats.MeleeCrit, 5*CritRatingPerCritChance)
 		// TODO: character.MultiplyStat(stats.RangedCrit, 1.05)
 		character.AddStat(stats.AttackPower, 140)
+		character.AddStat(stats.RangedAttackPower, 140)
 	}
 
 	if individualBuffs.SpiritOfZandalar {
@@ -771,6 +771,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 	// Dire Maul Buffs
 	if individualBuffs.FengusFerocity {
 		character.AddStat(stats.AttackPower, 200)
+		character.AddStat(stats.RangedAttackPower, 200)
 	}
 
 	if individualBuffs.MoldarsMoxie {
@@ -1010,6 +1011,8 @@ func ThornsAura(character *Character, points int32) *Aura {
 	}))
 }
 
+//TODO: Classic
+/*
 func BlessingOfSanctuaryAura(character *Character) {
 	if !character.HasManaBar() {
 		return
@@ -1031,7 +1034,7 @@ func BlessingOfSanctuaryAura(character *Character) {
 		},
 	})
 }
-
+*/
 // Used for approximating cooldowns applied by other players to you, such as
 // bloodlust, innervate, power infusion, etc. This is specifically for buffs
 // which can be consecutively applied multiple times to a single player.

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -463,7 +463,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 	if raidBuffs.GiftOfTheWild > 0 {
 		updateStats := BuffSpellByLevel[MarkOfTheWild][level]
 		if raidBuffs.GiftOfTheWild == proto.TristateEffect_TristateEffectImproved {
-			updateStats = updateStats.Multiply(1.35)
+			updateStats = updateStats.Multiply(1.35).Floor()
 		}
 		character.AddStats(updateStats)
 		bonusResist = updateStats[NatureResistanceTotem]
@@ -506,7 +506,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 	if raidBuffs.PowerWordFortitude > 0 {
 		updateStats := BuffSpellByLevel[PowerWordFortitude][level]
 		if raidBuffs.PowerWordFortitude == proto.TristateEffect_TristateEffectImproved {
-			updateStats = updateStats.Multiply(1.3)
+			updateStats = updateStats.Multiply(1.3).Floor()
 		}
 		character.AddStats(updateStats)
 	} else if raidBuffs.ScrollOfStamina {
@@ -516,7 +516,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 	if raidBuffs.BloodPact > 0 {
 		updateStats := BuffSpellByLevel[BloodPact][level]
 		if raidBuffs.BloodPact == proto.TristateEffect_TristateEffectImproved {
-			updateStats = updateStats.Multiply(1.3)
+			updateStats = updateStats.Multiply(1.3).Floor()
 		}
 		character.AddStats(updateStats)
 	}
@@ -1623,7 +1623,7 @@ func StrengthOfEarthTotemAura(unit *Unit, level int32, multiplier float64) *Aura
 		60: 25362,
 	}[level]
 	duration := time.Minute * 2
-	updateStats := BuffSpellByLevel[StrengthOfEarth][level].Multiply(multiplier)
+	updateStats := BuffSpellByLevel[StrengthOfEarth][level].Multiply(multiplier).Floor()
 
 	aura := unit.GetOrRegisterAura(Aura{
 		Label:      "Strength of Earth Totem",
@@ -1646,7 +1646,7 @@ func GraceOfAirTotemAura(unit *Unit, level int32, multiplier float64) *Aura {
 		60: 25359,
 	}[level]
 	duration := time.Minute * 2
-	updateStats := BuffSpellByLevel[GraceOfAir][level].Multiply(multiplier)
+	updateStats := BuffSpellByLevel[GraceOfAir][level].Multiply(multiplier).Floor()
 
 	aura := unit.GetOrRegisterAura(Aura{
 		Label:      "Grace of Air Totem",
@@ -1681,12 +1681,12 @@ func BattleShoutAura(unit *Unit, impBattleShout int32, boomingVoicePts int32) *A
 		BuildPhase: CharacterBuildPhaseBuffs,
 		OnGain: func(aura *Aura, sim *Simulation) {
 			aura.Unit.AddStatsDynamic(sim, stats.Stats{
-				stats.AttackPower: baseAP * (1 + 0.05*float64(impBattleShout)),
+				stats.AttackPower: math.Floor(baseAP * (1 + 0.05*float64(impBattleShout))),
 			})
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
 			aura.Unit.AddStatsDynamic(sim, stats.Stats{
-				stats.AttackPower: -1 * baseAP * (1 + 0.05*float64(impBattleShout)),
+				stats.AttackPower: -1 * math.Floor(baseAP*(1+0.05*float64(impBattleShout))),
 			})
 		},
 	})

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -107,13 +107,13 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 			stats.NatureResistance: 0,
 		},
 		40: stats.Stats{
-			stats.Stamina: 0,
+			stats.NatureResistance: 0,
 		},
 		50: stats.Stats{
-			stats.Stamina: 45,
+			stats.NatureResistance: 45,
 		},
 		60: stats.Stats{
-			stats.Stamina: 60,
+			stats.NatureResistance: 60,
 		},
 	},
 	// TODO: Class Melee specific AP?
@@ -190,30 +190,30 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 	},
 	FrostResistanceAura: {
 		25: stats.Stats{
-			stats.NatureResistance: 0,
+			stats.FrostResistance: 0,
 		},
 		40: stats.Stats{
-			stats.Stamina: 30,
+			stats.FrostResistance: 30,
 		},
 		50: stats.Stats{
-			stats.Stamina: 45,
+			stats.FrostResistance: 45,
 		},
 		60: stats.Stats{
-			stats.Stamina: 60,
+			stats.FrostResistance: 60,
 		},
 	},
 	FrostResistanceTotem: {
 		25: stats.Stats{
-			stats.NatureResistance: 30,
+			stats.FrostResistance: 30,
 		},
 		40: stats.Stats{
-			stats.Stamina: 45,
+			stats.FrostResistance: 45,
 		},
 		50: stats.Stats{
-			stats.Stamina: 60,
+			stats.FrostResistance: 45,
 		},
 		60: stats.Stats{
-			stats.Stamina: 60,
+			stats.FrostResistance: 60,
 		},
 	},
 	HornOfLordaeron: {
@@ -250,7 +250,7 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 	},
 	MarkOfTheWild: {
 		25: stats.Stats{
-			stats.Armor:            105,
+			stats.BonusArmor:       105,
 			stats.Stamina:          4,
 			stats.Agility:          4,
 			stats.Strength:         4,
@@ -263,7 +263,7 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 			stats.FrostResistance:  0,
 		},
 		40: stats.Stats{
-			stats.Armor:            195,
+			stats.BonusArmor:       195,
 			stats.Stamina:          8,
 			stats.Agility:          8,
 			stats.Strength:         8,
@@ -276,7 +276,7 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 			stats.FrostResistance:  10,
 		},
 		50: stats.Stats{
-			stats.Armor:            240,
+			stats.BonusArmor:       240,
 			stats.Stamina:          10,
 			stats.Agility:          10,
 			stats.Strength:         10,
@@ -289,7 +289,7 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 			stats.FrostResistance:  15,
 		},
 		60: stats.Stats{
-			stats.Armor:            285,
+			stats.BonusArmor:       285,
 			stats.Stamina:          12,
 			stats.Agility:          12,
 			stats.Strength:         12,
@@ -307,13 +307,13 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 			stats.NatureResistance: 0,
 		},
 		40: stats.Stats{
-			stats.Stamina: 30,
+			stats.NatureResistance: 30,
 		},
 		50: stats.Stats{
-			stats.Stamina: 45,
+			stats.NatureResistance: 45,
 		},
 		60: stats.Stats{
-			stats.Stamina: 60,
+			stats.NatureResistance: 60,
 		},
 	},
 	PowerWordFortitude: {
@@ -335,13 +335,13 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 			stats.ShadowResistance: 0,
 		},
 		40: stats.Stats{
-			stats.Stamina: 30,
+			stats.ShadowResistance: 30,
 		},
 		50: stats.Stats{
-			stats.Stamina: 45,
+			stats.ShadowResistance: 45,
 		},
 		60: stats.Stats{
-			stats.Stamina: 60,
+			stats.ShadowResistance: 60,
 		},
 	},
 	TrueshotAura: {
@@ -481,7 +481,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, partyBuffs *proto
 			updateStats = updateStats.Multiply(1.35).Floor()
 		}
 		character.AddStats(updateStats)
-		bonusResist = updateStats[NatureResistanceTotem]
+		bonusResist = updateStats[stats.NatureResistance]
 	}
 
 	if raidBuffs.NatureResistanceTotem {

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -118,13 +118,13 @@ var BuffSpellByLevel = map[BuffName]map[int32]stats.Stats{
 	// TODO: Class Melee specific AP?
 	BattleShout: {
 		25: stats.Stats{
-			stats.AttackPower: 60,
+			stats.AttackPower: 57,
 		},
 		40: stats.Stats{
-			stats.AttackPower: 94,
+			stats.AttackPower: 93,
 		},
 		50: stats.Stats{
-			stats.AttackPower: 139,
+			stats.AttackPower: 138,
 		},
 		60: stats.Stats{
 			stats.AttackPower: 193,

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -20,6 +20,7 @@ func applyConsumeEffects(agent Agent) {
 	applyFlaskConsumes(character, consumes)
 	applyWeaponImbueConsumes(character, consumes)
 	applyFoodConsumes(character, consumes)
+	applyDefensiveBuffConsumes(character, consumes)
 	applyPhysicalBuffConsumes(character, consumes)
 	applySpellBuffConsumes(character, consumes)
 	applyZanzaBuffConsumes(character, consumes)
@@ -343,6 +344,32 @@ func applyFoodConsumes(character *Character, consumes *proto.Consumes) {
 		}
 	}
 
+	if consumes.Alcohol != proto.Alcohol_AlcoholUnknown {
+		switch consumes.Alcohol {
+		case proto.Alcohol_AlcoholKreegsStoutBeatdown:
+			character.AddStats(stats.Stats{
+				stats.Stamina:   25,
+				stats.Intellect: -5,
+			})
+		case proto.Alcohol_AlcoholRumseyRumLight:
+			character.AddStats(stats.Stats{
+				stats.Stamina: 5,
+			})
+		case proto.Alcohol_AlcoholRumseyRumDark:
+			character.AddStats(stats.Stats{
+				stats.Stamina: 10,
+			})
+		case proto.Alcohol_AlcoholGordokGreenGrog:
+			character.AddStats(stats.Stats{
+				stats.Stamina: 10,
+			})
+		case proto.Alcohol_AlcoholRumseyRumBlackLabel:
+			character.AddStats(stats.Stats{
+				stats.Stamina: 15,
+			})
+		}
+	}
+
 	if consumes.DragonBreathChili {
 		MakePermanent(DragonBreathChiliAura(character))
 	}
@@ -383,6 +410,48 @@ func DragonBreathChiliAura(character *Character) *Aura {
 		},
 	})
 	return aura
+}
+
+///////////////////////////////////////////////////////////////////////////
+//                             Defensive Buff Consumes
+///////////////////////////////////////////////////////////////////////////
+
+func applyDefensiveBuffConsumes(character *Character, consumes *proto.Consumes) {
+	if consumes.ArmorElixir != proto.ArmorElixir_ArmorElixirUnknown {
+		switch consumes.ArmorElixir {
+		case proto.ArmorElixir_ElixirOfSuperiorDefense:
+			character.AddStats(stats.Stats{
+				stats.BonusArmor: 450,
+			})
+		case proto.ArmorElixir_ElixirOfGreaterDefense:
+			character.AddStats(stats.Stats{
+				stats.BonusArmor: 250,
+			})
+		case proto.ArmorElixir_ElixirOfDefense:
+			character.AddStats(stats.Stats{
+				stats.BonusArmor: 150,
+			})
+		case proto.ArmorElixir_ElixirOfMinorDefense:
+			character.AddStats(stats.Stats{
+				stats.BonusArmor: 50,
+			})
+		case proto.ArmorElixir_ScrollOfProtection:
+			character.AddStats(BuffSpellByLevel[ScrollOfProtection][character.Level])
+		}
+	}
+
+	if consumes.HealthElixir != proto.HealthElixir_HealthElixirUnknown {
+		switch consumes.HealthElixir {
+		case proto.HealthElixir_ElixirOfFortitude:
+			character.AddStats(stats.Stats{
+				stats.Health: 120,
+			})
+		case proto.HealthElixir_ElixirOfMinorFortitude:
+			character.AddStats(stats.Stats{
+				stats.Health: 27,
+			})
+		}
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -1059,18 +1059,74 @@ func makeManaConsumableMCD(itemId int32, character *Character, cdTimer *Timer) M
 	}
 }
 
-func makePotionActivationInternal(potionType proto.Potions, character *Character, potionCD *Timer) MajorCooldown {
-	// All potions are mana
-	if potionType != proto.Potions_UnknownPotion {
-		itemId := map[proto.Potions]int32{
-			proto.Potions_LesserManaPotion:   3385,
-			proto.Potions_ManaPotion:         3827,
-			proto.Potions_GreaterManaPotion:  6149,
-			proto.Potions_SuperiorManaPotion: 13443,
-			proto.Potions_MajorManaPotion:    13444,
-		}[potionType]
+func makeRageConsumableMCD(itemId int32, character *Character, cdTimer *Timer) MajorCooldown {
+	minRoll := map[int32]float64{
+		5631:  20.0,
+		5633:  30.0,
+		13442: 45.0,
+	}[itemId]
 
-		return makeManaConsumableMCD(itemId, character, potionCD)
+	maxRoll := map[int32]float64{
+		5631:  40.0,
+		5633:  60.0,
+		13442: 75.0,
+	}[itemId]
+
+	cdDuration := time.Minute * 2
+
+	actionID := ActionID{ItemID: itemId}
+	rageMetrics := character.NewRageMetrics(actionID)
+	aura := character.NewTemporaryStatsAura("Mighty Rage Potion", actionID, stats.Stats{stats.Strength: 60}, time.Second*20)
+	return MajorCooldown{
+		Type: CooldownTypeDPS,
+		ShouldActivate: func(sim *Simulation, character *Character) bool {
+			return !character.IsShapeshifted()
+		},
+		Spell: character.GetOrRegisterSpell(SpellConfig{
+			ActionID: actionID,
+			Flags:    SpellFlagNoOnCastComplete,
+			Cast: CastConfig{
+				CD: Cooldown{
+					Timer:    cdTimer,
+					Duration: cdDuration,
+				},
+				ModifyCast: func(sim *Simulation, _ *Spell, _ *Cast) {
+					character.CancelShapeshift(sim)
+				},
+			},
+			ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {
+				rageGain := sim.RollWithLabel(minRoll, maxRoll, "Rage Consumable")
+				character.AddRage(sim, rageGain, rageMetrics)
+				if itemId == 13442 {
+					aura.Activate(sim)
+				}
+			},
+		}),
+	}
+}
+
+func makePotionActivationInternal(potionType proto.Potions, character *Character, potionCD *Timer) MajorCooldown {
+	if potionType != proto.Potions_UnknownPotion {
+		switch potionType {
+		case proto.Potions_LesserManaPotion:
+			return makeManaConsumableMCD(3385, character, potionCD)
+		case proto.Potions_ManaPotion:
+			return makeManaConsumableMCD(3827, character, potionCD)
+		case proto.Potions_GreaterManaPotion:
+			return makeManaConsumableMCD(6149, character, potionCD)
+		case proto.Potions_SuperiorManaPotion:
+			return makeManaConsumableMCD(13443, character, potionCD)
+		case proto.Potions_MajorManaPotion:
+			return makeManaConsumableMCD(13444, character, potionCD)
+		case proto.Potions_RagePotion:
+			return makeRageConsumableMCD(5631, character, potionCD)
+		case proto.Potions_GreatRagePotion:
+			return makeRageConsumableMCD(5633, character, potionCD)
+		case proto.Potions_MightyRagePotion:
+			return makeRageConsumableMCD(13442, character, potionCD)
+		default:
+			return MajorCooldown{}
+		}
 	} else {
 		return MajorCooldown{}
 	}

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -159,6 +159,8 @@ func applyDebuffEffects(target *Unit, targetIdx int, debuffs *proto.Debuffs, rai
 			totalDuration := time.Second * 15
 			uptimePercent := float64(debuffs.Homunculi) / 100.0
 			ApplyFixedUptimeAura(HomunculiArmorAura(target, level), uptimePercent, totalDuration, 1)
+			ApplyFixedUptimeAura(HomunculiAttackSpeedAura(target, level), uptimePercent, totalDuration, 1)
+			ApplyFixedUptimeAura(HomunculiAttackPowerAura(target, level), uptimePercent, totalDuration, 1)
 		}
 	}
 
@@ -837,16 +839,7 @@ func HomunculiAttackSpeedAura(target *Unit, _ int32) *Aura {
 		Duration: time.Second * 15,
 	})
 
-	aura.NewExclusiveEffect("AtkSpdReduction", true, ExclusiveEffect{
-		Priority: multiplier,
-		OnGain: func(ee *ExclusiveEffect, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, 1/multiplier)
-		},
-		OnExpire: func(ee *ExclusiveEffect, sim *Simulation) {
-			aura.Unit.MultiplyAttackSpeed(sim, multiplier)
-		},
-	})
-
+	AtkSpeedReductionEffect(aura, multiplier)
 	return aura
 }
 
@@ -881,15 +874,7 @@ func HomunculiAttackPowerAura(target *Unit, playerLevel int32) *Aura {
 		Duration: time.Second * 15,
 	})
 
-	aura.NewExclusiveEffect("Homonculi AP", true, ExclusiveEffect{
-		Priority: ap,
-		OnGain: func(ee *ExclusiveEffect, sim *Simulation) {
-			target.AddStatDynamic(sim, stats.AttackPower, -1*ap)
-		},
-		OnExpire: func(ee *ExclusiveEffect, sim *Simulation) {
-			target.AddStatDynamic(sim, stats.AttackPower, ap)
-		},
-	})
+	apReductionEffect(aura, ap)
 
 	return aura
 }

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -276,6 +277,13 @@ func (stats Stats) Invert() Stats {
 func (stats Stats) Multiply(multiplier float64) Stats {
 	for k := range stats {
 		stats[k] *= multiplier
+	}
+	return stats
+}
+
+func (stats Stats) Floor() Stats {
+	for k := range stats {
+		stats[k] = math.Floor(stats[k])
 	}
 	return stats
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 10
   final_stats: 15
-  final_stats: 21
+  final_stats: 162
   final_stats: 22
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 119.9
   final_stats: 56.1
-  final_stats: 280.5
+  final_stats: 214.5
   final_stats: 200.2
   final_stats: 191.4
   final_stats: 265
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 4.93359
   final_stats: 0
   final_stats: 0
-  final_stats: 3473.4
+  final_stats: 2780.4
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 28
-  final_stats: 23
-  final_stats: 160
+  final_stats: 60
+  final_stats: 45
+  final_stats: 40
+  final_stats: 423
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 162.756
   final_stats: 149.688
-  final_stats: 420.552
+  final_stats: 313.632
   final_stats: 329.076
   final_stats: 231.66
   final_stats: 259
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 9.24427
   final_stats: 0
   final_stats: 0
-  final_stats: 5316.696
+  final_stats: 4194.036
   final_stats: 25
   final_stats: 35
-  final_stats: 85
-  final_stats: 35
-  final_stats: 25
-  final_stats: 0
+  final_stats: 65
+  final_stats: 60
+  final_stats: 50
+  final_stats: 324
   final_stats: 0
   final_stats: 85
   final_stats: 0

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2294.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1648.75
+  final_stats: 1073.75
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 10
   final_stats: 15
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 22
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3577
   final_stats: 0
   final_stats: 0
-  final_stats: 2057.95
+  final_stats: 1770.45
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2780.4
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 45
   final_stats: 40
-  final_stats: 423
+  final_stats: 1054.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 5720.14
   final_stats: 0
   final_stats: 0
-  final_stats: 2217.702
+  final_stats: 2073.952
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 4194.036
   final_stats: 25
-  final_stats: 35
-  final_stats: 65
+  final_stats: 45
+  final_stats: 50
   final_stats: 60
   final_stats: 50
-  final_stats: 324
+  final_stats: 1099
   final_stats: 0
   final_stats: 85
   final_stats: 0

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestBalance-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 79.64
-  final_stats: 38.94
-  final_stats: 145.31
-  final_stats: 140.14
-  final_stats: 119.24
+  final_stats: 79.2
+  final_stats: 38.5
+  final_stats: 144.1
+  final_stats: 139.7
+  final_stats: 118.8
   final_stats: 147
   final_stats: 0
   final_stats: 0
@@ -15,27 +15,27 @@ character_stats_results: {
   final_stats: 0
   final_stats: 35
   final_stats: 6
-  final_stats: 10.78398
+  final_stats: 10.76519
   final_stats: 0
   final_stats: 10
-  final_stats: 291.93
+  final_stats: 290.8
   final_stats: 1
-  final_stats: 6.89135
+  final_stats: 6.84625
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2301.1
+  final_stats: 2294.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1650.38
+  final_stats: 1648.75
   final_stats: 20
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 4.89135
+  final_stats: 4.84625
   final_stats: 0
   final_stats: 0
-  final_stats: 1670.655
+  final_stats: 1657.95
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestBalance-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 121.22
-  final_stats: 56.98
-  final_stats: 282.04
-  final_stats: 201.08
-  final_stats: 192.28
+  final_stats: 119.9
+  final_stats: 56.1
+  final_stats: 280.5
+  final_stats: 200.2
+  final_stats: 191.4
   final_stats: 265
   final_stats: 35
   final_stats: 0
@@ -64,32 +64,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 37
   final_stats: 3
-  final_stats: 14.02808
+  final_stats: 14.0052
   final_stats: 0
   final_stats: 0
-  final_stats: 532.41
+  final_stats: 529.6
   final_stats: 3
-  final_stats: 7.99686
+  final_stats: 7.93359
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3590.2
+  final_stats: 3577
   final_stats: 0
   final_stats: 0
-  final_stats: 2059.96
+  final_stats: 2057.95
   final_stats: 200
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 4.99686
+  final_stats: 4.93359
   final_stats: 0
   final_stats: 0
-  final_stats: 3489.57
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 28.5
-  final_stats: 23.5
+  final_stats: 3473.4
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 28
+  final_stats: 23
   final_stats: 160
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestBalance-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 163.8252
-  final_stats: 150.8166
-  final_stats: 422.6904
-  final_stats: 329.67
-  final_stats: 232.254
+  final_stats: 162.756
+  final_stats: 149.688
+  final_stats: 420.552
+  final_stats: 329.076
+  final_stats: 231.66
   final_stats: 259
   final_stats: 23
   final_stats: 0
@@ -113,32 +113,32 @@ character_stats_results: {
   final_stats: 23
   final_stats: 38
   final_stats: 4
-  final_stats: 23.55824
+  final_stats: 23.54606
   final_stats: 0
   final_stats: 0
-  final_stats: 752.584
+  final_stats: 750.096
   final_stats: 4
-  final_stats: 24.30629
+  final_stats: 24.24427
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 5729.05
+  final_stats: 5720.14
   final_stats: 0
   final_stats: 0
-  final_stats: 2219.79
+  final_stats: 2217.702
   final_stats: 300
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 9.30629
+  final_stats: 9.24427
   final_stats: 0
   final_stats: 0
-  final_stats: 5339.1492
-  final_stats: 25.25
-  final_stats: 35.25
-  final_stats: 85.25
-  final_stats: 35.25
-  final_stats: 25.25
+  final_stats: 5316.696
+  final_stats: 25
+  final_stats: 35
+  final_stats: 85
+  final_stats: 35
+  final_stats: 25
   final_stats: 0
   final_stats: 0
   final_stats: 85
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.04818
+  weights: 0.04257
   weights: 0
-  weights: 0.49184
-  weights: 0
-  weights: 0
+  weights: 0.49177
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.74187
+  weights: 0
+  weights: 0
+  weights: 0.73802
   weights: 0
   weights: 0
   weights: 0.00087
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.31032
+  weights: -0.08497
   weights: 0
-  weights: 0.7772
-  weights: 0
-  weights: 0
+  weights: 0.7766
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.8332
-  weights: 3.29575
+  weights: 0
+  weights: 0
+  weights: 5.85657
+  weights: 3.23611
   weights: 0
   weights: 0
   weights: 0
@@ -251,7 +251,7 @@ stat_weights_results: {
   weights: 0
   weights: 0.82628
   weights: 0
-  weights: 1.10402
+  weights: 1.10314
   weights: 0
   weights: 0
   weights: 0
@@ -259,8 +259,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.868
-  weights: 8.66966
+  weights: 9.86847
+  weights: 8.59834
   weights: 0
   weights: 0
   weights: 0
@@ -295,22 +295,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestBalance-Lvl25-Average-Default"
  value: {
-  dps: 174.59316
-  tps: 176.8049
+  dps: 174.56957
+  tps: 176.79281
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 172.18066
-  tps: 214.55025
+  dps: 172.14716
+  tps: 215.54922
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 172.18066
-  tps: 174.29914
+  dps: 172.14716
+  tps: 174.31726
  }
 }
 dps_results: {
@@ -344,15 +344,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 171.98734
-  tps: 217.39507
+  dps: 171.96299
+  tps: 217.37072
  }
 }
 dps_results: {
  key: "TestBalance-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 171.98734
-  tps: 174.25773
+  dps: 171.96299
+  tps: 174.23337
  }
 }
 dps_results: {
@@ -386,29 +386,29 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 173.2681
-  tps: 175.58116
+  dps: 173.2193
+  tps: 175.47885
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Average-Default"
  value: {
-  dps: 562.57673
-  tps: 573.14439
+  dps: 562.3414
+  tps: 572.91011
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 535.09236
-  tps: 716.08451
+  dps: 534.32099
+  tps: 716.89086
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 535.09236
-  tps: 544.14197
+  dps: 534.32099
+  tps: 543.44949
  }
 }
 dps_results: {
@@ -442,15 +442,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 533.13855
-  tps: 714.19358
+  dps: 533.92271
+  tps: 716.54841
  }
 }
 dps_results: {
  key: "TestBalance-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 533.13855
-  tps: 542.1913
+  dps: 533.92271
+  tps: 543.05399
  }
 }
 dps_results: {
@@ -484,36 +484,36 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 557.22933
-  tps: 567.74879
+  dps: 557.18909
+  tps: 567.70461
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Average-Default"
  value: {
-  dps: 1060.26143
-  tps: 1078.11448
+  dps: 1060.05351
+  tps: 1077.9083
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1005.00095
-  tps: 1339.12826
+  dps: 1004.54109
+  tps: 1338.6684
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1005.00095
-  tps: 1021.70732
+  dps: 1004.54109
+  tps: 1021.24745
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1006.78602
-  tps: 1017.59935
+  dps: 1005.11668
+  tps: 1015.93001
  }
 }
 dps_results: {
@@ -540,15 +540,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1003.0754
-  tps: 1337.04938
+  dps: 1002.97006
+  tps: 1336.94403
  }
 }
 dps_results: {
  key: "TestBalance-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1003.0754
-  tps: 1019.7741
+  dps: 1002.97006
+  tps: 1019.66876
  }
 }
 dps_results: {
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1053.48437
-  tps: 1071.34851
+  dps: 1053.27072
+  tps: 1071.13487
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 10
   final_stats: 10
-  final_stats: 130
+  final_stats: 271
   final_stats: 0
   final_stats: 0
   final_stats: 59
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 266.552
   final_stats: 203.5
-  final_stats: 324.5
+  final_stats: 258.5
   final_stats: 101.816
   final_stats: 129.8
   final_stats: 42
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 19.53165
   final_stats: 0
   final_stats: 0
-  final_stats: 3935.4
+  final_stats: 3242.4
   final_stats: 18
   final_stats: 13
-  final_stats: 83
-  final_stats: 28
-  final_stats: 23
-  final_stats: 100
+  final_stats: 70
+  final_stats: 45
+  final_stats: 40
+  final_stats: 363
   final_stats: 0
   final_stats: 0
   final_stats: 89
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 399.168
   final_stats: 390.852
-  final_stats: 450.252
+  final_stats: 343.332
   final_stats: 154.44
   final_stats: 188.892
   final_stats: 0
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 27.56942
   final_stats: 0
   final_stats: 0
-  final_stats: 5628.546
+  final_stats: 4505.886
   final_stats: 20
-  final_stats: 20
-  final_stats: 80
-  final_stats: 30
   final_stats: 20
   final_stats: 60
+  final_stats: 55
+  final_stats: 45
+  final_stats: 384
   final_stats: 0
   final_stats: 65
   final_stats: 114

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestFeral-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 136.84
-  final_stats: 134.64
-  final_stats: 165.11
-  final_stats: 75.24
-  final_stats: 92.84
+  final_stats: 136.4
+  final_stats: 134.2
+  final_stats: 163.9
+  final_stats: 74.8
+  final_stats: 92.4
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -15,27 +15,27 @@ character_stats_results: {
   final_stats: 0
   final_stats: 21
   final_stats: 5
-  final_stats: 5.01275
+  final_stats: 4.99396
   final_stats: 0
   final_stats: 0
-  final_stats: 693.97
+  final_stats: 692.4
   final_stats: 2
-  final_stats: 16.7006
+  final_stats: 16.6555
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1327.6
+  final_stats: 1321
   final_stats: 0
   final_stats: 0
-  final_stats: 2074.78
+  final_stats: 2073.15
   final_stats: 52
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 14.7006
+  final_stats: 14.6555
   final_stats: 0
   final_stats: 0
-  final_stats: 1878.555
+  final_stats: 1865.85
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestFeral-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 267.9248
-  final_stats: 204.38
-  final_stats: 326.04
-  final_stats: 102.7312
-  final_stats: 130.68
+  final_stats: 266.552
+  final_stats: 203.5
+  final_stats: 324.5
+  final_stats: 101.816
+  final_stats: 129.8
   final_stats: 42
   final_stats: 0
   final_stats: 0
@@ -64,32 +64,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 3
-  final_stats: 13.47101
+  final_stats: 13.44722
   final_stats: 0
   final_stats: 0
-  final_stats: 1311.1996
+  final_stats: 1307.404
   final_stats: 3
-  final_stats: 26.59492
+  final_stats: 26.53165
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 2114.968
+  final_stats: 2101.24
   final_stats: 0
   final_stats: 0
-  final_stats: 2488.76
+  final_stats: 2486.75
   final_stats: 252
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 19.59492
+  final_stats: 19.53165
   final_stats: 0
   final_stats: 0
-  final_stats: 3951.57
-  final_stats: 18.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 28.5
-  final_stats: 23.5
+  final_stats: 3935.4
+  final_stats: 18
+  final_stats: 13
+  final_stats: 83
+  final_stats: 28
+  final_stats: 23
   final_stats: 100
   final_stats: 0
   final_stats: 0
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestFeral-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 400.2372
-  final_stats: 391.9806
-  final_stats: 452.3904
-  final_stats: 155.034
-  final_stats: 189.486
+  final_stats: 399.168
+  final_stats: 390.852
+  final_stats: 450.252
+  final_stats: 154.44
+  final_stats: 188.892
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -113,32 +113,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 4
-  final_stats: 19.9782
+  final_stats: 19.96602
   final_stats: 0
   final_stats: 0
-  final_stats: 1921.3886
+  final_stats: 1917.772
   final_stats: 4
-  final_stats: 46.63143
+  final_stats: 46.56942
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 3109.51
+  final_stats: 3100.6
   final_stats: 0
   final_stats: 0
-  final_stats: 2992.118
+  final_stats: 2990.03
   final_stats: 315
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 27.63143
+  final_stats: 27.56942
   final_stats: 0
   final_stats: 0
-  final_stats: 5650.9992
-  final_stats: 20.25
-  final_stats: 20.25
-  final_stats: 80.25
-  final_stats: 30.25
-  final_stats: 20.25
+  final_stats: 5628.546
+  final_stats: 20
+  final_stats: 20
+  final_stats: 80
+  final_stats: 30
+  final_stats: 20
   final_stats: 60
   final_stats: 0
   final_stats: 65
@@ -148,8 +148,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestFeral-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.58422
-  weights: 0.51968
+  weights: 0.58421
+  weights: 0.52918
   weights: 0
   weights: 0
   weights: 0
@@ -166,8 +166,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.26555
-  weights: 2.71383
-  weights: 2.2509
+  weights: 2.3799
+  weights: 2.26731
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.83398
-  weights: 0.79587
+  weights: 0.8335
+  weights: 0.76493
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +214,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.36453
-  weights: 4.4971
-  weights: 5.70423
+  weights: 0.36432
+  weights: 5.25966
+  weights: 5.52438
   weights: 0
   weights: 0
   weights: 0
@@ -246,8 +246,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.39178
-  weights: 1.94711
+  weights: 1.39092
+  weights: 1.8801
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.58577
-  weights: 11.33603
-  weights: 13.42553
+  weights: 0.5854
+  weights: 11.31443
+  weights: 13.27001
   weights: 0
   weights: 0
   weights: 0
@@ -295,29 +295,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestFeral-Lvl25-Average-Default"
  value: {
-  dps: 266.76782
-  tps: 194.44605
+  dps: 266.18335
+  tps: 194.02606
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 121.77414
-  tps: 158.71346
+  dps: 121.44589
+  tps: 158.47906
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 121.77414
-  tps: 90.89001
+  dps: 121.44589
+  tps: 90.65561
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 159.52638
-  tps: 123.59202
+  dps: 159.28352
+  tps: 123.41287
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 121.77414
-  tps: 158.71346
+  dps: 121.44589
+  tps: 158.47906
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 121.77414
-  tps: 90.89001
+  dps: 121.44589
+  tps: 90.65561
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 159.52638
-  tps: 123.59202
+  dps: 159.28352
+  tps: 123.41287
  }
 }
 dps_results: {
@@ -386,22 +386,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 121.77414
-  tps: 158.71346
+  dps: 121.44589
+  tps: 158.47906
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 121.77414
-  tps: 90.89001
+  dps: 121.44589
+  tps: 90.65561
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-NightElf-phase_1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 159.52638
-  tps: 123.59202
+  dps: 159.28352
+  tps: 123.41287
  }
 }
 dps_results: {
@@ -428,22 +428,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 121.3757
-  tps: 157.54468
+  dps: 120.30789
+  tps: 156.79465
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 121.3757
-  tps: 90.54996
+  dps: 120.30789
+  tps: 89.79097
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Default-NoBleed-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 158.56066
-  tps: 122.83866
+  dps: 158.32081
+  tps: 122.66178
  }
 }
 dps_results: {
@@ -470,22 +470,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 121.3757
-  tps: 157.54468
+  dps: 120.30789
+  tps: 156.79465
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 121.3757
-  tps: 90.54996
+  dps: 120.30789
+  tps: 89.79097
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Default-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 158.56066
-  tps: 122.83866
+  dps: 158.32081
+  tps: 122.66178
  }
 }
 dps_results: {
@@ -512,22 +512,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 121.3757
-  tps: 157.54468
+  dps: 120.30789
+  tps: 156.79465
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 121.3757
-  tps: 90.54996
+  dps: 120.30789
+  tps: 89.79097
  }
 }
 dps_results: {
  key: "TestFeral-Lvl25-Settings-Tauren-phase_1-Flower-Aoe-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 158.56066
-  tps: 122.83866
+  dps: 158.32081
+  tps: 122.66178
  }
 }
 dps_results: {
@@ -554,36 +554,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 190.42957
-  tps: 138.82173
+  dps: 190.00861
+  tps: 138.51614
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Average-Default"
  value: {
-  dps: 757.63455
-  tps: 557.18859
+  dps: 755.81357
+  tps: 555.88277
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 387.39588
-  tps: 328.96263
+  dps: 386.90432
+  tps: 330.15954
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 387.39588
-  tps: 280.63138
+  dps: 386.90432
+  tps: 280.3549
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 496.36634
-  tps: 369.51467
+  dps: 495.53732
+  tps: 369.27502
  }
 }
 dps_results: {
@@ -610,22 +610,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 387.39588
-  tps: 328.96263
+  dps: 386.90432
+  tps: 330.15954
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 387.39588
-  tps: 280.63138
+  dps: 386.90432
+  tps: 280.3549
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 496.36634
-  tps: 369.51467
+  dps: 495.53732
+  tps: 369.27502
  }
 }
 dps_results: {
@@ -652,22 +652,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 387.39588
-  tps: 328.96263
+  dps: 386.90432
+  tps: 330.15954
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 387.39588
-  tps: 280.63138
+  dps: 386.90432
+  tps: 280.3549
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 496.36634
-  tps: 369.51467
+  dps: 495.53732
+  tps: 369.27502
  }
 }
 dps_results: {
@@ -694,22 +694,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 386.52265
-  tps: 330.07701
+  dps: 386.08769
+  tps: 328.02588
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 386.52265
-  tps: 280.11562
+  dps: 386.08769
+  tps: 279.71676
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 494.32961
-  tps: 368.53462
+  dps: 493.36298
+  tps: 367.41264
  }
 }
 dps_results: {
@@ -736,22 +736,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 386.52265
-  tps: 330.07701
+  dps: 386.08769
+  tps: 328.02588
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 386.52265
-  tps: 280.11562
+  dps: 386.08769
+  tps: 279.71676
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 494.32961
-  tps: 368.53462
+  dps: 493.36298
+  tps: 367.41264
  }
 }
 dps_results: {
@@ -778,22 +778,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 386.52265
-  tps: 330.07701
+  dps: 386.08769
+  tps: 328.02588
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 386.52265
-  tps: 280.11562
+  dps: 386.08769
+  tps: 279.71676
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 494.32961
-  tps: 368.53462
+  dps: 493.36298
+  tps: 367.41264
  }
 }
 dps_results: {
@@ -820,39 +820,39 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 417.51544
-  tps: 299.1288
+  dps: 416.36709
+  tps: 298.30823
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Average-Default"
  value: {
-  dps: 1826.64864
-  tps: 1315.40856
+  dps: 1823.79031
+  tps: 1313.38188
   hps: 18.12245
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1187.33814
-  tps: 1073.86791
+  dps: 1185.9972
+  tps: 1072.92797
   hps: 9.01486
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1187.33814
-  tps: 854.70402
+  dps: 1185.9972
+  tps: 853.75242
   hps: 9.01486
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1367.84129
-  tps: 975.95899
+  dps: 1365.55225
+  tps: 974.33376
   hps: 8.76619
  }
 }
@@ -883,24 +883,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1187.33814
-  tps: 1073.86791
+  dps: 1185.9972
+  tps: 1072.92797
   hps: 9.01486
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1187.33814
-  tps: 854.70402
+  dps: 1185.9972
+  tps: 853.75242
   hps: 9.01486
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1367.84129
-  tps: 975.95899
+  dps: 1365.55225
+  tps: 974.33376
   hps: 8.76619
  }
 }
@@ -931,24 +931,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1187.33814
-  tps: 1073.86791
+  dps: 1185.9972
+  tps: 1072.92797
   hps: 9.01486
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1187.33814
-  tps: 854.70402
+  dps: 1185.9972
+  tps: 853.75242
   hps: 9.01486
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-NightElf-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1367.84129
-  tps: 975.95899
+  dps: 1365.55225
+  tps: 974.33376
   hps: 8.76619
  }
 }
@@ -979,24 +979,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1182.59984
-  tps: 1070.39596
+  dps: 1180.27225
+  tps: 1068.7456
   hps: 9.00084
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1182.59984
-  tps: 851.32008
+  dps: 1180.27225
+  tps: 849.66748
   hps: 9.00084
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-NoBleed-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1366.08643
-  tps: 974.71303
+  dps: 1364.60356
+  tps: 973.66019
   hps: 8.76619
  }
 }
@@ -1027,24 +1027,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1182.59984
-  tps: 1070.39596
+  dps: 1180.27225
+  tps: 1068.7456
   hps: 9.00084
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1182.59984
-  tps: 851.32008
+  dps: 1180.27225
+  tps: 849.66748
   hps: 9.00084
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Default-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1366.08643
-  tps: 974.71303
+  dps: 1364.60356
+  tps: 973.66019
   hps: 8.76619
  }
 }
@@ -1075,24 +1075,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1182.59984
-  tps: 1070.39596
+  dps: 1180.27225
+  tps: 1068.7456
   hps: 9.00084
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1182.59984
-  tps: 851.32008
+  dps: 1180.27225
+  tps: 849.66748
   hps: 9.00084
  }
 }
 dps_results: {
  key: "TestFeral-Lvl50-Settings-Tauren-phase_3-Flower-Aoe-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1366.08643
-  tps: 974.71303
+  dps: 1364.60356
+  tps: 973.66019
   hps: 8.76619
  }
 }
@@ -1123,8 +1123,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1280.43363
-  tps: 916.72568
+  dps: 1277.86795
+  tps: 914.90635
   hps: 17.15738
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1321
   final_stats: 0
   final_stats: 0
-  final_stats: 2073.15
+  final_stats: 1498.15
   final_stats: 52
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 10
   final_stats: 10
-  final_stats: 271
+  final_stats: 614.75
   final_stats: 0
   final_stats: 0
   final_stats: 59
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2101.24
   final_stats: 0
   final_stats: 0
-  final_stats: 2486.75
+  final_stats: 2199.25
   final_stats: 252
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3242.4
   final_stats: 18
-  final_stats: 13
-  final_stats: 70
+  final_stats: 30
+  final_stats: 40
   final_stats: 45
   final_stats: 40
-  final_stats: 363
+  final_stats: 994.25
   final_stats: 0
   final_stats: 0
   final_stats: 89
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 3100.6
   final_stats: 0
   final_stats: 0
-  final_stats: 2990.03
+  final_stats: 2846.28
   final_stats: 315
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 4505.886
   final_stats: 20
-  final_stats: 20
-  final_stats: 60
+  final_stats: 30
+  final_stats: 45
   final_stats: 55
   final_stats: 45
-  final_stats: 384
+  final_stats: 1159
   final_stats: 0
   final_stats: 65
   final_stats: 114

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestBM-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 98.494
-  final_stats: 196.504
-  final_stats: 164.681
-  final_stats: 52.514
-  final_stats: 80.344
+  final_stats: 98.01
+  final_stats: 196.02
+  final_stats: 163.35
+  final_stats: 52.03
+  final_stats: 79.86
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -15,27 +15,27 @@ character_stats_results: {
   final_stats: 0
   final_stats: 21
   final_stats: 5
-  final_stats: 5.43799
+  final_stats: 5.42105
   final_stats: 0
   final_stats: 0
-  final_stats: 523.718
+  final_stats: 522.5
   final_stats: 2
-  final_stats: 12.11996
+  final_stats: 12.09503
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1118.71
+  final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 2068.508
-  final_stats: 492.008
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 2066.79
+  final_stats: 491.04
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1758.81
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 1745.5
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestBM-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 136.62
-  final_stats: 245.08
-  final_stats: 315.04
-  final_stats: 105.38
-  final_stats: 96.58
+  final_stats: 135.3
+  final_stats: 244.2
+  final_stats: 313.5
+  final_stats: 104.5
+  final_stats: 95.7
   final_stats: 42
   final_stats: 0
   final_stats: 0
@@ -64,32 +64,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 3
-  final_stats: 14.13966
+  final_stats: 14.11845
   final_stats: 0
   final_stats: 0
-  final_stats: 937.81
+  final_stats: 935.4
   final_stats: 3
-  final_stats: 11.42592
+  final_stats: 11.39926
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2405.7
+  final_stats: 2392.5
   final_stats: 0
   final_stats: 0
-  final_stats: 3067.16
-  final_stats: 932.16
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 3065.15
+  final_stats: 930.4
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3637.4
-  final_stats: 13.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 13.5
-  final_stats: 23.5
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 3622
+  final_stats: 13
+  final_stats: 13
+  final_stats: 83
+  final_stats: 13
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 14
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestBM-Lvl25-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.44241
+  weights: 0.46929
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02236
-  weights: 2.41863
-  weights: 2.07812
+  weights: 0.02212
+  weights: 2.33325
+  weights: 1.99622
   weights: 0
   weights: 0
   weights: 0
@@ -126,7 +126,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.12932
+  weights: 0.12943
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestBM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.68752
+  weights: 0.76922
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.33552
-  weights: 9.89185
-  weights: 8.2746
+  weights: 0.33548
+  weights: 9.97552
+  weights: 8.30309
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +175,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.06408
+  weights: 0.06401
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestBM-Lvl25-Average-Default"
  value: {
-  dps: 230.80842
-  tps: 101.4993
+  dps: 229.99576
+  tps: 101.07065
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 234.04905
-  tps: 112.70616
+  dps: 233.55527
+  tps: 112.80755
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 223.2899
-  tps: 98.81158
+  dps: 222.24485
+  tps: 98.54786
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 269.61235
-  tps: 111.68468
+  dps: 269.10295
+  tps: 111.57336
  }
 }
 dps_results: {
@@ -246,22 +246,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 235.85888
-  tps: 109.90852
+  dps: 234.79903
+  tps: 110.6152
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 224.50835
-  tps: 97.091
+  dps: 223.59412
+  tps: 96.80934
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 272.0259
-  tps: 109.71244
+  dps: 271.48448
+  tps: 109.60168
  }
 }
 dps_results: {
@@ -288,43 +288,43 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 228.4089
-  tps: 100.18936
+  dps: 227.80848
+  tps: 100.09238
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 881.49283
-  tps: 268.46915
+  dps: 879.24113
+  tps: 267.91747
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Average-Default"
  value: {
-  dps: 890.72588
-  tps: 276.99482
+  dps: 888.50608
+  tps: 276.49447
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1464.63392
-  tps: 875.63514
+  dps: 1461.7251
+  tps: 874.80244
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 789.83749
-  tps: 209.41259
+  dps: 788.06116
+  tps: 209.08882
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 826.52294
-  tps: 222.97716
+  dps: 824.47802
+  tps: 222.56979
  }
 }
 dps_results: {
@@ -351,22 +351,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 576.70154
-  tps: 543.35361
+  dps: 575.30382
+  tps: 543.52576
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 510.71419
-  tps: 246.08515
+  dps: 509.8014
+  tps: 245.70249
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 560.30403
-  tps: 263.78597
+  dps: 558.90488
+  tps: 263.358
  }
 }
 dps_results: {
@@ -393,22 +393,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 499.70641
-  tps: 469.0484
+  dps: 497.16094
+  tps: 467.62766
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 499.70641
-  tps: 203.66032
+  dps: 497.16094
+  tps: 202.63891
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 551.69873
-  tps: 227.7107
+  dps: 549.79659
+  tps: 227.10011
  }
 }
 dps_results: {
@@ -435,22 +435,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 784.44006
-  tps: 862.38231
+  dps: 782.88632
+  tps: 864.81311
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 701.6522
-  tps: 431.41859
+  dps: 701.20115
+  tps: 431.16103
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 768.41899
-  tps: 472.17994
+  dps: 766.72874
+  tps: 471.74641
  }
 }
 dps_results: {
@@ -477,22 +477,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1468.78927
-  tps: 864.53113
+  dps: 1465.75808
+  tps: 863.69965
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 798.70084
-  tps: 206.61678
+  dps: 796.76275
+  tps: 206.36678
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 837.27611
-  tps: 224.54183
+  dps: 835.2854
+  tps: 224.30596
  }
 }
 dps_results: {
@@ -519,22 +519,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 584.856
-  tps: 539.82957
+  dps: 583.9707
+  tps: 539.59722
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 520.80094
-  tps: 243.17848
+  dps: 518.94798
+  tps: 243.03795
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 570.87372
-  tps: 260.70901
+  dps: 569.30528
+  tps: 260.28684
  }
 }
 dps_results: {
@@ -561,22 +561,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 509.33186
-  tps: 465.97612
+  dps: 508.53481
+  tps: 466.81591
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 509.33186
-  tps: 200.09026
+  dps: 508.53481
+  tps: 200.00732
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 566.93736
-  tps: 231.38901
+  dps: 564.81274
+  tps: 230.82304
  }
 }
 dps_results: {
@@ -603,22 +603,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 792.08208
-  tps: 864.98235
+  dps: 787.39701
+  tps: 865.12636
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 708.51703
-  tps: 426.63257
+  dps: 707.2921
+  tps: 427.76238
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 775.61071
-  tps: 466.93882
+  dps: 773.47951
+  tps: 466.02053
  }
 }
 dps_results: {
@@ -645,7 +645,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 845.49431
-  tps: 253.55748
+  dps: 843.4814
+  tps: 253.18336
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 2066.79
+  final_stats: 1925.79
   final_stats: 491.04
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 40
+  final_stats: 181
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 135.3
   final_stats: 244.2
-  final_stats: 313.5
+  final_stats: 247.5
   final_stats: 104.5
   final_stats: 95.7
   final_stats: 42
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2392.5
   final_stats: 0
   final_stats: 0
-  final_stats: 3065.15
+  final_stats: 2802.15
   final_stats: 930.4
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3622
+  final_stats: 2962
   final_stats: 13
   final_stats: 13
-  final_stats: 83
-  final_stats: 13
-  final_stats: 23
-  final_stats: 0
+  final_stats: 70
+  final_stats: 30
+  final_stats: 40
+  final_stats: 263
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 1925.79
+  final_stats: 1007.04
   final_stats: 491.04
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 181
+  final_stats: 524.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2392.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2802.15
+  final_stats: 1883.4
   final_stats: 930.4
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2962
   final_stats: 13
-  final_stats: 13
-  final_stats: 70
   final_stats: 30
   final_stats: 40
-  final_stats: 263
+  final_stats: 30
+  final_stats: 40
+  final_stats: 894.25
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestMM-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 98.494
-  final_stats: 196.504
-  final_stats: 164.681
-  final_stats: 52.514
-  final_stats: 80.344
+  final_stats: 98.01
+  final_stats: 196.02
+  final_stats: 163.35
+  final_stats: 52.03
+  final_stats: 79.86
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -15,27 +15,27 @@ character_stats_results: {
   final_stats: 0
   final_stats: 21
   final_stats: 5
-  final_stats: 5.43799
+  final_stats: 5.42105
   final_stats: 0
   final_stats: 0
-  final_stats: 523.718
+  final_stats: 522.5
   final_stats: 2
-  final_stats: 12.11996
+  final_stats: 12.09503
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1118.71
+  final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 2068.508
-  final_stats: 492.008
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 2066.79
+  final_stats: 491.04
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1758.81
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 1745.5
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestMM-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 146.652
-  final_stats: 313.148
-  final_stats: 329.604
-  final_stats: 96.558
-  final_stats: 111.078
+  final_stats: 145.2
+  final_stats: 312.18
+  final_stats: 327.91
+  final_stats: 95.59
+  final_stats: 110.11
   final_stats: 42
   final_stats: 0
   final_stats: 0
@@ -64,32 +64,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 3
-  final_stats: 13.92705
+  final_stats: 13.90372
   final_stats: 0
   final_stats: 0
-  final_stats: 959.496
+  final_stats: 956.87
   final_stats: 3
-  final_stats: 13.48838
+  final_stats: 13.45905
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2273.37
+  final_stats: 2258.85
   final_stats: 0
   final_stats: 0
-  final_stats: 2882.296
-  final_stats: 1038.296
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 2880.11
+  final_stats: 1036.36
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3783.04
-  final_stats: 13.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 13.5
-  final_stats: 23.5
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 3766.1
+  final_stats: 13
+  final_stats: 13
+  final_stats: 83
+  final_stats: 13
+  final_stats: 23
   final_stats: 40
   final_stats: 0
   final_stats: 14
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestMM-Lvl25-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.42762
+  weights: 0.41653
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02322
-  weights: 2.0884
-  weights: 1.57413
+  weights: 0.02327
+  weights: 2.30994
+  weights: 1.61791
   weights: 0
   weights: 0
   weights: 0
@@ -126,7 +126,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.11931
+  weights: 0.12016
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestMM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.36667
+  weights: 0.42902
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.11596
-  weights: 4.08449
-  weights: 4.5795
+  weights: 0.11594
+  weights: 3.99282
+  weights: 4.63939
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +175,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.03367
+  weights: 0.03362
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestMM-Lvl25-Average-Default"
  value: {
-  dps: 210.28989
-  tps: 101.64702
+  dps: 209.87
+  tps: 101.46482
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 211.76997
-  tps: 110.95225
+  dps: 210.59446
+  tps: 109.92364
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 198.22835
-  tps: 95.85037
+  dps: 197.84134
+  tps: 96.42495
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 247.03228
-  tps: 115.50088
+  dps: 246.58924
+  tps: 115.38404
  }
 }
 dps_results: {
@@ -246,22 +246,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 216.03888
-  tps: 111.05709
+  dps: 215.68914
+  tps: 111.10525
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 203.00589
-  tps: 97.66958
+  dps: 201.89376
+  tps: 96.84123
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 252.37579
-  tps: 116.0906
+  dps: 251.82752
+  tps: 115.81576
  }
 }
 dps_results: {
@@ -288,43 +288,43 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 207.34175
-  tps: 100.73443
+  dps: 207.30519
+  tps: 100.54611
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 343.3494
-  tps: 180.83661
+  dps: 342.17168
+  tps: 180.39637
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Average-Default"
  value: {
-  dps: 346.94469
-  tps: 183.76538
+  dps: 345.86133
+  tps: 183.34319
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 740.35466
-  tps: 915.21673
+  dps: 739.23063
+  tps: 917.81334
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 645.6172
-  tps: 509.66959
+  dps: 644.74498
+  tps: 510.44748
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 669.82536
-  tps: 534.45331
+  dps: 668.07131
+  tps: 533.43971
  }
 }
 dps_results: {
@@ -351,22 +351,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 746.96316
-  tps: 916.34724
+  dps: 746.61355
+  tps: 918.93994
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 654.12909
-  tps: 509.93435
+  dps: 651.92406
+  tps: 508.8151
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 676.77918
-  tps: 533.13351
+  dps: 675.41036
+  tps: 532.63482
  }
 }
 dps_results: {
@@ -393,7 +393,7 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 330.79804
-  tps: 168.7563
+  dps: 329.78532
+  tps: 168.44709
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 1925.79
+  final_stats: 1007.04
   final_stats: 491.04
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 181
+  final_stats: 524.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2258.85
   final_stats: 0
   final_stats: 0
-  final_stats: 2617.11
+  final_stats: 1698.36
   final_stats: 1036.36
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3040.1
   final_stats: 13
-  final_stats: 13
-  final_stats: 70
   final_stats: 30
   final_stats: 40
-  final_stats: 303
+  final_stats: 30
+  final_stats: 40
+  final_stats: 934.25
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 2066.79
+  final_stats: 1925.79
   final_stats: 491.04
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 40
+  final_stats: 181
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 145.2
   final_stats: 312.18
-  final_stats: 327.91
+  final_stats: 255.31
   final_stats: 95.59
   final_stats: 110.11
   final_stats: 42
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2258.85
   final_stats: 0
   final_stats: 0
-  final_stats: 2880.11
+  final_stats: 2617.11
   final_stats: 1036.36
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3766.1
+  final_stats: 3040.1
   final_stats: 13
   final_stats: 13
-  final_stats: 83
-  final_stats: 13
-  final_stats: 23
+  final_stats: 70
+  final_stats: 30
   final_stats: 40
+  final_stats: 303
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 2066.79
+  final_stats: 1925.79
   final_stats: 491.04
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 40
+  final_stats: 181
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 135.3
   final_stats: 280.83
-  final_stats: 313.5
+  final_stats: 247.5
   final_stats: 104.5
   final_stats: 95.7
   final_stats: 42
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2392.5
   final_stats: 0
   final_stats: 0
-  final_stats: 3138.41
+  final_stats: 2875.41
   final_stats: 1003.66
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3984.2
+  final_stats: 3258.2
   final_stats: 13
   final_stats: 13
-  final_stats: 83
-  final_stats: 13
-  final_stats: 23
-  final_stats: 0
+  final_stats: 70
+  final_stats: 30
+  final_stats: 40
+  final_stats: 263
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestSV-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 98.494
-  final_stats: 196.504
-  final_stats: 164.681
-  final_stats: 52.514
-  final_stats: 80.344
+  final_stats: 98.01
+  final_stats: 196.02
+  final_stats: 163.35
+  final_stats: 52.03
+  final_stats: 79.86
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -15,27 +15,27 @@ character_stats_results: {
   final_stats: 0
   final_stats: 21
   final_stats: 6
-  final_stats: 5.43799
+  final_stats: 5.42105
   final_stats: 0
   final_stats: 0
-  final_stats: 523.718
+  final_stats: 522.5
   final_stats: 3
-  final_stats: 12.11996
+  final_stats: 12.09503
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1118.71
+  final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 2068.508
-  final_stats: 492.008
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 2066.79
+  final_stats: 491.04
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1793.9862
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 1780.41
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestSV-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 136.62
-  final_stats: 281.842
-  final_stats: 315.04
-  final_stats: 105.38
-  final_stats: 96.58
+  final_stats: 135.3
+  final_stats: 280.83
+  final_stats: 313.5
+  final_stats: 104.5
+  final_stats: 95.7
   final_stats: 42
   final_stats: 0
   final_stats: 0
@@ -64,32 +64,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 6
-  final_stats: 14.13966
+  final_stats: 14.11845
   final_stats: 0
   final_stats: 0
-  final_stats: 974.572
+  final_stats: 972.03
   final_stats: 6
-  final_stats: 15.53981
+  final_stats: 15.50915
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2405.7
+  final_stats: 2392.5
   final_stats: 0
   final_stats: 0
-  final_stats: 3140.684
-  final_stats: 1005.684
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
+  final_stats: 3138.41
+  final_stats: 1003.66
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 4001.14
-  final_stats: 13.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 13.5
-  final_stats: 23.5
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 3984.2
+  final_stats: 13
+  final_stats: 13
+  final_stats: 83
+  final_stats: 13
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 14
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestSV-Lvl25-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.41784
+  weights: 0.44677
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02418
-  weights: 1.8105
-  weights: 1.84758
+  weights: 0.0241
+  weights: 2.03318
+  weights: 1.77652
   weights: 0
   weights: 0
   weights: 0
@@ -126,7 +126,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.11943
+  weights: 0.11883
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestSV-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 1.0914
+  weights: 1.09055
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.38434
-  weights: 8.96253
-  weights: 6.44758
+  weights: 0.38382
+  weights: 8.60687
+  weights: 6.63871
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +175,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.03682
+  weights: 0.03674
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestSV-Lvl25-Average-Default"
  value: {
-  dps: 209.916
-  tps: 99.92339
+  dps: 209.27722
+  tps: 99.58194
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 214.31131
-  tps: 110.43105
+  dps: 213.72499
+  tps: 110.87562
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 202.53852
-  tps: 97.07045
+  dps: 202.44
+  tps: 97.11311
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 257.78864
-  tps: 114.44836
+  dps: 257.33083
+  tps: 114.33382
  }
 }
 dps_results: {
@@ -246,22 +246,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 214.75532
-  tps: 107.86492
+  dps: 213.94845
+  tps: 109.24336
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 204.18385
-  tps: 95.57262
+  dps: 203.58847
+  tps: 95.91106
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 259.09256
-  tps: 112.61581
+  dps: 258.69044
+  tps: 112.50165
  }
 }
 dps_results: {
@@ -288,43 +288,43 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 206.98783
-  tps: 99.03491
+  dps: 206.32254
+  tps: 98.70545
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 872.80793
-  tps: 299.23756
+  dps: 870.86536
+  tps: 298.7251
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
-  dps: 880.0975
-  tps: 305.70182
+  dps: 878.17862
+  tps: 305.13898
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1452.58883
-  tps: 883.93653
+  dps: 1449.87488
+  tps: 882.95044
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 746.56071
-  tps: 211.82617
+  dps: 745.09712
+  tps: 211.58767
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 757.08428
-  tps: 222.58687
+  dps: 755.79071
+  tps: 222.33327
  }
 }
 dps_results: {
@@ -351,22 +351,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1463.21743
-  tps: 881.29361
+  dps: 1460.32546
+  tps: 880.32229
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 755.2676
-  tps: 211.88608
+  dps: 753.56104
+  tps: 211.57321
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 767.6757
-  tps: 226.16248
+  dps: 766.32663
+  tps: 225.90238
  }
 }
 dps_results: {
@@ -393,7 +393,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 829.56173
-  tps: 281.17457
+  dps: 827.5296
+  tps: 280.69426
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1111.45
   final_stats: 0
   final_stats: 0
-  final_stats: 1925.79
+  final_stats: 1007.04
   final_stats: 491.04
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 181
+  final_stats: 524.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2392.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2875.41
+  final_stats: 1956.66
   final_stats: 1003.66
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3258.2
   final_stats: 13
-  final_stats: 13
-  final_stats: 70
   final_stats: 30
   final_stats: 40
-  final_stats: 263
+  final_stats: 30
+  final_stats: 40
+  final_stats: 894.25
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestArcane-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 57.64
-  final_stats: 35.64
-  final_stats: 98.01
-  final_stats: 159.94
-  final_stats: 117.04
+  final_stats: 57.2
+  final_stats: 35.2
+  final_stats: 96.8
+  final_stats: 159.5
+  final_stats: 116.6
   final_stats: 136
   final_stats: 9
   final_stats: 21
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 35
   final_stats: 5
-  final_stats: 22.79715
+  final_stats: 22.77625
   final_stats: 0
   final_stats: 10
-  final_stats: 147.25
+  final_stats: 147
   final_stats: 0
   final_stats: 5.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2630.1
+  final_stats: 2623.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1412.78
+  final_stats: 1411.15
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 1115.1
+  final_stats: 1103
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestArcane-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 83.82
-  final_stats: 37.18
-  final_stats: 231.44
-  final_stats: 225.28
-  final_stats: 190.08
+  final_stats: 82.5
+  final_stats: 36.3
+  final_stats: 229.9
+  final_stats: 224.4
+  final_stats: 189.2
   final_stats: 295
   final_stats: 16
   final_stats: 10
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 42
   final_stats: 2
-  final_stats: 30.41773
+  final_stats: 30.39344
   final_stats: 0
   final_stats: 0
-  final_stats: 308.25
+  final_stats: 308
   final_stats: 2
   final_stats: 8.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 4347.42
+  final_stats: 4332.9
   final_stats: 0
   final_stats: 0
-  final_stats: 1671.36
+  final_stats: 1669.35
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 2764.4
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 35.5
-  final_stats: 26.5
+  final_stats: 2749
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 35
+  final_stats: 26
   final_stats: 160
   final_stats: 0
   final_stats: 14
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.07236
+  weights: 0.32687
   weights: 0
-  weights: 0.30756
-  weights: 0.23413
-  weights: 0.07343
-  weights: 0
-  weights: 0
+  weights: 0.30775
+  weights: 0.23452
+  weights: 0.07323
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.44388
+  weights: 0
+  weights: 0
+  weights: 0.44014
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13027
+  weights: -0.01003
   weights: 0
-  weights: 0.47521
-  weights: 0.47521
-  weights: 0
-  weights: 0
+  weights: 0.47601
+  weights: 0.47601
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.51401
+  weights: 0
+  weights: 0
+  weights: 2.53672
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestArcane-Lvl25-Average-Default"
  value: {
-  dps: 134.6982
-  tps: 57.14949
+  dps: 134.52156
+  tps: 57.07859
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 469.21259
-  tps: 253.17384
+  dps: 466.77084
+  tps: 252.15105
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 117.30771
-  tps: 50.19752
+  dps: 116.18866
+  tps: 49.7476
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Gnome-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 158.39064
-  tps: 71.06136
+  dps: 158.40713
+  tps: 71.05644
  }
 }
 dps_results: {
@@ -246,15 +246,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 469.8175
-  tps: 253.45168
+  dps: 471.0502
+  tps: 253.94477
  }
 }
 dps_results: {
  key: "TestArcane-Lvl25-Settings-Troll-p1_generic-Arcane-p1_arcane-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 115.59265
-  tps: 49.5133
+  dps: 115.24699
+  tps: 49.37503
  }
 }
 dps_results: {
@@ -288,36 +288,36 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 134.73381
-  tps: 57.17017
+  dps: 135.48272
+  tps: 57.46973
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Average-Default"
  value: {
-  dps: 409.36536
-  tps: 171.66123
+  dps: 409.15278
+  tps: 171.57521
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 408.07801
-  tps: 321.4882
+  dps: 410.93151
+  tps: 322.64312
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 408.07801
-  tps: 171.14405
+  dps: 410.93151
+  tps: 172.28613
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Gnome-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 491.05859
-  tps: 210.61935
+  dps: 491.03518
+  tps: 210.60999
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 411.92155
-  tps: 323.35051
+  dps: 412.78875
+  tps: 323.8476
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 411.92155
-  tps: 172.69771
+  dps: 412.78875
+  tps: 173.0521
  }
 }
 dps_results: {
  key: "TestArcane-Lvl40-Settings-Troll-p2_arcane-Arcane-p2_arcane-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 494.48681
-  tps: 212.01809
+  dps: 494.45929
+  tps: 212.00714
  }
 }
 dps_results: {
@@ -386,7 +386,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 417.07912
-  tps: 174.75263
+  dps: 417.26839
+  tps: 174.83614
  }
 }

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2623.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1270.15
+  final_stats: 351.4
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 15
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 4332.9
   final_stats: 0
   final_stats: 0
-  final_stats: 1406.35
+  final_stats: 487.6
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2089
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 52
   final_stats: 43
-  final_stats: 423
+  final_stats: 1054.25
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2623.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1411.15
+  final_stats: 1270.15
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 15
-  final_stats: 21
+  final_stats: 162
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 82.5
   final_stats: 36.3
-  final_stats: 229.9
+  final_stats: 163.9
   final_stats: 224.4
   final_stats: 189.2
   final_stats: 295
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 4332.9
   final_stats: 0
   final_stats: 0
-  final_stats: 1669.35
+  final_stats: 1406.35
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 2749
+  final_stats: 2089
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 35
-  final_stats: 26
-  final_stats: 160
+  final_stats: 60
+  final_stats: 52
+  final_stats: 43
+  final_stats: 423
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2379
   final_stats: 0
   final_stats: 0
-  final_stats: 1417.35
+  final_stats: 1276.35
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 15
-  final_stats: 21
+  final_stats: 162
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 82.5
   final_stats: 36.3
-  final_stats: 229.9
+  final_stats: 163.9
   final_stats: 224.4
   final_stats: 189.2
   final_stats: 295
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3939
   final_stats: 0
   final_stats: 0
-  final_stats: 1669.35
+  final_stats: 1406.35
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 2749
+  final_stats: 2089
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 35
-  final_stats: 26
-  final_stats: 160
+  final_stats: 60
+  final_stats: 52
+  final_stats: 43
+  final_stats: 423
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 119.988
   final_stats: 135.432
-  final_stats: 368.28
+  final_stats: 261.36
   final_stats: 304.128
   final_stats: 234.036
   final_stats: 222
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1985.19
+  final_stats: 1661.19
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 4457.8
+  final_stats: 3388.6
   final_stats: 20
   final_stats: 45
-  final_stats: 80
-  final_stats: 20
-  final_stats: 20
-  final_stats: 0
+  final_stats: 60
+  final_stats: 45
+  final_stats: 45
+  final_stats: 324
   final_stats: 35
   final_stats: 85
   final_stats: 0

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestFire-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 58.74
-  final_stats: 36.74
-  final_stats: 104.61
-  final_stats: 145.64
-  final_stats: 118.14
+  final_stats: 58.3
+  final_stats: 36.3
+  final_stats: 103.4
+  final_stats: 145.2
+  final_stats: 117.7
   final_stats: 129
   final_stats: 0
   final_stats: 54
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 35
   final_stats: 5
-  final_stats: 22.1179
+  final_stats: 22.097
   final_stats: 0
   final_stats: 10
-  final_stats: 147.25
+  final_stats: 147
   final_stats: 0
   final_stats: 5.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2385.6
+  final_stats: 2379
   final_stats: 0
   final_stats: 0
-  final_stats: 1418.98
+  final_stats: 1417.35
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 1181.1
+  final_stats: 1169
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestFire-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 83.82
-  final_stats: 37.18
-  final_stats: 231.44
-  final_stats: 225.28
-  final_stats: 190.08
+  final_stats: 82.5
+  final_stats: 36.3
+  final_stats: 229.9
+  final_stats: 224.4
+  final_stats: 189.2
   final_stats: 295
   final_stats: 0
   final_stats: 26
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 42
   final_stats: 2
-  final_stats: 30.41773
+  final_stats: 30.39344
   final_stats: 0
   final_stats: 0
-  final_stats: 308.25
+  final_stats: 308
   final_stats: 2
   final_stats: 8.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3952.2
+  final_stats: 3939
   final_stats: 0
   final_stats: 0
-  final_stats: 1671.36
+  final_stats: 1669.35
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 2764.4
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 35.5
-  final_stats: 26.5
+  final_stats: 2749
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 35
+  final_stats: 26
   final_stats: 160
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestFire-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 121.0572
-  final_stats: 136.5606
-  final_stats: 370.4184
-  final_stats: 304.722
-  final_stats: 234.63
+  final_stats: 119.988
+  final_stats: 135.432
+  final_stats: 368.28
+  final_stats: 304.128
+  final_stats: 234.036
   final_stats: 222
   final_stats: 0
   final_stats: 145
@@ -113,19 +113,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 38
   final_stats: 0
-  final_stats: 37.62963
+  final_stats: 37.6171
   final_stats: 0
   final_stats: 0
-  final_stats: 450.5
+  final_stats: 450
   final_stats: 0
   final_stats: 19.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 5338.83
+  final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1987.278
+  final_stats: 1985.19
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -133,12 +133,12 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 4479.184
-  final_stats: 20.25
-  final_stats: 45.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 20.25
+  final_stats: 4457.8
+  final_stats: 20
+  final_stats: 45
+  final_stats: 80
+  final_stats: 20
+  final_stats: 20
   final_stats: 0
   final_stats: 35
   final_stats: 85
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.38662
+  weights: 0.32491
   weights: 0
-  weights: 0.42477
+  weights: 0.42427
   weights: 0
-  weights: 0.42477
-  weights: 0
-  weights: 0
+  weights: 0.42427
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.99986
+  weights: 0
+  weights: 0
+  weights: 0.91713
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.64333
+  weights: 0.36857
   weights: 0
-  weights: 0.64923
+  weights: 0.64716
   weights: 0
-  weights: 0.64923
-  weights: 0
-  weights: 0
+  weights: 0.64716
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.30887
-  weights: 3.74644
+  weights: 0
+  weights: 0
+  weights: 6.46286
+  weights: 3.53594
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.57217
+  weights: -0.79417
   weights: 0
-  weights: 0.82313
+  weights: 0.8281
   weights: 0
-  weights: 0.82313
-  weights: 0
-  weights: 0
+  weights: 0.8281
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.50207
+  weights: 0
+  weights: 0
+  weights: 10.09231
   weights: 0
   weights: 0
   weights: 0
@@ -295,22 +295,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestFire-Lvl25-Average-Default"
  value: {
-  dps: 150.57768
-  tps: 108.66667
+  dps: 150.35765
+  tps: 108.51307
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 423.20224
-  tps: 361.67905
+  dps: 423.72028
+  tps: 362.05407
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Gnome-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 150.49687
-  tps: 108.57892
+  dps: 150.56882
+  tps: 108.62929
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 391.36962
-  tps: 339.44105
+  dps: 391.63513
+  tps: 339.62691
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 144.15993
-  tps: 104.14406
+  dps: 143.99138
+  tps: 104.02586
  }
 }
 dps_results: {
  key: "TestFire-Lvl25-Settings-Troll-p1_fire-Fire-p1_fire-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 186.88439
-  tps: 138.54877
+  dps: 186.89071
+  tps: 138.55213
  }
 }
 dps_results: {
@@ -386,36 +386,36 @@ dps_results: {
 dps_results: {
  key: "TestFire-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 149.79501
-  tps: 108.08861
+  dps: 149.61479
+  tps: 107.96225
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Average-Default"
  value: {
-  dps: 472.61407
-  tps: 343.49199
+  dps: 471.56368
+  tps: 342.73749
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1491.0005
-  tps: 1279.27334
+  dps: 1486.79809
+  tps: 1276.75423
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 462.50907
-  tps: 336.69021
+  dps: 460.45118
+  tps: 335.2022
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Gnome-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 642.99646
-  tps: 471.75766
+  dps: 642.98524
+  tps: 471.76444
  }
 }
 dps_results: {
@@ -442,22 +442,22 @@ dps_results: {
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1453.5201
-  tps: 1248.40371
+  dps: 1456.71811
+  tps: 1250.63497
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 449.63421
-  tps: 327.48084
+  dps: 448.03835
+  tps: 326.32915
  }
 }
 dps_results: {
  key: "TestFire-Lvl40-Settings-Troll-p2_fire-Fire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 645.61685
-  tps: 473.55717
+  dps: 645.6174
+  tps: 473.55684
  }
 }
 dps_results: {
@@ -484,36 +484,36 @@ dps_results: {
 dps_results: {
  key: "TestFire-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 474.07555
-  tps: 344.58978
+  dps: 472.46831
+  tps: 343.44087
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Average-Default"
  value: {
-  dps: 813.73858
-  tps: 595.74624
+  dps: 812.46528
+  tps: 594.83686
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1675.32909
-  tps: 1748.15864
+  dps: 1689.15239
+  tps: 1761.91061
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 869.19522
-  tps: 635.07594
+  dps: 869.69909
+  tps: 635.39863
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1122.13447
-  tps: 826.79806
+  dps: 1122.13602
+  tps: 826.79665
  }
 }
 dps_results: {
@@ -540,22 +540,22 @@ dps_results: {
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1638.59561
-  tps: 1717.41975
+  dps: 1620.97977
+  tps: 1704.22586
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 807.44512
-  tps: 590.78728
+  dps: 811.91353
+  tps: 593.94012
  }
 }
 dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1135.30433
-  tps: 835.88846
+  dps: 1135.24447
+  tps: 835.85318
  }
 }
 dps_results: {
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 809.31674
-  tps: 592.1189
+  dps: 810.43826
+  tps: 592.91232
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2379
   final_stats: 0
   final_stats: 0
-  final_stats: 1276.35
+  final_stats: 357.6
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 15
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3939
   final_stats: 0
   final_stats: 0
-  final_stats: 1406.35
+  final_stats: 487.6
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2089
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 52
   final_stats: 43
-  final_stats: 423
+  final_stats: 1054.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1661.19
+  final_stats: 742.44
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3388.6
   final_stats: 20
+  final_stats: 55
   final_stats: 45
-  final_stats: 60
   final_stats: 45
   final_stats: 45
-  final_stats: 324
+  final_stats: 1099
   final_stats: 35
   final_stats: 85
   final_stats: 0

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestFrost-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 121.0572
-  final_stats: 136.5606
-  final_stats: 370.4184
-  final_stats: 304.722
-  final_stats: 234.63
+  final_stats: 119.988
+  final_stats: 135.432
+  final_stats: 368.28
+  final_stats: 304.128
+  final_stats: 234.036
   final_stats: 222
   final_stats: 0
   final_stats: 145
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 38
   final_stats: 0
-  final_stats: 27.62963
+  final_stats: 27.6171
   final_stats: 0
   final_stats: 0
-  final_stats: 450.5
+  final_stats: 450
   final_stats: 0
   final_stats: 19.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 5338.83
+  final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1987.278
+  final_stats: 1985.19
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -35,12 +35,12 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 4479.184
-  final_stats: 20.25
-  final_stats: 45.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 20.25
+  final_stats: 4457.8
+  final_stats: 20
+  final_stats: 45
+  final_stats: 80
+  final_stats: 20
+  final_stats: 20
   final_stats: 0
   final_stats: 35
   final_stats: 85
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestFrost-Lvl50-Average-Default"
  value: {
-  dps: 1191.34782
-  tps: 933.72124
+  dps: 1191.23001
+  tps: 933.62612
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1178.39576
-  tps: 1118.18295
+  dps: 1178.35542
+  tps: 1119.36448
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1178.39576
-  tps: 923.29497
+  dps: 1178.35542
+  tps: 923.32273
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Gnome-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 1259.77205
-  tps: 976.46161
+  tps: 976.46163
  }
 }
 dps_results: {
@@ -148,15 +148,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1179.98977
-  tps: 1127.99321
+  dps: 1180.03303
+  tps: 1126.95795
  }
 }
 dps_results: {
  key: "TestFrost-Lvl50-Settings-Troll-p3_frost_ffb-Frost-p3_frost-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1179.98977
-  tps: 924.43335
+  dps: 1180.03303
+  tps: 924.41368
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1181.51095
-  tps: 925.78444
+  dps: 1181.55421
+  tps: 925.76477
  }
 }

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1661.19
+  final_stats: 742.44
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3388.6
   final_stats: 20
+  final_stats: 55
   final_stats: 45
-  final_stats: 60
   final_stats: 45
   final_stats: 45
-  final_stats: 324
+  final_stats: 1099
   final_stats: 35
   final_stats: 85
   final_stats: 0

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 119.988
   final_stats: 135.432
-  final_stats: 368.28
+  final_stats: 261.36
   final_stats: 304.128
   final_stats: 234.036
   final_stats: 222
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1985.19
+  final_stats: 1661.19
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 4457.8
+  final_stats: 3388.6
   final_stats: 20
   final_stats: 45
-  final_stats: 80
-  final_stats: 20
-  final_stats: 20
-  final_stats: 0
+  final_stats: 60
+  final_stats: 45
+  final_stats: 45
+  final_stats: 324
   final_stats: 35
   final_stats: 85
   final_stats: 0

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestFrostFire-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 83.82
-  final_stats: 37.18
-  final_stats: 231.44
-  final_stats: 225.28
-  final_stats: 190.08
+  final_stats: 82.5
+  final_stats: 36.3
+  final_stats: 229.9
+  final_stats: 224.4
+  final_stats: 189.2
   final_stats: 295
   final_stats: 0
   final_stats: 26
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 42
   final_stats: 2
-  final_stats: 30.41773
+  final_stats: 30.39344
   final_stats: 0
   final_stats: 0
-  final_stats: 308.25
+  final_stats: 308
   final_stats: 2
   final_stats: 8.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3952.2
+  final_stats: 3939
   final_stats: 0
   final_stats: 0
-  final_stats: 1671.36
+  final_stats: 1669.35
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -35,12 +35,12 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 2764.4
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 35.5
-  final_stats: 26.5
+  final_stats: 2749
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 35
+  final_stats: 26
   final_stats: 160
   final_stats: 0
   final_stats: 14
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestFrostFire-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 121.0572
-  final_stats: 136.5606
-  final_stats: 370.4184
-  final_stats: 304.722
-  final_stats: 234.63
+  final_stats: 119.988
+  final_stats: 135.432
+  final_stats: 368.28
+  final_stats: 304.128
+  final_stats: 234.036
   final_stats: 222
   final_stats: 0
   final_stats: 145
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 38
   final_stats: 0
-  final_stats: 42.62963
+  final_stats: 42.6171
   final_stats: 0
   final_stats: 0
-  final_stats: 450.5
+  final_stats: 450
   final_stats: 0
   final_stats: 19.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 5338.83
+  final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1987.278
+  final_stats: 1985.19
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 4479.184
-  final_stats: 20.25
-  final_stats: 45.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 20.25
+  final_stats: 4457.8
+  final_stats: 20
+  final_stats: 45
+  final_stats: 80
+  final_stats: 20
+  final_stats: 20
   final_stats: 0
   final_stats: 35
   final_stats: 85
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+  weights: -0.68145
+  weights: 0
+  weights: 0.91787
+  weights: 0
+  weights: 0.91787
   weights: 0
   weights: 0
-  weights: 0.91597
-  weights: 0
-  weights: 0.91597
   weights: 0
   weights: 0
   weights: 0
-  weights: 0
-  weights: 0
-  weights: 2.45333
-  weights: 2.83067
+  weights: 3.44971
+  weights: 3.49387
   weights: 0
   weights: 0
   weights: 0
@@ -151,7 +151,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0
+  weights: 0.01305
   weights: 0
   weights: 1.28414
   weights: 0
@@ -197,22 +197,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestFrostFire-Lvl40-Average-Default"
  value: {
-  dps: 635.28469
-  tps: 456.25364
+  dps: 635.13969
+  tps: 456.16486
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1341.70896
-  tps: 1168.39994
+  dps: 1344.44485
+  tps: 1170.71477
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Gnome-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 625.92359
-  tps: 449.48188
+  dps: 625.28165
+  tps: 449.02559
  }
 }
 dps_results: {
@@ -246,22 +246,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1278.26835
-  tps: 1122.83801
+  dps: 1276.79034
+  tps: 1121.36729
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 625.63879
-  tps: 449.36054
+  dps: 625.854
+  tps: 449.53252
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl40-Settings-Troll-p2_frost-Frostfire-p2_fire-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 670.78738
-  tps: 483.07015
+  tps: 483.07065
  }
 }
 dps_results: {
@@ -288,36 +288,36 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 626.82982
-  tps: 450.21437
+  dps: 627.3566
+  tps: 450.60605
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Average-Default"
  value: {
-  dps: 1307.86653
-  tps: 937.09076
+  dps: 1307.55228
+  tps: 936.87311
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2579.77183
-  tps: 2336.83607
+  dps: 2579.46501
+  tps: 2336.07847
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1301.23141
-  tps: 932.13661
+  dps: 1301.22271
+  tps: 932.13308
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Gnome-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1330.77359
-  tps: 947.33505
+  dps: 1330.60542
+  tps: 947.26466
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2575.29192
-  tps: 2336.65041
+  dps: 2574.97314
+  tps: 2336.96296
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1307.52924
-  tps: 936.45268
+  dps: 1307.60408
+  tps: 936.50138
  }
 }
 dps_results: {
  key: "TestFrostFire-Lvl50-Settings-Troll-p3_fire_ffb-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 1340.08693
-  tps: 956.20684
+  tps: 956.88162
  }
 }
 dps_results: {
@@ -386,7 +386,7 @@ dps_results: {
 dps_results: {
  key: "TestFrostFire-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1303.59344
-  tps: 933.71116
+  dps: 1303.66852
+  tps: 933.76002
  }
 }

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 3939
   final_stats: 0
   final_stats: 0
-  final_stats: 1406.35
+  final_stats: 487.6
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2089
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 52
   final_stats: 43
-  final_stats: 423
+  final_stats: 1054.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1661.19
+  final_stats: 742.44
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3388.6
   final_stats: 20
+  final_stats: 55
   final_stats: 45
-  final_stats: 60
   final_stats: 45
   final_stats: 45
-  final_stats: 324
+  final_stats: 1099
   final_stats: 35
   final_stats: 85
   final_stats: 0

--- a/sim/mage/TestFrostFire.results
+++ b/sim/mage/TestFrostFire.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 82.5
   final_stats: 36.3
-  final_stats: 229.9
+  final_stats: 163.9
   final_stats: 224.4
   final_stats: 189.2
   final_stats: 295
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 3939
   final_stats: 0
   final_stats: 0
-  final_stats: 1669.35
+  final_stats: 1406.35
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 2749
+  final_stats: 2089
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 35
-  final_stats: 26
-  final_stats: 160
+  final_stats: 60
+  final_stats: 52
+  final_stats: 43
+  final_stats: 423
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 119.988
   final_stats: 135.432
-  final_stats: 368.28
+  final_stats: 261.36
   final_stats: 304.128
   final_stats: 234.036
   final_stats: 222
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 5329.92
   final_stats: 0
   final_stats: 0
-  final_stats: 1985.19
+  final_stats: 1661.19
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 3.2
   final_stats: 0
   final_stats: 0
-  final_stats: 4457.8
+  final_stats: 3388.6
   final_stats: 20
   final_stats: 45
-  final_stats: 80
-  final_stats: 20
-  final_stats: 20
-  final_stats: 0
+  final_stats: 60
+  final_stats: 45
+  final_stats: 45
+  final_stats: 324
   final_stats: 35
   final_stats: 85
   final_stats: 0

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 0
+  final_stats: 141
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 309.1
   final_stats: 170.5
-  final_stats: 359.7
+  final_stats: 293.7
   final_stats: 89.1
   final_stats: 100.485
   final_stats: 42
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 0.7
   final_stats: 0
   final_stats: 0
-  final_stats: 4038
+  final_stats: 3378
   final_stats: 18
   final_stats: 13
-  final_stats: 83
-  final_stats: 18
-  final_stats: 23
-  final_stats: 0
+  final_stats: 70
+  final_stats: 35
+  final_stats: 40
+  final_stats: 263
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 495.2772
   final_stats: 269.676
-  final_stats: 500.148
+  final_stats: 393.228
   final_stats: 133.056
   final_stats: 158.4198
   final_stats: 0
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 0.7
   final_stats: 0
   final_stats: 0
-  final_stats: 5787.48
+  final_stats: 4718.28
   final_stats: 20
   final_stats: 20
-  final_stats: 80
-  final_stats: 20
-  final_stats: 20
-  final_stats: 0
+  final_stats: 60
+  final_stats: 45
+  final_stats: 45
+  final_stats: 324
   final_stats: 0
   final_stats: 100
   final_stats: 0

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestRetribution-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 201.74
-  final_stats: 111.54
-  final_stats: 151.91
-  final_stats: 58.74
-  final_stats: 59.367
+  final_stats: 201.3
+  final_stats: 111.1
+  final_stats: 150.7
+  final_stats: 58.3
+  final_stats: 58.905
   final_stats: 25
   final_stats: 0
   final_stats: 10
@@ -15,27 +15,27 @@ character_stats_results: {
   final_stats: 0
   final_stats: 18
   final_stats: 3
-  final_stats: 5.59702
+  final_stats: 5.58131
   final_stats: 0
   final_stats: 0
-  final_stats: 629.13
+  final_stats: 628
   final_stats: 0
-  final_stats: 19.69055
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
-  final_stats: 1153.1
+  final_stats: 19.64325
   final_stats: 0
   final_stats: 0
-  final_stats: 2461.58
+  final_stats: 0
+  final_stats: 1146.5
+  final_stats: 0
+  final_stats: 0
+  final_stats: 2459.95
   final_stats: 38
   final_stats: 8
   final_stats: 0
-  final_stats: 9.972
+  final_stats: 9.95
   final_stats: 0.7
   final_stats: 0
   final_stats: 0
-  final_stats: 1605.1
+  final_stats: 1593
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestRetribution-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 310.42
-  final_stats: 171.38
-  final_stats: 361.24
-  final_stats: 89.98
-  final_stats: 101.409
+  final_stats: 309.1
+  final_stats: 170.5
+  final_stats: 359.7
+  final_stats: 89.1
+  final_stats: 100.485
   final_stats: 42
   final_stats: 0
   final_stats: 10
@@ -64,32 +64,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 2
-  final_stats: 14.71351
+  final_stats: 14.69186
   final_stats: 0
   final_stats: 0
-  final_stats: 1104.81
+  final_stats: 1102
   final_stats: 2
-  final_stats: 23.39926
+  final_stats: 23.33405
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 2056.7
+  final_stats: 2043.5
   final_stats: 0
   final_stats: 0
-  final_stats: 3219.76
+  final_stats: 3217.75
   final_stats: 274
   final_stats: 0
   final_stats: 0
-  final_stats: 15.314
+  final_stats: 15.25
   final_stats: 0.7
   final_stats: 0
   final_stats: 0
-  final_stats: 4053.4
-  final_stats: 18.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 18.5
-  final_stats: 23.5
+  final_stats: 4038
+  final_stats: 18
+  final_stats: 13
+  final_stats: 83
+  final_stats: 18
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestRetribution-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 496.45332
-  final_stats: 270.8046
-  final_stats: 502.2864
-  final_stats: 133.65
-  final_stats: 159.0435
+  final_stats: 495.2772
+  final_stats: 269.676
+  final_stats: 500.148
+  final_stats: 133.056
+  final_stats: 158.4198
   final_stats: 0
   final_stats: 0
   final_stats: 10
@@ -113,32 +113,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 4
-  final_stats: 22.173
+  final_stats: 22.16112
   final_stats: 0
   final_stats: 0
-  final_stats: 1750.2836
+  final_stats: 1747.5968
   final_stats: 4
-  final_stats: 39.54738
+  final_stats: 39.48412
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 2981.75
+  final_stats: 2972.84
   final_stats: 0
   final_stats: 0
-  final_stats: 5141.766
+  final_stats: 5139.678
   final_stats: 449
   final_stats: 0
   final_stats: 0
-  final_stats: 24.39459
+  final_stats: 24.33992
   final_stats: 0.7
   final_stats: 0
   final_stats: 0
-  final_stats: 5808.864
-  final_stats: 20.25
-  final_stats: 20.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 20.25
+  final_stats: 5787.48
+  final_stats: 20
+  final_stats: 20
+  final_stats: 80
+  final_stats: 20
+  final_stats: 20
   final_stats: 0
   final_stats: 0
   final_stats: 100
@@ -148,12 +148,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestRetribution-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.44461
-  weights: 0.21821
+  weights: 0.44446
+  weights: 0.23392
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13205
+  weights: 0.132
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42424
+  weights: 0.4256
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.20209
-  weights: 1.2369
-  weights: 2.09328
+  weights: 0.20203
+  weights: 1.23045
+  weights: 2.08601
   weights: 0
   weights: 0
   weights: 0
@@ -197,12 +197,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.67868
-  weights: 0.60471
+  weights: 0.67802
+  weights: 0.58093
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.27776
+  weights: 0.27734
   weights: 0
   weights: 0
   weights: 0
@@ -210,13 +210,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.21105
-  weights: 0.07723
+  weights: 2.24053
+  weights: 0.07026
   weights: 0
   weights: 0
-  weights: 0.30849
-  weights: 6.89894
-  weights: 7.23722
+  weights: 0.30819
+  weights: 6.42215
+  weights: 7.20987
   weights: 0
   weights: 0
   weights: 0
@@ -246,12 +246,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.14391
-  weights: -0.56392
+  weights: 1.14339
+  weights: 0.81656
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.44195
+  weights: 0.44187
   weights: 0
   weights: 0
   weights: 0
@@ -259,13 +259,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.97591
-  weights: 0.44045
+  weights: 4.88196
+  weights: 0.45283
   weights: 0
   weights: 0
-  weights: 0.43768
-  weights: 6.60519
-  weights: 4.80636
+  weights: 0.43748
+  weights: 7.09765
+  weights: 5.42316
   weights: 0
   weights: 0
   weights: 0
@@ -295,29 +295,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestRetribution-Lvl25-Average-Default"
  value: {
-  dps: 238.89977
-  tps: 245.16976
+  dps: 238.58101
+  tps: 244.8276
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 167.61741
-  tps: 291.2626
+  dps: 167.33283
+  tps: 290.49915
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 88.81146
-  tps: 94.99372
+  dps: 88.66407
+  tps: 94.82239
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 96.32768
-  tps: 101.05035
+  dps: 96.25258
+  tps: 100.9505
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 168.99522
-  tps: 293.80323
+  dps: 168.75303
+  tps: 293.09146
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 89.66657
-  tps: 95.90697
+  dps: 89.52364
+  tps: 95.74056
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 96.92784
-  tps: 101.71238
+  dps: 96.85189
+  tps: 101.61168
  }
 }
 dps_results: {
@@ -386,36 +386,36 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 223.89737
-  tps: 230.13777
+  dps: 223.6379
+  tps: 229.85482
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Average-Default"
  value: {
-  dps: 605.94188
-  tps: 619.86833
+  dps: 604.45825
+  tps: 618.36309
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 384.23135
-  tps: 635.04571
+  dps: 383.75757
+  tps: 634.41021
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 213.61564
-  tps: 225.85401
+  dps: 213.4003
+  tps: 225.6166
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 227.37729
-  tps: 239.41674
+  dps: 227.14749
+  tps: 239.14556
  }
 }
 dps_results: {
@@ -442,22 +442,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 383.51168
-  tps: 631.87269
+  dps: 382.94792
+  tps: 632.88107
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 214.14388
-  tps: 226.33484
+  dps: 213.65981
+  tps: 225.76152
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 228.31127
-  tps: 240.38754
+  dps: 228.08
+  tps: 240.11777
  }
 }
 dps_results: {
@@ -484,36 +484,36 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 571.66369
-  tps: 585.52767
+  dps: 570.77253
+  tps: 584.62279
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl50-Average-Default"
  value: {
-  dps: 1326.35429
-  tps: 1358.94933
+  dps: 1325.18535
+  tps: 1357.80461
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1306.14536
-  tps: 1858.5125
+  dps: 1304.62227
+  tps: 1855.93244
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 357.1934
-  tps: 384.86339
+  dps: 356.94008
+  tps: 384.57087
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 412.03639
-  tps: 443.02787
+  dps: 411.76307
+  tps: 442.72857
  }
 }
 dps_results: {
@@ -540,22 +540,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1318.00446
-  tps: 1870.85318
+  dps: 1311.0679
+  tps: 1863.73807
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 358.67276
-  tps: 386.3744
+  dps: 359.73082
+  tps: 387.40307
  }
 }
 dps_results: {
  key: "TestRetribution-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 414.76903
-  tps: 445.92808
+  dps: 414.56819
+  tps: 445.70223
  }
 }
 dps_results: {
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1245.11435
-  tps: 1277.79065
+  dps: 1243.16821
+  tps: 1275.83381
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1146.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2459.95
+  final_stats: 1884.95
   final_stats: 38
   final_stats: 8
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 141
+  final_stats: 484.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2043.5
   final_stats: 0
   final_stats: 0
-  final_stats: 3217.75
+  final_stats: 2930.25
   final_stats: 274
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3378
   final_stats: 18
-  final_stats: 13
-  final_stats: 70
+  final_stats: 30
+  final_stats: 40
   final_stats: 35
   final_stats: 40
-  final_stats: 263
+  final_stats: 894.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 2972.84
   final_stats: 0
   final_stats: 0
-  final_stats: 5139.678
+  final_stats: 4995.928
   final_stats: 449
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 4718.28
   final_stats: 20
-  final_stats: 20
-  final_stats: 60
+  final_stats: 30
   final_stats: 45
   final_stats: 45
-  final_stats: 324
+  final_stats: 45
+  final_stats: 1099
   final_stats: 0
   final_stats: 100
   final_stats: 0

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2177.15
   final_stats: 0
   final_stats: 0
-  final_stats: 3235.35
+  final_stats: 2947.85
   final_stats: 274
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3246
   final_stats: 18
-  final_stats: 13
-  final_stats: 70
+  final_stats: 30
+  final_stats: 40
   final_stats: 35
   final_stats: 40
-  final_stats: 263
+  final_stats: 894.25
   final_stats: 0
   final_stats: 14
   final_stats: 69

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 331.54
   final_stats: 179.3
-  final_stats: 346.5
+  final_stats: 280.5
   final_stats: 98.01
   final_stats: 100.485
   final_stats: 42
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 0.7
   final_stats: 0
   final_stats: 0
-  final_stats: 3906
+  final_stats: 3246
   final_stats: 18
   final_stats: 13
-  final_stats: 83
-  final_stats: 18
-  final_stats: 23
-  final_stats: 0
+  final_stats: 70
+  final_stats: 35
+  final_stats: 40
+  final_stats: 263
   final_stats: 0
   final_stats: 14
   final_stats: 69

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestShockadin-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 332.992
-  final_stats: 180.18
-  final_stats: 348.04
-  final_stats: 98.978
-  final_stats: 101.409
+  final_stats: 331.54
+  final_stats: 179.3
+  final_stats: 346.5
+  final_stats: 98.01
+  final_stats: 100.485
   final_stats: 42
   final_stats: 0
   final_stats: 10
@@ -15,32 +15,32 @@ character_stats_results: {
   final_stats: 0
   final_stats: 30
   final_stats: 2
-  final_stats: 14.93486
+  final_stats: 14.91105
   final_stats: 0
   final_stats: 0
-  final_stats: 1149.126
+  final_stats: 1146.06
   final_stats: 2
-  final_stats: 19.05134
+  final_stats: 18.98613
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 2191.67
+  final_stats: 2177.15
   final_stats: 0
   final_stats: 0
-  final_stats: 3237.36
+  final_stats: 3235.35
   final_stats: 274
   final_stats: 0
   final_stats: 0
-  final_stats: 16.4219
+  final_stats: 16.3515
   final_stats: 0.7
   final_stats: 0
   final_stats: 0
-  final_stats: 3921.4
-  final_stats: 18.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 18.5
-  final_stats: 23.5
+  final_stats: 3906
+  final_stats: 18
+  final_stats: 13
+  final_stats: 83
+  final_stats: 18
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 14
@@ -50,12 +50,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestShockadin-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.7043
-  weights: -2.56195
+  weights: 0.70386
+  weights: 0.37241
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.28711
+  weights: 0.28674
   weights: 0
   weights: 0
   weights: 0
@@ -63,13 +63,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.58921
-  weights: 0.46412
+  weights: 2.43669
+  weights: 0.41674
   weights: 0
   weights: 0
-  weights: 0.29103
-  weights: -8.4761
-  weights: -0.94888
+  weights: 0.29085
+  weights: -8.69922
+  weights: -6.28491
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestShockadin-Lvl40-Average-Default"
  value: {
-  dps: 562.25332
-  tps: 580.77307
+  dps: 561.10091
+  tps: 579.62895
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 572.84371
-  tps: 859.62002
+  dps: 573.14623
+  tps: 858.86359
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 168.85171
-  tps: 183.23084
+  dps: 167.13757
+  tps: 181.42173
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 184.65953
-  tps: 200.35435
+  dps: 183.7385
+  tps: 199.36974
  }
 }
 dps_results: {
@@ -148,22 +148,22 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 580.78937
-  tps: 870.38546
+  dps: 575.28754
+  tps: 862.65522
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 168.44743
-  tps: 182.87702
+  dps: 169.11266
+  tps: 183.50141
  }
 }
 dps_results: {
  key: "TestShockadin-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 185.72664
-  tps: 201.44773
+  dps: 185.56265
+  tps: 201.25064
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 545.11583
-  tps: 564.01301
+  dps: 544.2533
+  tps: 563.11674
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestShadow-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 60.94
-  final_stats: 37.84
-  final_stats: 133.21
-  final_stats: 134.64
-  final_stats: 126.94
+  final_stats: 60.5
+  final_stats: 37.4
+  final_stats: 132
+  final_stats: 134.2
+  final_stats: 126.5
   final_stats: 142
   final_stats: 0
   final_stats: 0
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 35
   final_stats: 6
-  final_stats: 6.95305
+  final_stats: 6.93294
   final_stats: 0
   final_stats: 10
-  final_stats: 147.25
+  final_stats: 147
   final_stats: 1
   final_stats: 5
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2236.6
+  final_stats: 2230
   final_stats: 0
   final_stats: 0
-  final_stats: 1425.18
+  final_stats: 1423.55
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 1454.1
+  final_stats: 1442
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestShadow-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 92.62
-  final_stats: 50.38
-  final_stats: 288.64
-  final_stats: 212.08
-  final_stats: 166.98
+  final_stats: 91.3
+  final_stats: 49.5
+  final_stats: 287.1
+  final_stats: 211.2
+  final_stats: 166.1
   final_stats: 242
   final_stats: 0
   final_stats: 0
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 57
   final_stats: 41
   final_stats: 2
-  final_stats: 13.50495
+  final_stats: 13.48128
   final_stats: 0
   final_stats: 0
-  final_stats: 308.25
+  final_stats: 308
   final_stats: 2
   final_stats: 6
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3812.2
+  final_stats: 3799
   final_stats: 0
   final_stats: 0
-  final_stats: 1690.76
+  final_stats: 1688.75
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 3343.4
-  final_stats: 21.5
-  final_stats: 26.5
-  final_stats: 76.5
-  final_stats: 21.5
-  final_stats: 29.5
+  final_stats: 3328
+  final_stats: 21
+  final_stats: 26
+  final_stats: 76
+  final_stats: 21
+  final_stats: 29
   final_stats: 290
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestShadow-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 125.8092
-  final_stats: 140.1246
-  final_stats: 395.3664
-  final_stats: 271.458
-  final_stats: 220.374
+  final_stats: 124.74
+  final_stats: 138.996
+  final_stats: 393.228
+  final_stats: 270.864
+  final_stats: 219.78
   final_stats: 196
   final_stats: 23
   final_stats: 0
@@ -113,19 +113,19 @@ character_stats_results: {
   final_stats: 147
   final_stats: 38
   final_stats: 1
-  final_stats: 22.44633
+  final_stats: 22.43397
   final_stats: 0
   final_stats: 0
-  final_stats: 450.5
+  final_stats: 450
   final_stats: 1
   final_stats: 19
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 4957.87
+  final_stats: 4948.96
   final_stats: 0
   final_stats: 0
-  final_stats: 1981.406
+  final_stats: 1979.318
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -133,12 +133,12 @@ character_stats_results: {
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 4745.664
-  final_stats: 23.25
-  final_stats: 23.25
-  final_stats: 83.25
-  final_stats: 23.25
-  final_stats: 23.25
+  final_stats: 4724.28
+  final_stats: 23
+  final_stats: 23
+  final_stats: 83
+  final_stats: 23
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 85
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13515
+  weights: 0.29459
   weights: 0
-  weights: 0.287
-  weights: 0
-  weights: 0
+  weights: 0.28658
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.18005
   weights: 0
   weights: 0
-  weights: 0.3124
+  weights: 0.17913
+  weights: 0
+  weights: 0
+  weights: 0.29832
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.08049
+  weights: 0.25163
   weights: 0
-  weights: 0.69601
-  weights: 0
-  weights: 0
+  weights: 0.69596
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.69601
   weights: 0
-  weights: 0.08752
-  weights: 1.3832
+  weights: 0
+  weights: 0.69596
+  weights: 0
+  weights: 0.08059
+  weights: 1.38306
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13622
+  weights: 0.06764
   weights: 0
-  weights: 0.84608
-  weights: 0
-  weights: 0
+  weights: 0.84597
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.84608
   weights: 0
-  weights: 2.9584
-  weights: 4.74834
+  weights: 0
+  weights: 0.84597
+  weights: 0
+  weights: 2.88143
+  weights: 4.75652
   weights: 0
   weights: 0
   weights: 0
@@ -295,22 +295,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestShadow-Lvl25-Average-Default"
  value: {
-  dps: 138.51336
-  tps: 113.19199
+  dps: 138.35307
+  tps: 113.0348
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 140.67668
-  tps: 205.02945
+  dps: 140.23886
+  tps: 204.50461
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 140.67668
-  tps: 115.42335
+  dps: 140.23886
+  tps: 115.01346
  }
 }
 dps_results: {
@@ -344,15 +344,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 138.56038
-  tps: 201.74112
+  dps: 138.23631
+  tps: 201.33788
  }
 }
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 138.56038
-  tps: 113.28452
+  dps: 138.23631
+  tps: 112.99624
  }
 }
 dps_results: {
@@ -386,36 +386,36 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 138.56038
-  tps: 113.28452
+  dps: 138.23631
+  tps: 112.99624
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Average-Default"
  value: {
-  dps: 627.97649
-  tps: 496.90526
+  dps: 627.90957
+  tps: 496.81514
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 627.35694
-  tps: 716.22108
+  dps: 627.46541
+  tps: 715.72013
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 627.35694
-  tps: 496.58787
+  dps: 627.46541
+  tps: 496.49242
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 603.56732
-  tps: 481.18085
+  dps: 603.35031
+  tps: 480.99856
  }
 }
 dps_results: {
@@ -442,15 +442,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 626.96127
-  tps: 714.51419
+  dps: 627.26593
+  tps: 715.5338
  }
 }
 dps_results: {
  key: "TestShadow-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 626.96127
-  tps: 495.82949
+  dps: 627.26593
+  tps: 495.97678
  }
 }
 dps_results: {
@@ -484,23 +484,23 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 626.96127
-  tps: 495.82949
+  dps: 627.26593
+  tps: 495.97678
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Average-Default"
  value: {
-  dps: 1080.93078
-  tps: 873.91627
-  hps: 14.65683
+  dps: 1080.86551
+  tps: 873.8627
+  hps: 14.65667
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
   dps: 1079.85716
-  tps: 1186.99584
+  tps: 1186.99064
   hps: 15.06255
  }
 }
@@ -508,7 +508,7 @@ dps_results: {
  key: "TestShadow-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
   dps: 1079.85716
-  tps: 872.54583
+  tps: 872.54557
   hps: 15.06255
  }
 }
@@ -547,24 +547,24 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1078.65579
-  tps: 1190.62455
+  dps: 1078.50573
+  tps: 1190.53718
   hps: 15.05572
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1078.65579
-  tps: 871.79093
+  dps: 1078.50573
+  tps: 871.68725
   hps: 15.05572
  }
 }
 dps_results: {
  key: "TestShadow-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1096.15772
-  tps: 844.03434
+  dps: 1095.50115
+  tps: 843.48227
   hps: 15.67813
  }
 }
@@ -595,8 +595,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1078.65579
-  tps: 871.79093
+  dps: 1078.50573
+  tps: 871.68725
   hps: 15.05572
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2230
   final_stats: 0
   final_stats: 0
-  final_stats: 1423.55
+  final_stats: 1282.55
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 20
-  final_stats: 21
+  final_stats: 162
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 91.3
   final_stats: 49.5
-  final_stats: 287.1
+  final_stats: 221.1
   final_stats: 211.2
   final_stats: 166.1
   final_stats: 242
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3799
   final_stats: 0
   final_stats: 0
-  final_stats: 1688.75
+  final_stats: 1425.75
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 3328
+  final_stats: 2668
   final_stats: 21
   final_stats: 26
-  final_stats: 76
-  final_stats: 21
-  final_stats: 29
-  final_stats: 290
+  final_stats: 63
+  final_stats: 38
+  final_stats: 46
+  final_stats: 553
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 124.74
   final_stats: 138.996
-  final_stats: 393.228
+  final_stats: 286.308
   final_stats: 270.864
   final_stats: 219.78
   final_stats: 196
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 4948.96
   final_stats: 0
   final_stats: 0
-  final_stats: 1979.318
+  final_stats: 1655.318
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 3
   final_stats: 0
   final_stats: 0
-  final_stats: 4724.28
+  final_stats: 3655.08
   final_stats: 23
   final_stats: 23
-  final_stats: 83
-  final_stats: 23
-  final_stats: 23
-  final_stats: 0
+  final_stats: 63
+  final_stats: 48
+  final_stats: 48
+  final_stats: 324
   final_stats: 0
   final_stats: 85
   final_stats: 0

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2230
   final_stats: 0
   final_stats: 0
-  final_stats: 1282.55
+  final_stats: 363.8
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 20
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3799
   final_stats: 0
   final_stats: 0
-  final_stats: 1425.75
+  final_stats: 507
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2668
   final_stats: 21
-  final_stats: 26
-  final_stats: 63
+  final_stats: 43
+  final_stats: 33
   final_stats: 38
   final_stats: 46
-  final_stats: 553
+  final_stats: 1184.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 4948.96
   final_stats: 0
   final_stats: 0
-  final_stats: 1655.318
+  final_stats: 736.568
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3655.08
   final_stats: 23
-  final_stats: 23
-  final_stats: 63
+  final_stats: 33
   final_stats: 48
   final_stats: 48
-  final_stats: 324
+  final_stats: 48
+  final_stats: 1099
   final_stats: 0
   final_stats: 85
   final_stats: 0

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1847.15
+  final_stats: 928.4
   final_stats: 235.2
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 141
+  final_stats: 484.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2192.35
+  final_stats: 1273.6
   final_stats: 518.8
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3086
   final_stats: 18
-  final_stats: 13
-  final_stats: 70
+  final_stats: 30
+  final_stats: 40
   final_stats: 35
   final_stats: 40
-  final_stats: 263
+  final_stats: 894.25
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1988.15
+  final_stats: 1847.15
   final_stats: 235.2
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 0
+  final_stats: 141
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 215.6
   final_stats: 250.8
-  final_stats: 322.3
+  final_stats: 256.3
   final_stats: 61.6
   final_stats: 83.16
   final_stats: 42
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2455.35
+  final_stats: 2192.35
   final_stats: 518.8
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3746
+  final_stats: 3086
   final_stats: 18
   final_stats: 13
-  final_stats: 83
-  final_stats: 18
-  final_stats: 23
-  final_stats: 0
+  final_stats: 70
+  final_stats: 35
+  final_stats: 40
+  final_stats: 263
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestAssassination-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 110.44
-  final_stats: 167.64
-  final_stats: 143.11
-  final_stats: 45.54
-  final_stats: 59.367
+  final_stats: 110
+  final_stats: 167.2
+  final_stats: 141.9
+  final_stats: 45.1
+  final_stats: 58.905
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -18,24 +18,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 511.03
+  final_stats: 509.9
   final_stats: 2
-  final_stats: 22.95933
+  final_stats: 22.91744
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1989.78
-  final_stats: 235.64
+  final_stats: 1988.15
+  final_stats: 235.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1569.1
+  final_stats: 1557
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestAssassination-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 216.92
-  final_stats: 251.68
-  final_stats: 323.84
-  final_stats: 62.48
-  final_stats: 84.084
+  final_stats: 215.6
+  final_stats: 250.8
+  final_stats: 322.3
+  final_stats: 61.6
+  final_stats: 83.16
   final_stats: 42
   final_stats: 0
   final_stats: 0
@@ -67,29 +67,29 @@ character_stats_results: {
   final_stats: 9
   final_stats: 0
   final_stats: 0
-  final_stats: 910.71
+  final_stats: 908.3
   final_stats: 4
-  final_stats: 23.99341
+  final_stats: 23.94448
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2457.36
-  final_stats: 519.68
+  final_stats: 2455.35
+  final_stats: 518.8
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3761.4
-  final_stats: 18.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 18.5
-  final_stats: 23.5
+  final_stats: 3746
+  final_stats: 18
+  final_stats: 13
+  final_stats: 83
+  final_stats: 18
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestAssassination-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.33776
-  weights: 0.54934
+  weights: 0.33763
+  weights: 0.56485
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.30706
-  weights: 2.31706
-  weights: 2.32564
+  weights: 0.30694
+  weights: 2.30408
+  weights: 2.33808
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestAssassination-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.41322
-  weights: 0.7238
+  weights: 0.41315
+  weights: 0.6236
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37566
-  weights: 6.49674
-  weights: 4.14
+  weights: 0.37559
+  weights: 6.52739
+  weights: 4.13142
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestAssassination-Lvl25-Average-Default"
  value: {
-  dps: 293.03921
-  tps: 208.05784
+  dps: 292.58782
+  tps: 207.73735
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 147.91149
-  tps: 105.01716
+  dps: 147.7122
+  tps: 104.87567
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 147.91149
-  tps: 105.01716
+  dps: 147.7122
+  tps: 104.87567
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Human-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 157.35432
-  tps: 111.72156
+  dps: 157.1757
+  tps: 111.59475
  }
 }
 dps_results: {
@@ -246,22 +246,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 147.15738
-  tps: 104.48174
+  dps: 146.9898
+  tps: 104.36276
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 147.15738
-  tps: 104.48174
+  dps: 146.9898
+  tps: 104.36276
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl25-Settings-Orc-p1_daggers-No Poisons-mutilate-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 158.2889
-  tps: 112.38512
+  dps: 158.10237
+  tps: 112.25269
  }
 }
 dps_results: {
@@ -288,36 +288,36 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 277.82898
-  tps: 197.25858
+  dps: 277.47909
+  tps: 197.01015
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Average-Default"
  value: {
-  dps: 635.82875
-  tps: 451.43841
+  dps: 634.70159
+  tps: 450.63813
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 337.94475
-  tps: 239.94077
+  dps: 337.50338
+  tps: 239.6274
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 337.94475
-  tps: 239.94077
+  dps: 337.50338
+  tps: 239.6274
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 367.01318
-  tps: 260.57936
+  dps: 366.53032
+  tps: 260.23653
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 339.72411
-  tps: 241.20412
+  dps: 339.07769
+  tps: 240.74516
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 339.72411
-  tps: 241.20412
+  dps: 339.07769
+  tps: 240.74516
  }
 }
 dps_results: {
  key: "TestAssassination-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 372.54693
-  tps: 264.50832
+  dps: 372.01895
+  tps: 264.13346
  }
 }
 dps_results: {
@@ -386,7 +386,7 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 603.985
-  tps: 428.82935
+  dps: 603.05202
+  tps: 428.16694
  }
 }

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1988.15
+  final_stats: 1847.15
   final_stats: 235.2
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 0
+  final_stats: 141
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 215.6
   final_stats: 250.8
-  final_stats: 322.3
+  final_stats: 256.3
   final_stats: 61.6
   final_stats: 83.16
   final_stats: 42
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2455.35
+  final_stats: 2192.35
   final_stats: 518.8
   final_stats: 0
   final_stats: 0
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 5
   final_stats: 0
   final_stats: 0
-  final_stats: 3746
+  final_stats: 3086
   final_stats: 18
   final_stats: 13
-  final_stats: 83
-  final_stats: 18
-  final_stats: 23
-  final_stats: 0
+  final_stats: 70
+  final_stats: 35
+  final_stats: 40
+  final_stats: 263
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestCombat-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 110.44
-  final_stats: 167.64
-  final_stats: 143.11
-  final_stats: 45.54
-  final_stats: 59.367
+  final_stats: 110
+  final_stats: 167.2
+  final_stats: 141.9
+  final_stats: 45.1
+  final_stats: 58.905
   final_stats: 25
   final_stats: 0
   final_stats: 0
@@ -18,24 +18,24 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 511.03
+  final_stats: 509.9
   final_stats: 7
-  final_stats: 17.95933
+  final_stats: 17.91744
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1989.78
-  final_stats: 235.64
+  final_stats: 1988.15
+  final_stats: 235.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 5
   final_stats: 0
   final_stats: 0
-  final_stats: 1569.1
+  final_stats: 1557
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestCombat-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 216.92
-  final_stats: 251.68
-  final_stats: 323.84
-  final_stats: 62.48
-  final_stats: 84.084
+  final_stats: 215.6
+  final_stats: 250.8
+  final_stats: 322.3
+  final_stats: 61.6
+  final_stats: 83.16
   final_stats: 42
   final_stats: 0
   final_stats: 0
@@ -67,29 +67,29 @@ character_stats_results: {
   final_stats: 9
   final_stats: 0
   final_stats: 0
-  final_stats: 910.71
+  final_stats: 908.3
   final_stats: 9
-  final_stats: 23.99341
+  final_stats: 23.94448
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2457.36
-  final_stats: 519.68
+  final_stats: 2455.35
+  final_stats: 518.8
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 5
   final_stats: 0
   final_stats: 0
-  final_stats: 3761.4
-  final_stats: 18.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 18.5
-  final_stats: 23.5
+  final_stats: 3746
+  final_stats: 18
+  final_stats: 13
+  final_stats: 83
+  final_stats: 18
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestCombat-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.24471
-  weights: 0.4595
+  weights: 0.24462
+  weights: 0.45263
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22246
-  weights: 1.66793
-  weights: 1.76792
+  weights: 0.22238
+  weights: 1.66957
+  weights: 1.75331
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestCombat-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.38904
-  weights: 0.63813
+  weights: 0.38891
+  weights: 0.63213
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.35367
-  weights: 3.49404
-  weights: 4.03813
+  weights: 0.35355
+  weights: 3.46923
+  weights: 4.03294
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestCombat-Lvl25-Average-Default"
  value: {
-  dps: 207.4125
-  tps: 147.26287
+  dps: 207.08722
+  tps: 147.03193
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 49.75008
-  tps: 35.32256
+  dps: 49.69407
+  tps: 35.28279
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 49.75008
-  tps: 35.32256
+  dps: 49.69407
+  tps: 35.28279
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Human-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 52.51764
-  tps: 37.28753
+  dps: 52.45832
+  tps: 37.24541
  }
 }
 dps_results: {
@@ -246,22 +246,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 49.64858
-  tps: 35.25049
+  dps: 49.5927
+  tps: 35.21082
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 49.64858
-  tps: 35.25049
+  dps: 49.5927
+  tps: 35.21082
  }
 }
 dps_results: {
  key: "TestCombat-Lvl25-Settings-Orc-p1_combat-No Poisons-basic_strike_25-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 52.33827
-  tps: 37.16017
+  dps: 52.27912
+  tps: 37.11818
  }
 }
 dps_results: {
@@ -288,36 +288,36 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 195.43849
-  tps: 138.76132
+  dps: 195.13533
+  tps: 138.54608
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Average-Default"
  value: {
-  dps: 575.00453
-  tps: 408.25321
+  dps: 573.943
+  tps: 407.49953
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 262.37235
-  tps: 186.28437
+  dps: 262.03012
+  tps: 186.04138
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 227.88942
-  tps: 161.80149
+  dps: 227.59385
+  tps: 161.59163
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 302.65496
-  tps: 214.88502
+  dps: 302.25727
+  tps: 214.60266
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 265.52388
-  tps: 188.52196
+  dps: 265.15794
+  tps: 188.26214
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 228.39443
-  tps: 162.16004
+  dps: 228.08717
+  tps: 161.94189
  }
 }
 dps_results: {
  key: "TestCombat-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 302.00831
-  tps: 214.4259
+  dps: 301.58055
+  tps: 214.12219
  }
 }
 dps_results: {
@@ -386,7 +386,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 552.91981
-  tps: 392.57306
+  dps: 551.90817
+  tps: 391.8548
  }
 }

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1847.15
+  final_stats: 928.4
   final_stats: 235.2
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 141
+  final_stats: 484.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2192.35
+  final_stats: 1273.6
   final_stats: 518.8
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3086
   final_stats: 18
-  final_stats: 13
-  final_stats: 70
+  final_stats: 30
+  final_stats: 40
   final_stats: 35
   final_stats: 40
-  final_stats: 263
+  final_stats: 894.25
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestElemental-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 81.84
-  final_stats: 44.44
-  final_stats: 154.11
-  final_stats: 136.84
-  final_stats: 109.34
+  final_stats: 81.4
+  final_stats: 44
+  final_stats: 152.9
+  final_stats: 136.4
+  final_stats: 108.9
   final_stats: 147
   final_stats: 0
   final_stats: 19
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 39
   final_stats: 6
-  final_stats: 8.07465
+  final_stats: 8.05608
   final_stats: 0
   final_stats: 10
-  final_stats: 346.33
+  final_stats: 345.2
   final_stats: 1
-  final_stats: 8.01512
+  final_stats: 7.9724
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2277.6
+  final_stats: 2271
   final_stats: 0
   final_stats: 0
-  final_stats: 1662.38
+  final_stats: 1660.75
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 1618.1
+  final_stats: 1606
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestElemental-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 130.02
-  final_stats: 60.28
-  final_stats: 319.44
-  final_stats: 209.88
-  final_stats: 133.98
+  final_stats: 128.7
+  final_stats: 59.4
+  final_stats: 317.9
+  final_stats: 209
+  final_stats: 133.1
   final_stats: 268
   final_stats: 0
   final_stats: 10
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 69.75
   final_stats: 4
-  final_stats: 14.79886
+  final_stats: 14.7758
   final_stats: 0
   final_stats: 0
-  final_stats: 630.01
+  final_stats: 627.2
   final_stats: 4
-  final_stats: 9.02208
+  final_stats: 8.95898
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3843.2
+  final_stats: 3830
   final_stats: 0
   final_stats: 0
-  final_stats: 2833.56
+  final_stats: 2831.55
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 3624.4
-  final_stats: 21.5
-  final_stats: 26.5
-  final_stats: 76.5
-  final_stats: 21.5
-  final_stats: 26.5
+  final_stats: 3609
+  final_stats: 21
+  final_stats: 26
+  final_stats: 76
+  final_stats: 21
+  final_stats: 26
   final_stats: 70
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestElemental-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 242.2332
-  final_stats: 154.3806
-  final_stats: 453.5784
-  final_stats: 309.474
-  final_stats: 200.178
+  final_stats: 241.164
+  final_stats: 153.252
+  final_stats: 451.44
+  final_stats: 308.88
+  final_stats: 199.584
   final_stats: 238
   final_stats: 0
   final_stats: 40
@@ -113,19 +113,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 69.5
   final_stats: 5
-  final_stats: 26.73706
+  final_stats: 26.7247
   final_stats: 0
   final_stats: 0
-  final_stats: 1009.4
+  final_stats: 1006.912
   final_stats: 5
-  final_stats: 30.40504
+  final_stats: 30.3424
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 5897.9655
+  final_stats: 5888.61
   final_stats: 0
   final_stats: 0
-  final_stats: 3037.918
+  final_stats: 3035.83
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -133,12 +133,12 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 5302.784
-  final_stats: 23.25
-  final_stats: 33.25
-  final_stats: 83.25
-  final_stats: 23.25
-  final_stats: 23.25
+  final_stats: 5281.4
+  final_stats: 23
+  final_stats: 33
+  final_stats: 83
+  final_stats: 23
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 285
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.01786
+  weights: 0.02401
   weights: 0
-  weights: 0.51964
+  weights: 0.51961
   weights: 0
   weights: 0.21054
   weights: 0
   weights: 0
-  weights: 0.3091
+  weights: 0.30908
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.52525
+  weights: 0.52354
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.028
+  weights: 0.78915
   weights: 0
-  weights: 0.87043
+  weights: 0.86783
   weights: 0
-  weights: 0.27834
-  weights: 0
-  weights: 0
-  weights: 0.59209
+  weights: 0.27824
   weights: 0
   weights: 0
-  weights: 7.5352
-  weights: 3.54229
+  weights: 0.5896
+  weights: 0
+  weights: 0
+  weights: 8.02694
+  weights: 3.6404
   weights: 0
   weights: 0
   weights: 0
@@ -249,7 +249,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.26915
+  weights: 0
   weights: 0
   weights: 1.11529
   weights: 0
@@ -260,7 +260,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.28495
+  weights: 6.33882
   weights: 0
   weights: 0
   weights: 0
@@ -295,29 +295,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-Lvl25-Average-Default"
  value: {
-  dps: 190.24604
-  tps: 155.31772
+  dps: 190.22285
+  tps: 155.2953
  }
 }
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Orc-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 181.07979
-  tps: 319.20875
+  dps: 181.07642
+  tps: 319.20456
  }
 }
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Orc-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 181.07979
-  tps: 146.72488
+  dps: 181.07642
+  tps: 146.72467
  }
 }
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Orc-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 186.5929
-  tps: 149.85907
+  tps: 149.85929
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Troll-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 181.07008
-  tps: 319.19535
+  dps: 181.04151
+  tps: 319.12474
  }
 }
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Troll-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 181.07008
-  tps: 146.72421
+  dps: 181.04151
+  tps: 146.69353
  }
 }
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Troll-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 186.5929
-  tps: 149.85184
+  tps: 149.84464
  }
 }
 dps_results: {
@@ -386,36 +386,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 189.1081
-  tps: 154.50488
+  dps: 189.06721
+  tps: 154.46166
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Average-Default"
  value: {
-  dps: 641.1284
-  tps: 550.4111
+  dps: 640.64963
+  tps: 549.74779
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 716.98901
-  tps: 1165.68488
+  dps: 715.0641
+  tps: 1161.87269
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 595.55323
-  tps: 506.91422
+  dps: 596.04747
+  tps: 508.70817
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 638.88722
-  tps: 549.45804
+  tps: 549.12216
  }
 }
 dps_results: {
@@ -442,22 +442,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 722.52179
-  tps: 1182.49034
+  dps: 720.15034
+  tps: 1173.0339
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 597.20374
-  tps: 509.39296
+  dps: 589.26682
+  tps: 501.53725
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 670.55738
-  tps: 583.40989
+  dps: 669.97246
+  tps: 581.64399
  }
 }
 dps_results: {
@@ -484,36 +484,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 641.9673
-  tps: 551.78941
+  dps: 639.26942
+  tps: 548.80733
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Average-Default"
  value: {
-  dps: 1364.20247
-  tps: 1215.90713
+  dps: 1364.03916
+  tps: 1215.7362
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2762.41714
-  tps: 3244.82524
+  dps: 2762.32448
+  tps: 3244.58451
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
   dps: 1269.14767
-  tps: 1126.56958
+  tps: 1126.56447
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Orc-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 1337.06347
-  tps: 1223.162
+  tps: 1223.15118
  }
 }
 dps_results: {
@@ -540,22 +540,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2782.54795
-  tps: 3293.79427
+  dps: 2782.47163
+  tps: 3293.44949
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
   dps: 1282.34358
-  tps: 1139.02689
+  tps: 1139.02118
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 1352.5583
-  tps: 1239.29202
+  tps: 1239.28409
  }
 }
 dps_results: {
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1352.40226
-  tps: 1204.85441
+  dps: 1352.3366
+  tps: 1204.68943
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.63707
+  weights: 0.63923
   weights: 0
-  weights: 0.86771
+  weights: 0.8678
   weights: 0
-  weights: 0.27811
-  weights: 0
-  weights: 0
-  weights: 0.5896
+  weights: 0.27799
   weights: 0
   weights: 0
-  weights: 7.93841
-  weights: 3.49627
+  weights: 0.58981
+  weights: 0
+  weights: 0
+  weights: 7.97386
+  weights: 3.47819
   weights: 0
   weights: 0
   weights: 0
@@ -251,16 +251,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.1194
+  weights: 1.1201
   weights: 0
-  weights: 0.37368
-  weights: 0
-  weights: 0
-  weights: 0.74572
+  weights: 0.37389
   weights: 0
   weights: 0
+  weights: 0.74621
   weights: 0
-  weights: 5.72016
+  weights: 0
+  weights: 0
+  weights: 5.78169
   weights: 0
   weights: 0
   weights: 0
@@ -393,8 +393,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Average-Default"
  value: {
-  dps: 640.60072
-  tps: 549.70243
+  dps: 640.68423
+  tps: 549.75517
  }
 }
 dps_results: {
@@ -442,22 +442,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 717.74813
-  tps: 1169.81097
+  dps: 717.76243
+  tps: 1169.82139
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 592.84401
-  tps: 505.37219
+  dps: 593.02642
+  tps: 505.49324
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 668.75003
-  tps: 581.60456
+  dps: 667.98078
+  tps: 580.72853
  }
 }
 dps_results: {
@@ -484,15 +484,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 640.56121
-  tps: 549.94769
+  dps: 640.2933
+  tps: 549.76289
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Average-Default"
  value: {
-  dps: 1365.08045
-  tps: 1216.91955
+  dps: 1365.35469
+  tps: 1217.17427
  }
 }
 dps_results: {
@@ -540,22 +540,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2783.54307
-  tps: 3295.98035
+  dps: 2784.41615
+  tps: 3296.75351
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1283.07811
-  tps: 1138.0072
+  dps: 1282.66848
+  tps: 1137.57346
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1357.57361
-  tps: 1246.15601
+  dps: 1355.82863
+  tps: 1244.23389
  }
 }
 dps_results: {
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1353.01544
-  tps: 1205.84106
+  dps: 1353.27178
+  tps: 1205.89641
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2271
   final_stats: 0
   final_stats: 0
-  final_stats: 1660.75
+  final_stats: 1085.75
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 15
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 22
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3830
   final_stats: 0
   final_stats: 0
-  final_stats: 2831.55
+  final_stats: 2544.05
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2949
   final_stats: 21
-  final_stats: 26
-  final_stats: 63
+  final_stats: 43
+  final_stats: 33
   final_stats: 38
   final_stats: 43
-  final_stats: 333
+  final_stats: 964.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 5888.61
   final_stats: 0
   final_stats: 0
-  final_stats: 3035.83
+  final_stats: 2892.08
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 4212.2
   final_stats: 23
-  final_stats: 33
-  final_stats: 63
+  final_stats: 43
   final_stats: 48
   final_stats: 48
-  final_stats: 324
+  final_stats: 48
+  final_stats: 1099
   final_stats: 0
   final_stats: 285
   final_stats: 0

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 15
-  final_stats: 21
+  final_stats: 162
   final_stats: 22
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 128.7
   final_stats: 59.4
-  final_stats: 317.9
+  final_stats: 251.9
   final_stats: 209
   final_stats: 133.1
   final_stats: 268
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 3609
+  final_stats: 2949
   final_stats: 21
   final_stats: 26
-  final_stats: 76
-  final_stats: 21
-  final_stats: 26
-  final_stats: 70
+  final_stats: 63
+  final_stats: 38
+  final_stats: 43
+  final_stats: 333
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 241.164
   final_stats: 153.252
-  final_stats: 451.44
+  final_stats: 344.52
   final_stats: 308.88
   final_stats: 199.584
   final_stats: 238
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 5281.4
+  final_stats: 4212.2
   final_stats: 23
   final_stats: 33
-  final_stats: 83
-  final_stats: 23
-  final_stats: 23
-  final_stats: 0
+  final_stats: 63
+  final_stats: 48
+  final_stats: 48
+  final_stats: 324
   final_stats: 0
   final_stats: 285
   final_stats: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.78915
+  weights: 0.63707
   weights: 0
-  weights: 0.86783
+  weights: 0.86771
   weights: 0
-  weights: 0.27824
+  weights: 0.27811
   weights: 0
   weights: 0
   weights: 0.5896
   weights: 0
   weights: 0
-  weights: 8.02694
-  weights: 3.6404
+  weights: 7.93841
+  weights: 3.49627
   weights: 0
   weights: 0
   weights: 0
@@ -251,16 +251,16 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.11529
+  weights: 1.1194
   weights: 0
-  weights: 0.37395
-  weights: 0
-  weights: 0
-  weights: 0.74133
+  weights: 0.37368
   weights: 0
   weights: 0
+  weights: 0.74572
   weights: 0
-  weights: 6.33882
+  weights: 0
+  weights: 0
+  weights: 5.72016
   weights: 0
   weights: 0
   weights: 0
@@ -393,8 +393,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Average-Default"
  value: {
-  dps: 640.64963
-  tps: 549.74779
+  dps: 640.60072
+  tps: 549.70243
  }
 }
 dps_results: {
@@ -442,22 +442,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 720.15034
-  tps: 1173.0339
+  dps: 717.74813
+  tps: 1169.81097
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 589.26682
-  tps: 501.53725
+  dps: 592.84401
+  tps: 505.37219
  }
 }
 dps_results: {
  key: "TestElemental-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 669.97246
-  tps: 581.64399
+  dps: 668.75003
+  tps: 581.60456
  }
 }
 dps_results: {
@@ -484,15 +484,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 639.26942
-  tps: 548.80733
+  dps: 640.56121
+  tps: 549.94769
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Average-Default"
  value: {
-  dps: 1364.03916
-  tps: 1215.7362
+  dps: 1365.08045
+  tps: 1216.91955
  }
 }
 dps_results: {
@@ -540,22 +540,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2782.47163
-  tps: 3293.44949
+  dps: 2783.54307
+  tps: 3295.98035
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1282.34358
-  tps: 1139.02118
+  dps: 1283.07811
+  tps: 1138.0072
  }
 }
 dps_results: {
  key: "TestElemental-Lvl50-Settings-Troll-phase_3-Adaptive-phase_3-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1352.5583
-  tps: 1239.28409
+  dps: 1357.57361
+  tps: 1246.15601
  }
 }
 dps_results: {
@@ -582,7 +582,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1352.3366
-  tps: 1204.68943
+  dps: 1353.01544
+  tps: 1205.84106
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 70
+  final_stats: 211
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 174.9
   final_stats: 171.6
-  final_stats: 327.8
+  final_stats: 261.8
   final_stats: 136.4
   final_stats: 124.3
   final_stats: 42
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 3708
+  final_stats: 3048
   final_stats: 18
   final_stats: 13
-  final_stats: 83
-  final_stats: 18
-  final_stats: 23
+  final_stats: 70
+  final_stats: 35
   final_stats: 40
+  final_stats: 303
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 367.092
   final_stats: 264.924
-  final_stats: 478.764
+  final_stats: 371.844
   final_stats: 238.788
   final_stats: 181.764
   final_stats: 0
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 5554.64
+  final_stats: 4485.44
   final_stats: 20
   final_stats: 20
-  final_stats: 80
-  final_stats: 20
-  final_stats: 20
-  final_stats: 0
+  final_stats: 60
+  final_stats: 45
+  final_stats: 45
+  final_stats: 324
   final_stats: 0
   final_stats: 79
   final_stats: 0
@@ -197,16 +197,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl40-StatWeights-Default"
  value: {
-  weights: 1.04254
-  weights: 0.84671
+  weights: 1.04402
+  weights: 0.85308
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43276
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.43202
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +210,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.47388
-  weights: 3.68116
-  weights: 8.78943
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.47456
+  weights: 4.89135
+  weights: 6.96708
   weights: 0
   weights: 0
   weights: 0
@@ -477,8 +477,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
-  dps: 873.0946
-  tps: 924.77103
+  dps: 873.63545
+  tps: 925.34632
  }
 }
 dps_results: {
@@ -652,8 +652,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 807.97664
-  tps: 856.43722
+  dps: 808.1577
+  tps: 855.76074
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 1206.45
   final_stats: 0
   final_stats: 0
-  final_stats: 1982.35
+  final_stats: 1407.35
   final_stats: 74
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 10
-  final_stats: 211
+  final_stats: 554.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 2878.05
   final_stats: 0
   final_stats: 0
-  final_stats: 2962.95
+  final_stats: 2675.45
   final_stats: 398
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3048
   final_stats: 18
-  final_stats: 13
-  final_stats: 70
+  final_stats: 30
+  final_stats: 40
   final_stats: 35
   final_stats: 40
-  final_stats: 303
+  final_stats: 934.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 4784.661
   final_stats: 0
   final_stats: 0
-  final_stats: 3688.174
+  final_stats: 3544.424
   final_stats: 511
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 4485.44
   final_stats: 20
-  final_stats: 20
-  final_stats: 60
+  final_stats: 30
   final_stats: 45
   final_stats: 45
-  final_stats: 324
+  final_stats: 45
+  final_stats: 1099
   final_stats: 0
   final_stats: 79
   final_stats: 0

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -197,16 +197,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl40-StatWeights-Default"
  value: {
-  weights: 1.04402
-  weights: 0.85308
+  weights: 1.04539
+  weights: 0.78827
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43202
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.43274
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +210,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.47456
-  weights: 4.89135
-  weights: 6.96708
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.47518
+  weights: 4.56796
+  weights: 7.13017
   weights: 0
   weights: 0
   weights: 0
@@ -477,8 +477,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
-  dps: 873.63545
-  tps: 925.34632
+  dps: 873.89202
+  tps: 925.53887
  }
 }
 dps_results: {
@@ -652,8 +652,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 808.1577
-  tps: 855.76074
+  dps: 810.16619
+  tps: 857.81961
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestEnhancement-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 141.24
-  final_stats: 130.24
-  final_stats: 149.71
-  final_stats: 62.04
-  final_stats: 68.64
+  final_stats: 140.8
+  final_stats: 129.8
+  final_stats: 148.5
+  final_stats: 61.6
+  final_stats: 68.2
   final_stats: 25
   final_stats: 0
   final_stats: 10
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 22
   final_stats: 14
-  final_stats: 4.91809
+  final_stats: 4.89952
   final_stats: 0
   final_stats: 0
-  final_stats: 558.73
+  final_stats: 557.6
   final_stats: 11
-  final_stats: 21.3463
+  final_stats: 21.30358
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 1213.38
+  final_stats: 1206.45
   final_stats: 0
   final_stats: 0
-  final_stats: 1983.98
+  final_stats: 1982.35
   final_stats: 74
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 1574.1
+  final_stats: 1562
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestEnhancement-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 176.22
-  final_stats: 172.48
-  final_stats: 329.34
-  final_stats: 137.28
-  final_stats: 125.18
+  final_stats: 174.9
+  final_stats: 171.6
+  final_stats: 327.8
+  final_stats: 136.4
+  final_stats: 124.3
   final_stats: 42
   final_stats: 0
   final_stats: 10
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 34
   final_stats: 14
-  final_stats: 14.89674
+  final_stats: 14.87368
   final_stats: 0
   final_stats: 0
-  final_stats: 920.41
+  final_stats: 917.6
   final_stats: 14
-  final_stats: 24.06682
+  final_stats: 24.00372
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2891.91
+  final_stats: 2878.05
   final_stats: 0
   final_stats: 0
-  final_stats: 2964.96
+  final_stats: 2962.95
   final_stats: 398
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 3723.4
-  final_stats: 18.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 18.5
-  final_stats: 23.5
+  final_stats: 3708
+  final_stats: 18
+  final_stats: 13
+  final_stats: 83
+  final_stats: 18
+  final_stats: 23
   final_stats: 40
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestEnhancement-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 368.1612
-  final_stats: 266.0526
-  final_stats: 480.9024
-  final_stats: 239.382
-  final_stats: 182.358
+  final_stats: 367.092
+  final_stats: 264.924
+  final_stats: 478.764
+  final_stats: 238.788
+  final_stats: 181.764
   final_stats: 0
   final_stats: 0
   final_stats: 10
@@ -113,19 +113,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 36
   final_stats: 11
-  final_stats: 23.27915
+  final_stats: 23.26679
   final_stats: 0
   final_stats: 0
-  final_stats: 1492.256
+  final_stats: 1489.768
   final_stats: 12
-  final_stats: 38.10536
+  final_stats: 38.04272
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 4794.0165
+  final_stats: 4784.661
   final_stats: 0
   final_stats: 0
-  final_stats: 3690.262
+  final_stats: 3688.174
   final_stats: 511
   final_stats: 0
   final_stats: 0
@@ -133,12 +133,12 @@ character_stats_results: {
   final_stats: 1.7
   final_stats: 0
   final_stats: 0
-  final_stats: 5576.024
-  final_stats: 20.25
-  final_stats: 20.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 20.25
+  final_stats: 5554.64
+  final_stats: 20
+  final_stats: 20
+  final_stats: 80
+  final_stats: 20
+  final_stats: 20
   final_stats: 0
   final_stats: 0
   final_stats: 79
@@ -148,16 +148,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.3629
-  weights: 0.20505
+  weights: 0.36273
+  weights: 0.17909
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.12621
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.12619
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.16496
-  weights: 1.26191
-  weights: 1.67864
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.16488
+  weights: 1.25965
+  weights: 1.66941
   weights: 0
   weights: 0
   weights: 0
@@ -197,16 +197,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl40-StatWeights-Default"
  value: {
-  weights: 1.04448
-  weights: 0.57095
+  weights: 1.04254
+  weights: 0.84671
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43272
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.43276
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +210,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.47476
-  weights: 2.77061
-  weights: 8.30315
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.47388
+  weights: 3.68116
+  weights: 8.78943
   weights: 0
   weights: 0
   weights: 0
@@ -246,8 +246,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.59142
-  weights: 0.85632
+  weights: 1.59077
+  weights: 1.04893
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.66979
-  weights: 8.9746
-  weights: 11.84767
+  weights: 0.66952
+  weights: 8.86447
+  weights: 12.19382
   weights: 0
   weights: 0
   weights: 0
@@ -295,29 +295,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestEnhancement-Lvl25-Average-Default"
  value: {
-  dps: 171.72796
-  tps: 170.75396
+  dps: 171.4641
+  tps: 170.45632
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Auto-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 53.91819
-  tps: 185.3134
+  dps: 53.8839
+  tps: 185.08853
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Auto-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 53.91819
-  tps: 52.9713
+  dps: 53.8839
+  tps: 52.92748
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Auto-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 55.8802
-  tps: 52.30595
+  dps: 55.84372
+  tps: 52.26948
  }
 }
 dps_results: {
@@ -344,22 +344,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 53.91819
-  tps: 185.3134
+  dps: 53.8839
+  tps: 185.08853
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 53.91819
-  tps: 52.9713
+  dps: 53.8839
+  tps: 52.92748
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Orc-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 55.8802
-  tps: 52.30595
+  dps: 55.84372
+  tps: 52.26948
  }
 }
 dps_results: {
@@ -386,22 +386,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Auto-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 53.59064
-  tps: 183.86613
+  dps: 53.53054
+  tps: 183.11303
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Auto-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 53.59064
-  tps: 52.58935
+  dps: 53.53054
+  tps: 52.4946
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Auto-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 55.36807
-  tps: 51.79382
+  dps: 55.33277
+  tps: 51.75852
  }
 }
 dps_results: {
@@ -428,22 +428,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 53.59064
-  tps: 183.86613
+  dps: 53.53054
+  tps: 183.11303
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 53.59064
-  tps: 52.58935
+  dps: 53.53054
+  tps: 52.4946
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl25-Settings-Troll-phase_1-Sync Delay OH-phase_1-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 55.36807
-  tps: 51.79382
+  dps: 55.33277
+  tps: 51.75852
  }
 }
 dps_results: {
@@ -470,371 +470,371 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 161.26078
-  tps: 160.25949
+  dps: 161.06448
+  tps: 160.02854
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Average-Default"
  value: {
-  dps: 874.94315
-  tps: 926.62598
+  dps: 873.0946
+  tps: 924.77103
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 404.23361
-  tps: 456.92492
+  dps: 403.689
+  tps: 456.47375
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 322.33632
-  tps: 370.81406
+  dps: 321.9424
+  tps: 370.51882
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 398.73485
-  tps: 451.75447
+  dps: 398.19629
+  tps: 451.19134
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 242.76783
-  tps: 284.0768
+  dps: 242.65786
+  tps: 283.96263
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 197.09572
-  tps: 235.59797
+  dps: 197.01721
+  tps: 235.51636
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 237.28202
-  tps: 278.20447
+  dps: 237.17548
+  tps: 278.09385
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 404.23361
-  tps: 456.92492
+  dps: 403.689
+  tps: 456.47375
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 322.33632
-  tps: 370.81406
+  dps: 321.9424
+  tps: 370.51882
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 398.73485
-  tps: 451.75447
+  dps: 398.19629
+  tps: 451.19134
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 242.76783
-  tps: 284.0768
+  dps: 242.65786
+  tps: 283.96263
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 197.09572
-  tps: 235.59797
+  dps: 197.01721
+  tps: 235.51636
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Orc-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 237.28202
-  tps: 278.20447
+  dps: 237.17548
+  tps: 278.09385
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 412.77284
-  tps: 465.94521
+  dps: 412.23572
+  tps: 465.27709
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 332.48356
-  tps: 381.53332
+  dps: 332.09074
+  tps: 381.01212
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 410.98659
-  tps: 464.8163
+  dps: 410.44806
+  tps: 464.19492
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 246.98561
-  tps: 288.37979
+  dps: 246.87796
+  tps: 288.26821
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 202.41132
-  tps: 241.1484
+  dps: 202.3336
+  tps: 241.06782
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Auto-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 243.11785
-  tps: 284.1458
+  dps: 243.01206
+  tps: 284.03625
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 412.77284
-  tps: 465.94521
+  dps: 412.23572
+  tps: 465.27709
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 332.48356
-  tps: 381.53332
+  dps: 332.09074
+  tps: 381.01212
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-FullBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 410.98659
-  tps: 464.8163
+  dps: 410.44806
+  tps: 464.19492
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 246.98561
-  tps: 288.37979
+  dps: 246.87796
+  tps: 288.26821
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 202.41132
-  tps: 241.1484
+  dps: 202.3336
+  tps: 241.06782
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-Settings-Troll-phase_2-Sync Delay OH-phase_2-NoBuffs-Phase 2 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 243.11785
-  tps: 284.1458
+  dps: 243.01206
+  tps: 284.03625
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 810.74623
-  tps: 859.18824
+  dps: 807.97664
+  tps: 856.43722
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Average-Default"
  value: {
-  dps: 1829.77195
-  tps: 1346.35521
+  dps: 1826.9549
+  tps: 1344.36206
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 900.07361
-  tps: 681.67542
+  dps: 899.09654
+  tps: 680.99214
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 733.58814
-  tps: 563.94509
+  dps: 732.8418
+  tps: 563.42276
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 903.19726
-  tps: 685.05297
+  dps: 902.23009
+  tps: 684.37749
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 461.81887
-  tps: 367.54113
+  dps: 461.64271
+  tps: 367.41569
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 391.23584
-  tps: 317.45778
+  dps: 391.09899
+  tps: 317.36005
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 469.83181
-  tps: 373.25728
+  dps: 469.65586
+  tps: 373.13199
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 900.07361
-  tps: 681.67542
+  dps: 899.09654
+  tps: 680.99214
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 733.58814
-  tps: 563.94509
+  dps: 732.8418
+  tps: 563.42276
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 903.19726
-  tps: 685.05297
+  dps: 902.23009
+  tps: 684.37749
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 461.81887
-  tps: 367.54113
+  dps: 461.64271
+  tps: 367.41569
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 391.23584
-  tps: 317.45778
+  dps: 391.09899
+  tps: 317.36005
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 469.83181
-  tps: 373.25728
+  dps: 469.65586
+  tps: 373.13199
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 912.35853
-  tps: 690.28556
+  dps: 910.88115
+  tps: 689.247
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 748.68357
-  tps: 573.11
+  dps: 747.39963
+  tps: 572.21027
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 920.72684
-  tps: 696.6889
+  dps: 919.38164
+  tps: 695.74435
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 467.76505
-  tps: 370.61517
+  dps: 467.59284
+  tps: 370.49264
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 395.9523
-  tps: 317.68632
+  dps: 395.81788
+  tps: 317.59081
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 474.66197
-  tps: 373.76101
+  dps: 474.48967
+  tps: 373.63878
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 912.35853
-  tps: 690.28556
+  dps: 910.88115
+  tps: 689.247
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 748.68357
-  tps: 573.11
+  dps: 747.39963
+  tps: 572.21027
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-FullBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 920.72684
-  tps: 696.6889
+  dps: 919.38164
+  tps: 695.74435
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/FT-ShortSingleTarget"
  value: {
-  dps: 467.76505
-  tps: 370.61517
+  dps: 467.59284
+  tps: 370.49264
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/RB-ShortSingleTarget"
  value: {
-  dps: 395.9523
-  tps: 317.68632
+  dps: 395.81788
+  tps: 317.59081
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Troll-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
-  dps: 474.66197
-  tps: 373.76101
+  dps: 474.48967
+  tps: 373.63878
  }
 }
 dps_results: {
  key: "TestEnhancement-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1700.44863
-  tps: 1253.84659
+  dps: 1697.58473
+  tps: 1251.7169
  }
 }

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 4025.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2253.95
+  final_stats: 1966.45
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2203
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 52
   final_stats: 49
-  final_stats: 453
+  final_stats: 1084.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 6514.12
   final_stats: 0
   final_stats: 0
-  final_stats: 2487.446
+  final_stats: 2343.696
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3852.16
   final_stats: 20
-  final_stats: 20
-  final_stats: 60
+  final_stats: 30
+  final_stats: 45
   final_stats: 45
   final_stats: 57
-  final_stats: 324
+  final_stats: 1099
   final_stats: 0
   final_stats: 100
   final_stats: 0

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 93.5
   final_stats: 39.6
-  final_stats: 240.9
+  final_stats: 174.9
   final_stats: 225.5
   final_stats: 182.6
   final_stats: 283
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 2863
+  final_stats: 2203
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 35
-  final_stats: 32
-  final_stats: 190
+  final_stats: 60
+  final_stats: 52
+  final_stats: 49
+  final_stats: 453
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 135.432
   final_stats: 142.56
-  final_stats: 412.236
+  final_stats: 305.316
   final_stats: 375.408
   final_stats: 249.48
   final_stats: 268
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 4921.36
+  final_stats: 3852.16
   final_stats: 20
   final_stats: 20
-  final_stats: 80
-  final_stats: 20
-  final_stats: 32
-  final_stats: 0
+  final_stats: 60
+  final_stats: 45
+  final_stats: 57
+  final_stats: 324
   final_stats: 0
   final_stats: 100
   final_stats: 0
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.11119
+  weights: -0.14218
   weights: 0
-  weights: 0.58069
-  weights: 0
-  weights: 0
+  weights: 0.62902
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.24937
-  weights: 1.60052
+  weights: 0
+  weights: 0
+  weights: 3.64568
+  weights: 1.78293
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.50339
+  weights: 2.2968
   weights: 0
-  weights: 0.85507
-  weights: 0
-  weights: 0
+  weights: 0.75365
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 14.31704
-  weights: 8.20918
+  weights: 0
+  weights: 0
+  weights: 12.28448
+  weights: 8.02564
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-Average-Default"
  value: {
-  dps: 600.43096
-  tps: 568.91609
+  dps: 589.02381
+  tps: 558.31485
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 594.2872
-  tps: 1195.20746
+  dps: 585.30386
+  tps: 1187.38523
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 594.2872
-  tps: 562.99175
+  dps: 585.30386
+  tps: 554.19023
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 586.5625
-  tps: 544.42184
+  dps: 575.10165
+  tps: 534.11193
  }
 }
 dps_results: {
@@ -246,36 +246,36 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 603.44748
-  tps: 571.69085
+  dps: 589.59543
+  tps: 558.41429
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1407.32682
-  tps: 1178.11562
+  dps: 1376.85817
+  tps: 1152.25445
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2009.87197
-  tps: 2734.00877
+  dps: 1961.00017
+  tps: 2688.50556
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1389.57532
-  tps: 1159.40157
+  dps: 1357.71388
+  tps: 1132.53756
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1486.39277
-  tps: 1243.37322
+  dps: 1455.82732
+  tps: 1217.21464
  }
 }
 dps_results: {
@@ -302,7 +302,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1395.71461
-  tps: 1165.82194
+  dps: 1365.28313
+  tps: 1139.51599
  }
 }

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestAffliction-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 94.82
-  final_stats: 40.48
-  final_stats: 242.44
-  final_stats: 226.38
-  final_stats: 183.48
+  final_stats: 93.5
+  final_stats: 39.6
+  final_stats: 240.9
+  final_stats: 225.5
+  final_stats: 182.6
   final_stats: 283
   final_stats: 0
   final_stats: 10
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 28
   final_stats: 42
   final_stats: 1
-  final_stats: 16.63116
+  final_stats: 16.6081
   final_stats: 0
   final_stats: 0
-  final_stats: 398.93
+  final_stats: 397.4
   final_stats: 1
-  final_stats: 9.8255
+  final_stats: 9.76408
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 4038.7
+  final_stats: 4025.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2255.96
+  final_stats: 2253.95
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -35,12 +35,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 2878.4
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 35.5
-  final_stats: 32.5
+  final_stats: 2863
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 35
+  final_stats: 32
   final_stats: 190
   final_stats: 0
   final_stats: 14
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestAffliction-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 136.5012
-  final_stats: 143.6886
-  final_stats: 414.3744
-  final_stats: 376.002
-  final_stats: 250.074
+  final_stats: 135.432
+  final_stats: 142.56
+  final_stats: 412.236
+  final_stats: 375.408
+  final_stats: 249.48
   final_stats: 268
   final_stats: 23
   final_stats: 10
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 63
   final_stats: 36
   final_stats: 2
-  final_stats: 25.37044
+  final_stats: 25.35832
   final_stats: 0
   final_stats: 0
-  final_stats: 579.218
+  final_stats: 577.724
   final_stats: 2
-  final_stats: 25.90225
+  final_stats: 25.84086
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 6523.03
+  final_stats: 6514.12
   final_stats: 0
   final_stats: 0
-  final_stats: 2489.534
+  final_stats: 2487.446
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 4942.744
-  final_stats: 20.25
-  final_stats: 20.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 32.25
+  final_stats: 4921.36
+  final_stats: 20
+  final_stats: 20
+  final_stats: 80
+  final_stats: 20
+  final_stats: 32
   final_stats: 0
   final_stats: 0
   final_stats: 100
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37929
+  weights: -0.11119
   weights: 0
-  weights: 1.04786
-  weights: 0
-  weights: 0
+  weights: 0.58069
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.06085
-  weights: 1.72728
+  weights: 0
+  weights: 0
+  weights: 4.24937
+  weights: 1.60052
   weights: 0
   weights: 0
   weights: 0
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.50891
+  weights: 2.50339
   weights: 0
-  weights: 2.32483
-  weights: 0
-  weights: 0
+  weights: 0.85507
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 12.72584
-  weights: 8.12795
+  weights: 0
+  weights: 0
+  weights: 14.31704
+  weights: 8.20918
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-Average-Default"
  value: {
-  dps: 600.83402
-  tps: 569.22966
+  dps: 600.43096
+  tps: 568.91609
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 597.40233
-  tps: 1199.80946
+  dps: 594.2872
+  tps: 1195.20746
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 597.40233
-  tps: 565.79399
+  dps: 594.2872
+  tps: 562.99175
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 587.57903
-  tps: 544.97873
+  dps: 586.5625
+  tps: 544.42184
  }
 }
 dps_results: {
@@ -246,63 +246,63 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 601.46916
-  tps: 569.55922
+  dps: 603.44748
+  tps: 571.69085
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1407.90403
-  tps: 1178.51201
+  dps: 1407.32682
+  tps: 1178.11562
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2009.24752
-  tps: 2733.25673
+  dps: 2009.87197
+  tps: 2734.00877
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1388.42013
-  tps: 1159.75553
+  dps: 1389.57532
+  tps: 1159.40157
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1487.03176
-  tps: 1243.95208
+  dps: 1486.39277
+  tps: 1243.37322
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1223.44459
-  tps: 2094.55371
+  dps: 1223.04728
+  tps: 2092.75699
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 770.68672
-  tps: 641.13099
+  dps: 770.38712
+  tps: 640.724
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 758.55371
-  tps: 649.74155
+  dps: 758.49633
+  tps: 649.68819
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1406.81558
-  tps: 1178.46697
+  dps: 1395.71461
+  tps: 1165.82194
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestDemonology-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 94.82
-  final_stats: 40.48
-  final_stats: 281.336
-  final_stats: 221.98
-  final_stats: 174.306
+  final_stats: 93.5
+  final_stats: 39.6
+  final_stats: 279.565
+  final_stats: 221.1
+  final_stats: 173.47
   final_stats: 281
   final_stats: 0
   final_stats: 38
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 42
   final_stats: 2
-  final_stats: 26.51588
+  final_stats: 26.49282
   final_stats: 0
   final_stats: 0
-  final_stats: 398.93
+  final_stats: 397.4
   final_stats: 2
-  final_stats: 19.8255
+  final_stats: 19.76408
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3972.7
+  final_stats: 3959.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2227.96
+  final_stats: 2225.95
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -35,12 +35,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 3267.36
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 35.5
-  final_stats: 32.5
+  final_stats: 3249.65
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 35
+  final_stats: 32
   final_stats: 160
   final_stats: 0
   final_stats: 14
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.15094
+  weights: 0.63084
   weights: 0
-  weights: 0.94405
-  weights: 0
-  weights: 0
+  weights: 1.10396
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.16606
-  weights: 2.10439
+  weights: 0
+  weights: 0
+  weights: 5.01308
+  weights: 2.04166
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 655.28542
-  tps: 545.9111
+  dps: 654.39162
+  tps: 545.37953
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 655.975
-  tps: 869.51358
+  dps: 654.86103
+  tps: 867.91497
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 655.975
-  tps: 548.00703
+  dps: 654.86103
+  tps: 547.0362
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 699.41532
-  tps: 587.86449
+  dps: 698.7244
+  tps: 587.49089
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 659.56968
-  tps: 552.11402
+  dps: 658.02643
+  tps: 550.60375
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 93.5
   final_stats: 39.6
-  final_stats: 279.565
+  final_stats: 203.665
   final_stats: 221.1
   final_stats: 173.47
   final_stats: 281
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 3249.65
+  final_stats: 2490.65
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 35
-  final_stats: 32
-  final_stats: 160
+  final_stats: 60
+  final_stats: 52
+  final_stats: 49
+  final_stats: 423
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.63084
+  weights: 0.57422
   weights: 0
-  weights: 1.10396
-  weights: 0
-  weights: 0
+  weights: 0.9762
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.01308
-  weights: 2.04166
+  weights: 0
+  weights: 0
+  weights: 5.52283
+  weights: 2.16027
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 654.39162
-  tps: 545.37953
+  dps: 642.5165
+  tps: 534.38772
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 654.86103
-  tps: 867.91497
+  dps: 645.14307
+  tps: 854.61754
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 654.86103
-  tps: 547.0362
+  dps: 645.14307
+  tps: 538.20271
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 698.7244
-  tps: 587.49089
+  dps: 686.6049
+  tps: 575.9718
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 658.02643
-  tps: 550.60375
+  dps: 645.9956
+  tps: 539.51019
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 3959.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2225.95
+  final_stats: 1938.45
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2490.65
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 52
   final_stats: 49
-  final_stats: 423
+  final_stats: 1054.25
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2330
   final_stats: 0
   final_stats: 0
-  final_stats: 1648.35
+  final_stats: 1073.35
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 18
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3827.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2225.95
+  final_stats: 1938.45
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2192
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 52
   final_stats: 39
-  final_stats: 423
+  final_stats: 1054.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 6425.02
   final_stats: 0
   final_stats: 0
-  final_stats: 2487.446
+  final_stats: 2343.696
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 4035.3496
   final_stats: 20
-  final_stats: 20
-  final_stats: 60
+  final_stats: 30
+  final_stats: 45
   final_stats: 45
   final_stats: 57
-  final_stats: 324
+  final_stats: 1099
   final_stats: 35
   final_stats: 100
   final_stats: 0

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 18
-  final_stats: 21
+  final_stats: 162
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 93.5
   final_stats: 39.6
-  final_stats: 239.8
+  final_stats: 173.8
   final_stats: 212.3
   final_stats: 182.6
   final_stats: 279
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 2852
+  final_stats: 2192
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 35
-  final_stats: 22
-  final_stats: 160
+  final_stats: 60
+  final_stats: 52
+  final_stats: 39
+  final_stats: 423
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 135.432
   final_stats: 142.56
-  final_stats: 436.97016
+  final_stats: 323.63496
   final_stats: 369.468
   final_stats: 244.4904
   final_stats: 259
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 5168.7016
+  final_stats: 4035.3496
   final_stats: 20
   final_stats: 20
-  final_stats: 80
-  final_stats: 20
-  final_stats: 32
-  final_stats: 0
+  final_stats: 60
+  final_stats: 45
+  final_stats: 57
+  final_stats: 324
   final_stats: 35
   final_stats: 100
   final_stats: 0
@@ -210,8 +210,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.12821
-  weights: 0.17205
+  weights: 3.07989
+  weights: 0.16853
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 18.26284
+  weights: 7.91948
   weights: 0
-  weights: 3.81207
-  weights: 0
-  weights: 0
+  weights: 1.46823
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 19.70188
-  weights: 6.73792
+  weights: 0
+  weights: 0
+  weights: 18.16846
+  weights: 6.90242
   weights: 0
   weights: 0
   weights: 0
@@ -351,29 +351,29 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 148.22125
-  tps: 79.86331
+  dps: 146.13539
+  tps: 78.78047
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 145.2259
-  tps: 1049.05246
+  dps: 143.26629
+  tps: 1043.85705
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 145.2259
-  tps: 75.12595
+  dps: 143.26629
+  tps: 74.4465
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 244.14961
-  tps: 163.5337
+  dps: 240.39285
+  tps: 160.47286
  }
 }
 dps_results: {
@@ -400,36 +400,36 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 145.49768
-  tps: 75.48553
+  dps: 143.53262
+  tps: 74.7991
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1324.69399
-  tps: 1154.8631
+  dps: 1296.71774
+  tps: 1129.4448
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2072.3678
-  tps: 2564.05915
+  dps: 2034.21177
+  tps: 2525.72072
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1310.83766
-  tps: 1141.43364
+  dps: 1287.9392
+  tps: 1122.12114
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1468.72518
-  tps: 1282.85275
+  dps: 1440.2917
+  tps: 1256.75356
  }
 }
 dps_results: {
@@ -456,7 +456,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1332.55364
-  tps: 1162.72532
+  dps: 1287.12802
+  tps: 1119.6369
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestDestruction-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 66.44
-  final_stats: 36.74
-  final_stats: 113.41
-  final_stats: 141.24
-  final_stats: 119.24
+  final_stats: 66
+  final_stats: 36.3
+  final_stats: 112.2
+  final_stats: 140.8
+  final_stats: 118.8
   final_stats: 129
   final_stats: 0
   final_stats: 54
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 35
   final_stats: 5
-  final_stats: 7.7592
+  final_stats: 7.74032
   final_stats: 0
   final_stats: 10
-  final_stats: 211.39
+  final_stats: 210.7
   final_stats: 0
-  final_stats: 7.33967
-  final_stats: 0
-  final_stats: 0
-  final_stats: 0
-  final_stats: 2336.6
+  final_stats: 7.29967
   final_stats: 0
   final_stats: 0
-  final_stats: 1649.98
+  final_stats: 0
+  final_stats: 2330
+  final_stats: 0
+  final_stats: 0
+  final_stats: 1648.35
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 1233.1
+  final_stats: 1221
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestDestruction-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 94.82
-  final_stats: 40.48
-  final_stats: 241.34
-  final_stats: 213.18
-  final_stats: 183.48
+  final_stats: 93.5
+  final_stats: 39.6
+  final_stats: 239.8
+  final_stats: 212.3
+  final_stats: 182.6
   final_stats: 279
   final_stats: 0
   final_stats: 24
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 45
   final_stats: 2
-  final_stats: 16.28532
+  final_stats: 16.26226
   final_stats: 0
   final_stats: 0
-  final_stats: 398.93
+  final_stats: 397.4
   final_stats: 2
-  final_stats: 9.8255
+  final_stats: 9.76408
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3840.7
+  final_stats: 3827.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2227.96
+  final_stats: 2225.95
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 2867.4
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 35.5
-  final_stats: 22.5
+  final_stats: 2852
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 35
+  final_stats: 22
   final_stats: 160
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestDestruction-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 136.5012
-  final_stats: 143.6886
-  final_stats: 439.23686
-  final_stats: 370.062
-  final_stats: 245.07252
+  final_stats: 135.432
+  final_stats: 142.56
+  final_stats: 436.97016
+  final_stats: 369.468
+  final_stats: 244.4904
   final_stats: 259
   final_stats: 0
   final_stats: 46
@@ -113,19 +113,19 @@ character_stats_results: {
   final_stats: 40
   final_stats: 36
   final_stats: 3
-  final_stats: 36.24926
+  final_stats: 36.23715
   final_stats: 0
   final_stats: 0
-  final_stats: 579.218
+  final_stats: 577.724
   final_stats: 3
-  final_stats: 36.90225
+  final_stats: 36.84086
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 6433.93
+  final_stats: 6425.02
   final_stats: 0
   final_stats: 0
-  final_stats: 2489.534
+  final_stats: 2487.446
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -133,12 +133,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 5191.36864
-  final_stats: 20.25
-  final_stats: 20.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 32.25
+  final_stats: 5168.7016
+  final_stats: 20
+  final_stats: 20
+  final_stats: 80
+  final_stats: 20
+  final_stats: 32
   final_stats: 0
   final_stats: 35
   final_stats: 100
@@ -151,9 +151,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.20223
+  weights: 3.71683
   weights: 0
-  weights: 0.3762
+  weights: 0.26889
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02921
+  weights: 0.00593
   weights: 0
-  weights: 0.13619
-  weights: 0
-  weights: 0
+  weights: 0.13617
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.12991
-  weights: 0.17217
+  weights: 0
+  weights: 0
+  weights: 3.12821
+  weights: 0.17205
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 7.46111
+  weights: 18.26284
   weights: 0
-  weights: 0.26886
-  weights: 0
-  weights: 0
+  weights: 3.81207
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 13.14487
-  weights: 7.00941
+  weights: 0
+  weights: 0
+  weights: 19.70188
+  weights: 6.73792
   weights: 0
   weights: 0
   weights: 0
@@ -295,29 +295,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 125.24834
-  tps: 94.73149
+  dps: 125.23588
+  tps: 94.72664
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 394.05901
-  tps: 693.41252
+  dps: 394.05573
+  tps: 693.42903
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 124.50648
-  tps: 93.81014
+  dps: 124.50062
+  tps: 93.8129
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 213.78234
-  tps: 159.67588
+  dps: 212.9204
+  tps: 159.74469
  }
 }
 dps_results: {
@@ -344,36 +344,36 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 124.50648
-  tps: 93.81014
+  dps: 124.50062
+  tps: 93.8129
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 148.23564
-  tps: 79.75196
+  dps: 148.22125
+  tps: 79.86331
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 145.31144
-  tps: 1049.74922
+  dps: 145.2259
+  tps: 1049.05246
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 145.31144
-  tps: 75.17466
+  dps: 145.2259
+  tps: 75.12595
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 244.27378
-  tps: 163.63486
+  dps: 244.14961
+  tps: 163.5337
  }
 }
 dps_results: {
@@ -400,63 +400,63 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 145.5834
-  tps: 75.53446
+  dps: 145.49768
+  tps: 75.48553
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1326.14008
-  tps: 1156.15571
+  dps: 1324.69399
+  tps: 1154.8631
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2075.1075
-  tps: 2562.54588
+  dps: 2072.3678
+  tps: 2564.05915
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1312.14252
-  tps: 1142.33031
+  dps: 1310.83766
+  tps: 1141.43364
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1469.40404
-  tps: 1283.47588
+  dps: 1468.72518
+  tps: 1282.85275
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1303.53279
-  tps: 1904.30148
+  dps: 1304.49562
+  tps: 1904.32569
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 746.04815
-  tps: 639.76967
+  dps: 745.65915
+  tps: 639.367
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 787.6358
-  tps: 703.23364
+  dps: 787.57204
+  tps: 703.17375
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1333.08773
-  tps: 1162.87592
+  dps: 1332.55364
+  tps: 1162.72532
  }
 }

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2379.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1672.95
+  final_stats: 1097.95
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 18
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 18
-  final_stats: 21
+  final_stats: 162
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestAffliction-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 75.24
-  final_stats: 45.54
-  final_stats: 158.2515
-  final_stats: 144.54
-  final_stats: 118.503
+  final_stats: 74.8
+  final_stats: 45.1
+  final_stats: 156.86
+  final_stats: 144.1
+  final_stats: 118.085
   final_stats: 142
   final_stats: 0
   final_stats: 32
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 35
   final_stats: 6
-  final_stats: 7.90077
+  final_stats: 7.88189
   final_stats: 0
   final_stats: 10
-  final_stats: 220.19
+  final_stats: 219.5
   final_stats: 1
-  final_stats: 8.13959
+  final_stats: 8.09959
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2386.1
+  final_stats: 2379.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1674.58
+  final_stats: 1672.95
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 1681.515
+  final_stats: 1667.6
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.09661
+  weights: 0.17667
   weights: 0
-  weights: 0.5995
-  weights: 0
-  weights: 0
+  weights: 0.67825
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.38058
+  weights: 0
+  weights: 0
+  weights: 0.38192
   weights: 0
   weights: 0
   weights: 0
@@ -99,22 +99,22 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Average-Default"
  value: {
-  dps: 174.72925
-  tps: 327.22402
+  dps: 174.72622
+  tps: 327.21329
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 211.14778
-  tps: 613.9037
+  dps: 211.02064
+  tps: 613.78737
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 175.00747
-  tps: 327.75983
+  dps: 174.97843
+  tps: 327.67162
  }
 }
 dps_results: {
@@ -148,15 +148,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 211.14778
-  tps: 613.9037
+  dps: 211.02064
+  tps: 613.78737
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 175.00747
-  tps: 327.75983
+  dps: 174.97843
+  tps: 327.67162
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 175.08438
-  tps: 327.8752
+  dps: 175.05525
+  tps: 327.78685
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 96.8
   final_stats: 53.9
-  final_stats: 370.645
+  final_stats: 294.745
   final_stats: 221.1
   final_stats: 142.12
   final_stats: 251
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 4160.45
+  final_stats: 3401.45
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 18
-  final_stats: 32
-  final_stats: 492
+  final_stats: 60
+  final_stats: 35
+  final_stats: 49
+  final_stats: 755
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.16325
+  weights: -0.03124
   weights: 0
-  weights: 0.62203
-  weights: 0
-  weights: 0
+  weights: 1.21203
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.94151
-  weights: 1.48907
+  weights: 0
+  weights: 0
+  weights: 6.56627
+  weights: 1.41855
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 594.58946
-  tps: 1141.53574
+  dps: 583.51479
+  tps: 1116.35268
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 557.60887
-  tps: 1592.96008
+  dps: 547.17913
+  tps: 1566.36708
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 557.60887
-  tps: 1078.83678
+  dps: 547.17913
+  tps: 1054.1079
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 584.77182
-  tps: 1130.40454
+  dps: 573.74021
+  tps: 1105.31698
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 591.31627
-  tps: 1135.84584
+  dps: 578.5522
+  tps: 1106.04337
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 3959.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2586.55
+  final_stats: 2299.05
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3401.45
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 35
   final_stats: 49
-  final_stats: 755
+  final_stats: 1386.25
   final_stats: 0
   final_stats: 14
   final_stats: 0

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestDemonology-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 98.12
-  final_stats: 54.78
-  final_stats: 372.416
-  final_stats: 221.98
-  final_stats: 142.956
+  final_stats: 96.8
+  final_stats: 53.9
+  final_stats: 370.645
+  final_stats: 221.1
+  final_stats: 142.12
   final_stats: 251
   final_stats: 0
   final_stats: 42.2
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 38
   final_stats: 2
-  final_stats: 14.51588
+  final_stats: 14.49282
   final_stats: 0
   final_stats: 0
-  final_stats: 402.23
+  final_stats: 400.7
   final_stats: 2
-  final_stats: 8.82364
+  final_stats: 8.76222
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3972.7
+  final_stats: 3959.5
   final_stats: 0
   final_stats: 0
-  final_stats: 2588.56
+  final_stats: 2586.55
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -35,12 +35,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 4178.16
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 18.5
-  final_stats: 32.5
+  final_stats: 4160.45
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 18
+  final_stats: 32
   final_stats: 492
   final_stats: 0
   final_stats: 14
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.11041
+  weights: 0.16325
   weights: 0
-  weights: 0.40799
-  weights: 0
-  weights: 0
+  weights: 0.62203
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.42199
-  weights: 1.49799
+  weights: 0
+  weights: 0
+  weights: 6.94151
+  weights: 1.48907
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 595.44815
-  tps: 1142.61143
+  dps: 594.58946
+  tps: 1141.53574
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 559.75431
-  tps: 1599.42562
+  dps: 557.60887
+  tps: 1592.96008
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 559.75431
-  tps: 1083.55832
+  dps: 557.60887
+  tps: 1078.83678
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 585.58191
-  tps: 1131.21821
+  dps: 584.77182
+  tps: 1130.40454
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 594.2001
-  tps: 1139.19022
+  dps: 591.31627
+  tps: 1135.84584
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestDestruction-Lvl25-CharacterStats-Default"
  value: {
-  final_stats: 75.24
-  final_stats: 45.54
-  final_stats: 137.61
-  final_stats: 144.54
-  final_stats: 124.74
+  final_stats: 74.8
+  final_stats: 45.1
+  final_stats: 136.4
+  final_stats: 144.1
+  final_stats: 124.3
   final_stats: 142
   final_stats: 0
   final_stats: 32
@@ -15,19 +15,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 35
   final_stats: 6
-  final_stats: 7.90077
+  final_stats: 7.88189
   final_stats: 0
   final_stats: 10
-  final_stats: 220.19
+  final_stats: 219.5
   final_stats: 1
-  final_stats: 8.13959
+  final_stats: 8.09959
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 2386.1
+  final_stats: 2379.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1674.58
+  final_stats: 1672.95
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -35,7 +35,7 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 1475.1
+  final_stats: 1463
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,11 +50,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestDestruction-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 98.12
-  final_stats: 54.78
-  final_stats: 368.621
-  final_stats: 218.68
-  final_stats: 142.956
+  final_stats: 96.8
+  final_stats: 53.9
+  final_stats: 366.85
+  final_stats: 217.8
+  final_stats: 142.12
   final_stats: 249
   final_stats: 0
   final_stats: 24
@@ -64,19 +64,19 @@ character_stats_results: {
   final_stats: 0
   final_stats: 41
   final_stats: 2
-  final_stats: 14.42942
+  final_stats: 14.40636
   final_stats: 0
   final_stats: 0
-  final_stats: 402.23
+  final_stats: 400.7
   final_stats: 2
-  final_stats: 8.82364
+  final_stats: 8.76222
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3923.2
+  final_stats: 3910
   final_stats: 0
   final_stats: 0
-  final_stats: 2588.56
+  final_stats: 2586.55
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -84,12 +84,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 4140.21
-  final_stats: 18.5
-  final_stats: 23.5
-  final_stats: 73.5
-  final_stats: 18.5
-  final_stats: 22.5
+  final_stats: 4122.5
+  final_stats: 18
+  final_stats: 23
+  final_stats: 73
+  final_stats: 18
+  final_stats: 22
   final_stats: 492
   final_stats: 0
   final_stats: 14
@@ -99,11 +99,11 @@ character_stats_results: {
 character_stats_results: {
  key: "TestDestruction-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 136.5012
-  final_stats: 143.6886
-  final_stats: 478.5264
-  final_stats: 284.526
-  final_stats: 241.758
+  final_stats: 135.432
+  final_stats: 142.56
+  final_stats: 476.388
+  final_stats: 283.932
+  final_stats: 241.164
   final_stats: 262
   final_stats: 0
   final_stats: 33
@@ -113,19 +113,19 @@ character_stats_results: {
   final_stats: 40
   final_stats: 36
   final_stats: 4
-  final_stats: 20.50433
+  final_stats: 20.49221
   final_stats: 0
   final_stats: 0
-  final_stats: 579.218
+  final_stats: 577.724
   final_stats: 4
-  final_stats: 22.90225
+  final_stats: 22.84086
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 5150.89
+  final_stats: 5141.98
   final_stats: 0
   final_stats: 0
-  final_stats: 2877.534
+  final_stats: 2875.446
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -133,12 +133,12 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 5584.264
-  final_stats: 20.25
-  final_stats: 20.25
-  final_stats: 80.25
-  final_stats: 20.25
-  final_stats: 32.25
+  final_stats: 5562.88
+  final_stats: 20
+  final_stats: 20
+  final_stats: 80
+  final_stats: 20
+  final_stats: 32
   final_stats: 390
   final_stats: 35
   final_stats: 100
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.79378
+  weights: -0.6542
   weights: 0
-  weights: 1.38359
-  weights: 0
-  weights: 0
+  weights: 1.21852
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.40683
+  weights: 0
+  weights: 0
+  weights: 0.34889
   weights: 0
   weights: 0
   weights: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.03819
+  weights: 1.09452
   weights: 0
-  weights: 0.64028
-  weights: 0
-  weights: 0
+  weights: 0.92602
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.09141
-  weights: 3.1893
+  weights: 0
+  weights: 0
+  weights: 2.52517
+  weights: 2.98491
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.07239
+  weights: -4.55404
   weights: 0
-  weights: -2.28659
-  weights: 0
-  weights: 0
+  weights: -2.31698
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.52568
-  weights: 5.87868
+  weights: 0
+  weights: 0
+  weights: 11.28308
+  weights: 7.10479
   weights: 0
   weights: 0
   weights: 0
@@ -295,29 +295,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 172.17724
-  tps: 273.5437
+  dps: 165.18748
+  tps: 257.64347
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 417.18418
-  tps: 839.16629
+  dps: 427.75001
+  tps: 908.43323
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 163.73074
-  tps: 260.49625
+  dps: 157.50222
+  tps: 248.01033
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 174.61266
-  tps: 293.72033
+  dps: 175.4972
+  tps: 294.2214
  }
 }
 dps_results: {
@@ -344,36 +344,36 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 168.60192
-  tps: 267.80302
+  dps: 162.49659
+  tps: 255.50188
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 520.95084
-  tps: 1138.44184
+  dps: 520.58426
+  tps: 1137.5105
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 871.38842
-  tps: 1855.90167
+  dps: 865.53654
+  tps: 1838.22946
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 488.59803
-  tps: 1081.15441
+  dps: 489.99174
+  tps: 1084.70673
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 473.88253
-  tps: 1030.94712
+  dps: 471.21214
+  tps: 1023.33024
  }
 }
 dps_results: {
@@ -400,71 +400,71 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 516.18895
-  tps: 1130.689
+  dps: 515.15369
+  tps: 1127.19092
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1339.74177
-  tps: 2197.11391
-  hps: 19.38366
+  dps: 1339.24537
+  tps: 2195.63951
+  hps: 19.37089
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1911.83687
-  tps: 4004.30034
-  hps: 15.15675
+  dps: 1916.3761
+  tps: 4015.47019
+  hps: 15.19682
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1276.45672
-  tps: 2079.80624
-  hps: 15.3651
+  dps: 1273.37508
+  tps: 2076.93241
+  hps: 15.33778
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1268.23222
-  tps: 2069.45989
-  hps: 15.46719
+  dps: 1265.35969
+  tps: 2065.23363
+  hps: 15.50589
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1201.9215
-  tps: 2897.36173
-  hps: 10.28333
+  dps: 1201.46531
+  tps: 2896.56851
+  hps: 10.27667
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 742.553
-  tps: 1175.40668
-  hps: 10.405
+  dps: 742.85721
+  tps: 1175.42721
+  hps: 10.41167
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 694.42142
-  tps: 1127.59646
+  dps: 694.37064
+  tps: 1127.50176
   hps: 10.575
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1309.70147
-  tps: 2146.05966
-  hps: 19.73934
+  dps: 1311.60424
+  tps: 2145.03312
+  hps: 19.79626
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 18
-  final_stats: 21
+  final_stats: 162
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -52,7 +52,7 @@ character_stats_results: {
  value: {
   final_stats: 96.8
   final_stats: 53.9
-  final_stats: 366.85
+  final_stats: 290.95
   final_stats: 217.8
   final_stats: 142.12
   final_stats: 249
@@ -84,13 +84,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 4122.5
+  final_stats: 3363.5
   final_stats: 18
   final_stats: 23
-  final_stats: 73
-  final_stats: 18
-  final_stats: 22
-  final_stats: 492
+  final_stats: 60
+  final_stats: 35
+  final_stats: 39
+  final_stats: 755
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -101,7 +101,7 @@ character_stats_results: {
  value: {
   final_stats: 135.432
   final_stats: 142.56
-  final_stats: 476.388
+  final_stats: 369.468
   final_stats: 283.932
   final_stats: 241.164
   final_stats: 262
@@ -133,13 +133,13 @@ character_stats_results: {
   final_stats: 2
   final_stats: 0
   final_stats: 0
-  final_stats: 5562.88
+  final_stats: 4493.68
   final_stats: 20
   final_stats: 20
-  final_stats: 80
-  final_stats: 20
-  final_stats: 32
-  final_stats: 390
+  final_stats: 60
+  final_stats: 45
+  final_stats: 57
+  final_stats: 714
   final_stats: 35
   final_stats: 100
   final_stats: 0
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.09452
+  weights: 0.73409
   weights: 0
-  weights: 0.92602
-  weights: 0
-  weights: 0
+  weights: 0.67582
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.52517
-  weights: 2.98491
+  weights: 0
+  weights: 0
+  weights: 2.57227
+  weights: 2.91556
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -4.55404
+  weights: -1.57289
   weights: 0
-  weights: -2.31698
-  weights: 0
-  weights: 0
+  weights: 1.22065
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 11.28308
-  weights: 7.10479
+  weights: 0
+  weights: 0
+  weights: 5.46623
+  weights: 5.26549
   weights: 0
   weights: 0
   weights: 0
@@ -351,29 +351,29 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 520.58426
-  tps: 1137.5105
+  dps: 510.02629
+  tps: 1111.73712
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 865.53654
-  tps: 1838.22946
+  dps: 845.5588
+  tps: 1797.34074
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 489.99174
-  tps: 1084.70673
+  dps: 478.22281
+  tps: 1057.27655
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 471.21214
-  tps: 1023.33024
+  dps: 461.55054
+  tps: 999.90828
  }
 }
 dps_results: {
@@ -400,39 +400,39 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 515.15369
-  tps: 1127.19092
+  dps: 504.7985
+  tps: 1102.63798
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1339.24537
-  tps: 2195.63951
-  hps: 19.37089
+  dps: 1312.79728
+  tps: 2149.2677
+  hps: 19.38905
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1916.3761
-  tps: 4015.47019
-  hps: 15.19682
+  dps: 1878.02588
+  tps: 3940.4153
+  hps: 15.26058
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1273.37508
-  tps: 2076.93241
-  hps: 15.33778
+  dps: 1243.3602
+  tps: 2017.04243
+  hps: 15.20799
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1265.35969
-  tps: 2065.23363
+  dps: 1240.30471
+  tps: 2021.38175
   hps: 15.50589
  }
 }
@@ -463,8 +463,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1311.60424
-  tps: 2145.03312
-  hps: 19.79626
+  dps: 1277.24381
+  tps: 2084.94784
+  hps: 19.74617
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 2379.5
   final_stats: 0
   final_stats: 0
-  final_stats: 1672.95
+  final_stats: 1097.95
   final_stats: 20
   final_stats: 0
   final_stats: 0
@@ -41,7 +41,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 18
-  final_stats: 162
+  final_stats: 505.75
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -76,7 +76,7 @@ character_stats_results: {
   final_stats: 3910
   final_stats: 0
   final_stats: 0
-  final_stats: 2586.55
+  final_stats: 2299.05
   final_stats: 200
   final_stats: 0
   final_stats: 0
@@ -86,11 +86,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3363.5
   final_stats: 18
-  final_stats: 23
-  final_stats: 60
+  final_stats: 40
+  final_stats: 30
   final_stats: 35
   final_stats: 39
-  final_stats: 755
+  final_stats: 1386.25
   final_stats: 0
   final_stats: 14
   final_stats: 0
@@ -125,7 +125,7 @@ character_stats_results: {
   final_stats: 5141.98
   final_stats: 0
   final_stats: 0
-  final_stats: 2875.446
+  final_stats: 2731.696
   final_stats: 300
   final_stats: 0
   final_stats: 0
@@ -135,11 +135,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 4493.68
   final_stats: 20
-  final_stats: 20
-  final_stats: 60
+  final_stats: 30
+  final_stats: 45
   final_stats: 45
   final_stats: 57
-  final_stats: 714
+  final_stats: 1489
   final_stats: 35
   final_stats: 100
   final_stats: 0

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestArms-Lvl50-CharacterStats-Default"
  value: {
-  final_stats: 375.2892
-  final_stats: 317.1366
-  final_stats: 528.4224
-  final_stats: 93.258
-  final_stats: 126.522
+  final_stats: 374.22
+  final_stats: 316.008
+  final_stats: 526.284
+  final_stats: 92.664
+  final_stats: 125.928
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -18,29 +18,29 @@ character_stats_results: {
   final_stats: 21
   final_stats: 0
   final_stats: 0
-  final_stats: 1361.512
+  final_stats: 1359.024
   final_stats: 5
-  final_stats: 46.77824
+  final_stats: 46.71456
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3775.43
+  final_stats: 3773.342
   final_stats: 336
   final_stats: 0
   final_stats: 0
-  final_stats: 18.3753
-  final_stats: 18.77824
+  final_stats: 18.3256
+  final_stats: 18.71456
   final_stats: 0
   final_stats: 0
-  final_stats: 6183.224
-  final_stats: 20.25
-  final_stats: 20.25
-  final_stats: 80.25
-  final_stats: 25.25
-  final_stats: 20.25
+  final_stats: 6161.84
+  final_stats: 20
+  final_stats: 20
+  final_stats: 80
+  final_stats: 25
+  final_stats: 20
   final_stats: 0
   final_stats: 0
   final_stats: 65
@@ -50,8 +50,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestArms-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.25768
-  weights: 0.41036
+  weights: 1.35841
+  weights: 0.72612
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.1974
-  weights: 15.05169
-  weights: 13.50736
+  weights: 0.74708
+  weights: 15.97644
+  weights: 13.16917
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestArms-Lvl50-Average-Default"
  value: {
-  dps: 1311.29626
-  tps: 1141.3894
+  dps: 1309.04302
+  tps: 1139.48718
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 110.67152
-  tps: 171.3539
+  dps: 110.54858
+  tps: 171.24498
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 75.46361
-  tps: 68.7564
+  dps: 75.38483
+  tps: 68.69338
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 127.01722
-  tps: 111.38044
+  dps: 126.88468
+  tps: 111.27441
  }
 }
 dps_results: {
@@ -148,22 +148,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 115.96716
-  tps: 176.1997
+  dps: 115.83187
+  tps: 176.07953
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 79.10121
-  tps: 71.66349
+  dps: 79.01493
+  tps: 71.59446
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 137.98828
-  tps: 120.15729
+  dps: 137.83391
+  tps: 120.0338
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1209.88383
-  tps: 1054.70461
+  dps: 1207.897
+  tps: 1052.95723
  }
 }

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 374.22
   final_stats: 316.008
-  final_stats: 526.284
+  final_stats: 419.364
   final_stats: 92.664
   final_stats: 125.928
   final_stats: 0
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 18.71456
   final_stats: 0
   final_stats: 0
-  final_stats: 6161.84
+  final_stats: 5092.64
   final_stats: 20
   final_stats: 20
-  final_stats: 80
-  final_stats: 25
-  final_stats: 20
-  final_stats: 0
+  final_stats: 60
+  final_stats: 50
+  final_stats: 45
+  final_stats: 324
   final_stats: 0
   final_stats: 65
   final_stats: 0

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3773.342
+  final_stats: 3629.592
   final_stats: 336
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 5092.64
   final_stats: 20
-  final_stats: 20
-  final_stats: 60
+  final_stats: 30
+  final_stats: 45
   final_stats: 50
   final_stats: 45
-  final_stats: 324
+  final_stats: 1099
   final_stats: 0
   final_stats: 65
   final_stats: 0

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -50,8 +50,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestArms-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.35841
-  weights: 0.72612
+  weights: 1.22892
+  weights: 0.83088
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.74708
-  weights: 15.97644
-  weights: 13.16917
+  weights: 0.42284
+  weights: 15.43844
+  weights: 13.87321
   weights: 0
   weights: 0
   weights: 0
@@ -99,98 +99,98 @@ stat_weights_results: {
 dps_results: {
  key: "TestArms-Lvl50-Average-Default"
  value: {
-  dps: 1309.04302
-  tps: 1139.48718
+  dps: 1331.10887
+  tps: 1159.07418
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 110.54858
-  tps: 171.24498
+  dps: 171.61837
+  tps: 282.87932
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 75.38483
-  tps: 68.69338
+  dps: 119.04686
+  tps: 110.07977
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 126.88468
-  tps: 111.27441
+  dps: 221.89652
+  tps: 198.35303
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 49.67689
-  tps: 117.70088
+  dps: 77.75978
+  tps: 202.05109
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 33.77674
-  tps: 35.36921
+  dps: 53.69889
+  tps: 55.93633
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 63.92184
-  tps: 60.90414
+  dps: 114.28005
+  tps: 109.30438
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 115.83187
-  tps: 176.07953
+  dps: 181.44018
+  tps: 291.70926
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 79.01493
-  tps: 71.59446
+  dps: 125.27482
+  tps: 115.29709
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 137.83391
-  tps: 120.0338
+  dps: 233.04211
+  tps: 207.23154
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 52.34385
-  tps: 120.11161
+  dps: 82.03602
+  tps: 205.67519
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 35.61855
-  tps: 36.80257
+  dps: 56.60186
+  tps: 58.33397
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 69.74219
-  tps: 65.56042
+  dps: 120.48751
+  tps: 113.94817
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1207.897
-  tps: 1052.95723
+  dps: 1227.63319
+  tps: 1069.86661
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -1,11 +1,11 @@
 character_stats_results: {
  key: "TestFury-Lvl40-CharacterStats-Default"
  value: {
-  final_stats: 289.52
-  final_stats: 188.98
-  final_stats: 349.14
-  final_stats: 61.38
-  final_stats: 80.08
+  final_stats: 288.2
+  final_stats: 188.1
+  final_stats: 347.6
+  final_stats: 60.5
+  final_stats: 79.2
   final_stats: 42
   final_stats: 0
   final_stats: 0
@@ -18,29 +18,29 @@ character_stats_results: {
   final_stats: 9
   final_stats: 0
   final_stats: 0
-  final_stats: 1091.01
+  final_stats: 1088.2
   final_stats: 5
-  final_stats: 27.32468
+  final_stats: 27.25798
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3048.96
+  final_stats: 3046.95
   final_stats: 302
   final_stats: 0
   final_stats: 0
-  final_stats: 14.269
-  final_stats: 14.32468
+  final_stats: 14.205
+  final_stats: 14.25798
   final_stats: 0
   final_stats: 0
-  final_stats: 3960.4
-  final_stats: 18.5
-  final_stats: 13.5
-  final_stats: 83.5
-  final_stats: 18.5
-  final_stats: 23.5
+  final_stats: 3945
+  final_stats: 18
+  final_stats: 13
+  final_stats: 83
+  final_stats: 18
+  final_stats: 23
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -50,8 +50,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestFury-Lvl40-StatWeights-Default"
  value: {
-  weights: 1.96548
-  weights: 1.14313
+  weights: 1.13932
+  weights: 0.09389
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.07122
-  weights: 10.94179
-  weights: 12.04275
+  weights: 0.04525
+  weights: 10.99655
+  weights: 11.09269
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestFury-Lvl40-Average-Default"
  value: {
-  dps: 813.157
-  tps: 757.73762
+  dps: 810.63111
+  tps: 755.50169
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 20.40727
-  tps: 56.37672
+  dps: 20.37359
+  tps: 56.34753
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 16.78581
-  tps: 18.01841
+  dps: 16.76075
+  tps: 17.99829
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 32.57514
-  tps: 32.38232
+  dps: 32.51052
+  tps: 32.33025
  }
 }
 dps_results: {
@@ -148,22 +148,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 21.99097
-  tps: 57.78337
+  dps: 21.95139
+  tps: 57.74891
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 18.07752
-  tps: 19.06588
+  dps: 18.04809
+  tps: 19.04224
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 37.60671
-  tps: 36.43044
+  dps: 37.52428
+  tps: 36.36404
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 754.40745
-  tps: 705.85747
+  dps: 756.3503
+  tps: 707.39878
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -3,7 +3,7 @@ character_stats_results: {
  value: {
   final_stats: 288.2
   final_stats: 188.1
-  final_stats: 347.6
+  final_stats: 281.6
   final_stats: 60.5
   final_stats: 79.2
   final_stats: 42
@@ -35,13 +35,13 @@ character_stats_results: {
   final_stats: 14.25798
   final_stats: 0
   final_stats: 0
-  final_stats: 3945
+  final_stats: 3285
   final_stats: 18
   final_stats: 13
-  final_stats: 83
-  final_stats: 18
-  final_stats: 23
-  final_stats: 0
+  final_stats: 70
+  final_stats: 35
+  final_stats: 40
+  final_stats: 263
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -27,7 +27,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 3046.95
+  final_stats: 2759.45
   final_stats: 302
   final_stats: 0
   final_stats: 0
@@ -37,11 +37,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 3285
   final_stats: 18
-  final_stats: 13
-  final_stats: 70
+  final_stats: 30
+  final_stats: 40
   final_stats: 35
   final_stats: 40
-  final_stats: 263
+  final_stats: 894.25
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warrior/dps/dps_warrior_test.go
+++ b/sim/warrior/dps/dps_warrior_test.go
@@ -124,6 +124,7 @@ var Phase3Consumes = core.ConsumesCombo{
 		MainHandImbue:     proto.WeaponImbue_WildStrikes,
 		OffHandImbue:      proto.WeaponImbue_SolidSharpeningStone,
 		StrengthBuff:      proto.StrengthBuff_ElixirOfOgresStrength,
+		DefaultPotion:     proto.Potions_MightyRagePotion,
 	},
 }
 

--- a/tools/database/overrides.go
+++ b/tools/database/overrides.go
@@ -232,9 +232,17 @@ var ExtraItemIcons = []int32{
 
 	// Single Elixirs
 	20007, // Mana Regen Elixir
-	13445, // Defense
 	20004, // Major Troll's Blood Potion
 	9088,  // Gift of Arthas
+
+	// Armor Elixirs
+	3389,  // Defense
+	8951,  // Greater
+	13445, // Superior Defense
+
+	// Health Elixirs
+	2458, // Minor Fortitude
+	3825, // Fortitude
 
 	// Strength
 	12451,
@@ -259,6 +267,8 @@ var ExtraItemIcons = []int32{
 	// Alcohol Buff
 	18284,
 	18269,
+	20709,
+	21114,
 	21151,
 
 	// Potions / In Battle Consumes

--- a/ui/core/components/individual_sim_ui/consumes_picker.ts
+++ b/ui/core/components/individual_sim_ui/consumes_picker.ts
@@ -23,6 +23,7 @@ export class ConsumesPicker extends Component {
 			this.buildWeaponImbuePicker();
 			this.buildFoodPicker();
 			this.buildPhysicalBuffPickers();
+			this.buildDefensiveBuffPickers();
 			this.buildSpellPowerBuffPickers();
 			this.buildMiscConsumesPickers();
 			this.buildEngPickers();
@@ -113,10 +114,12 @@ export class ConsumesPicker extends Component {
 		const foodsElem = this.rootElem.querySelector('.consumes-food') as HTMLElement;
 
 		const foodOptions = ConsumablesInputs.makeFoodInput(relevantStatOptions(ConsumablesInputs.FOOD_CONFIG, this.simUI));
+		const alcoholOptions = ConsumablesInputs.makeFoodInput(relevantStatOptions(ConsumablesInputs.ALCOHOL_CONFIG, this.simUI));
 
 		const pickers = [
 			buildIconInput(foodsElem, this.simUI.player, foodOptions),
 			buildIconInput(foodsElem, this.simUI.player, ConsumablesInputs.DragonBreathChili),
+			buildIconInput(foodsElem, this.simUI.player, alcoholOptions),
 		];
 
 		TypedEvent.onAny([this.simUI.player.levelChangeEmitter]).on(() => this.updateRow(row, pickers));
@@ -154,6 +157,37 @@ export class ConsumesPicker extends Component {
 			buildIconInput(physicalConsumesElem, this.simUI.player, apBuffOptions),
 			buildIconInput(physicalConsumesElem, this.simUI.player, agiBuffOptions),
 			buildIconInput(physicalConsumesElem, this.simUI.player, strBuffOptions),
+		];
+
+		TypedEvent.onAny([this.simUI.player.levelChangeEmitter]).on(() => this.updateRow(row, pickers));
+		this.updateRow(row, pickers);
+	}
+
+	private buildDefensiveBuffPickers() {
+		const fragment = document.createElement('fragment');
+		fragment.innerHTML = `
+			<div class="consumes-row input-root input-inline">
+				<label class="form-label">Defensive</label>
+				<div class="consumes-row-inputs consumes-defensive"></div>
+			</div>
+		`;
+
+		const row = this.rootElem.appendChild(fragment.children[0] as HTMLElement);
+		const defensiveConsumesElem = this.rootElem.querySelector('.consumes-defensive') as HTMLElement;
+
+		const healthBuffOptions = ConsumablesInputs.makeHealthConsumeInput(
+			relevantStatOptions(ConsumablesInputs.HEALTH_CONSUMES_CONFIG, this.simUI), 
+			'Health'
+		);
+
+		const armorBuffOptions = ConsumablesInputs.makeArmorConsumeInput(
+			relevantStatOptions(ConsumablesInputs.ARMOR_CONSUMES_CONFIG, this.simUI), 
+			'Armor'
+		);
+
+		const pickers = [
+			buildIconInput(defensiveConsumesElem, this.simUI.player, healthBuffOptions),
+			buildIconInput(defensiveConsumesElem, this.simUI.player, armorBuffOptions),
 		];
 
 		TypedEvent.onAny([this.simUI.player.levelChangeEmitter]).on(() => this.updateRow(row, pickers));

--- a/ui/core/components/inputs/buffs_debuffs.ts
+++ b/ui/core/components/inputs/buffs_debuffs.ts
@@ -694,6 +694,13 @@ export const AttackPowerDebuff = InputHelpers.makeMultiIconInput(
 			impId: ActionId.fromSpellId(16862),
 			fieldName: 'demoralizingRoar',
 		}),
+		makeMultistateMultiplierDebuffInput({
+			actionId: () => ActionId.fromSpellId(402811),
+			numStates: 11,
+			multiplier: 10,
+			reverse: true,
+			fieldName: 'homunculi',
+		}),
 	],
 	'Attack Power',
 );
@@ -701,12 +708,21 @@ export const AttackPowerDebuff = InputHelpers.makeMultiIconInput(
 // TODO: SoD Mangle
 export const BleedDebuff = withLabel(makeBooleanDebuffInput({ actionId: () => ActionId.fromSpellId(409828), fieldName: 'mangle' }), 'Bleed');
 
-export const MeleeAttackSpeedDebuff = withLabel(
-	makeTristateDebuffInput({
-		actionId: () => ActionId.fromSpellId(6343),
-		impId: ActionId.fromSpellId(12666),
-		fieldName: 'thunderClap',
-	}),
+export const MeleeAttackSpeedDebuff = InputHelpers.makeMultiIconInput(
+	[
+		makeTristateDebuffInput({
+			actionId: () => ActionId.fromSpellId(6343),
+			impId: ActionId.fromSpellId(12666),
+			fieldName: 'thunderClap',
+		}),
+		makeMultistateMultiplierDebuffInput({
+			actionId: () => ActionId.fromSpellId(402808),
+			numStates: 11,
+			multiplier: 10,
+			reverse: true,
+			fieldName: 'homunculi',
+		}),
+	],
 	'Thunder Clap',
 );
 
@@ -1192,7 +1208,7 @@ export const DEBUFFS_CONFIG = [
 	},
 	{
 		config: MeleeAttackSpeedDebuff,
-		picker: IconPicker,
+		picker: MultiIconPicker,
 		stats: [Stat.StatArmor],
 	},
 	{

--- a/ui/core/components/inputs/buffs_debuffs.ts
+++ b/ui/core/components/inputs/buffs_debuffs.ts
@@ -56,33 +56,21 @@ export const AllStatsPercentBuff = InputHelpers.makeMultiIconInput(
 	'Stats %',
 );
 
-export const ArmorBuff = InputHelpers.makeMultiIconInput(
-	[
-		makeTristateRaidBuffInput({
-			actionId: player =>
-				player.getMatchingSpellActionId([
-					{ id: 465, maxLevel: 9 },
-					{ id: 10290, minLevel: 10, maxLevel: 19 },
-					{ id: 643, minLevel: 20, maxLevel: 29 },
-					{ id: 10291, minLevel: 30, maxLevel: 39 },
-					{ id: 1032, minLevel: 40, maxLevel: 49 },
-					{ id: 10292, minLevel: 50, maxLevel: 59 },
-					{ id: 10293, minLevel: 60 },
-				]),
-			impId: ActionId.fromSpellId(20142),
-			fieldName: 'devotionAura',
-		}),
-		makeBooleanRaidBuffInput({
-			actionId: player =>
-				player.getMatchingItemActionId([
-					{ id: 3013, maxLevel: 14 },
-					{ id: 1478, minLevel: 15, maxLevel: 29 },
-					{ id: 4421, minLevel: 30, maxLevel: 44 },
-					{ id: 10305, minLevel: 45 },
-				]),
-			fieldName: 'scrollOfProtection',
-		}),
-	],
+export const ArmorBuff = withLabel(
+	makeTristateRaidBuffInput({
+		actionId: player =>
+			player.getMatchingSpellActionId([
+				{ id: 465, maxLevel: 9 },
+				{ id: 10290, minLevel: 10, maxLevel: 19 },
+				{ id: 643, minLevel: 20, maxLevel: 29 },
+				{ id: 10291, minLevel: 30, maxLevel: 39 },
+				{ id: 1032, minLevel: 40, maxLevel: 49 },
+				{ id: 10292, minLevel: 50, maxLevel: 59 },
+				{ id: 10293, minLevel: 60 },
+			]),
+		impId: ActionId.fromSpellId(20142),
+		fieldName: 'devotionAura',
+	}),
 	'Armor',
 );
 
@@ -115,19 +103,25 @@ export const StaminaBuff = InputHelpers.makeMultiIconInput(
 	'Stamina',
 );
 
-export const BloodPactBuff = withLabel(
-	makeTristateRaidBuffInput({
-		actionId: player =>
-			player.getMatchingSpellActionId([
-				{ id: 6307, minLevel: 4, maxLevel: 13 },
-				{ id: 7804, minLevel: 14, maxLevel: 25 },
-				{ id: 7805, minLevel: 26, maxLevel: 37 },
-				{ id: 11766, minLevel: 38, maxLevel: 49 },
-				{ id: 11767, minLevel: 50 },
-			]),
-		impId: ActionId.fromSpellId(18696),
-		fieldName: 'bloodPact',
-	}),
+export const BloodPactBuff = InputHelpers.makeMultiIconInput(
+	[
+		makeTristateRaidBuffInput({
+			actionId: player =>
+				player.getMatchingSpellActionId([
+					{ id: 6307, minLevel: 4, maxLevel: 13 },
+					{ id: 7804, minLevel: 14, maxLevel: 25 },
+					{ id: 7805, minLevel: 26, maxLevel: 37 },
+					{ id: 11766, minLevel: 38, maxLevel: 49 },
+					{ id: 11767, minLevel: 50 },
+				]),
+			impId: ActionId.fromSpellId(18696),
+			fieldName: 'bloodPact',
+		}),
+		makeBooleanRaidBuffInput({
+			actionId: () => ActionId.fromSpellId(403215),
+			fieldName: 'commandingShout',
+		}),
+	],
 	'BloodPact',
 );
 
@@ -311,6 +305,15 @@ export const ResistanceBuff = InputHelpers.makeMultiIconInput(
 					{ id: 10958, minLevel: 56 },
 				]),
 			fieldName: 'shadowProtection',
+		}),
+		makeBooleanRaidBuffInput({
+			actionId: player =>
+				player.getMatchingSpellActionId([
+					{ id: 19876, minLevel: 28, maxLevel: 39 },
+					{ id: 19895, minLevel: 40, maxLevel: 51 },
+					{ id: 19896, minLevel: 52 },
+				]),
+			fieldName: 'shadowResistanceAura',
 		}),
 		// Nature
 		makeBooleanRaidBuffInput({
@@ -900,7 +903,7 @@ export const RAID_BUFFS_CONFIG = [
 	},
 	{
 		config: ArmorBuff,
-		picker: MultiIconPicker,
+		picker: IconPicker,
 		stats: [Stat.StatArmor],
 	},
 	{
@@ -910,7 +913,7 @@ export const RAID_BUFFS_CONFIG = [
 	},
 	{
 		config: BloodPactBuff,
-		picker: IconPicker,
+		picker: MultiIconPicker,
 		stats: [Stat.StatStamina],
 	},
 	{

--- a/ui/core/components/inputs/buffs_debuffs.ts
+++ b/ui/core/components/inputs/buffs_debuffs.ts
@@ -662,11 +662,23 @@ export const FaerieFire = withLabel(
 	'Faerie Fire',
 );
 
-// TODO: Classic
-// export const MinorArmorDebuff = InputHelpers.makeMultiIconInput([
-// 	makeTristateDebuffInput(ActionId.fromSpellId(770), ActionId.fromSpellId(33602), 'faerieFire'),
-// 	makeBooleanDebuffInput({actionId: () => ActionId.fromSpellId(50511), fieldName: 'curseOfWeakness'}),
-// ], 'Minor ArP');
+export const curseOfWeaknessDebuff = withLabel(
+	makeTristateDebuffInput({
+		actionId: player =>
+			player.getMatchingSpellActionId([
+				{ id: 702, minLevel: 4, maxLevel: 11 },
+				{ id: 1108, minLevel: 12, maxLevel: 21 },
+				{ id: 6205, minLevel: 22, maxLevel: 31 },
+				{ id: 6205, minLevel: 22, maxLevel: 31 },
+				{ id: 7646, minLevel: 32, maxLevel: 41 },
+				{ id: 11707, minLevel: 42, maxLevel: 51 },
+				{ id: 11708, minLevel: 52 },
+			]),
+		impId: ActionId.fromSpellId(18181),
+		fieldName: 'curseOfWeakness',
+	}),
+	'Curse of Weakness',
+);
 
 export const AttackPowerDebuff = InputHelpers.makeMultiIconInput(
 	[
@@ -721,6 +733,10 @@ export const MeleeAttackSpeedDebuff = InputHelpers.makeMultiIconInput(
 			multiplier: 10,
 			reverse: true,
 			fieldName: 'homunculi',
+		}),
+		makeBooleanDebuffInput({
+			actionId: () => ActionId.fromSpellId(408699),
+			fieldName: 'waylay',
 		}),
 	],
 	'Thunder Clap',
@@ -1151,16 +1167,13 @@ export const DEBUFFS_CONFIG = [
 		picker: IconPicker,
 		stats: [Stat.StatAttackPower],
 	},
-	// // {
-	// // 	config: MinorArmorDebuff,
-	// // 	picker: MultiIconPicker,
-	// // 	stats: [Stat.StatAttackPower]
-	// // },
 	{
 		config: BleedDebuff,
 		picker: IconPicker,
 		stats: [Stat.StatAttackPower, Stat.StatRangedAttackPower],
 	},
+
+	// Magic
 	{
 		config: JudgementOfTheCrusader,
 		picker: IconPicker,
@@ -1201,6 +1214,8 @@ export const DEBUFFS_CONFIG = [
 		picker: IconPicker,
 		stats: [Stat.StatShadowPower, Stat.StatArcanePower],
 	},
+
+	// Defensive
 	{
 		config: AttackPowerDebuff,
 		picker: MultiIconPicker,
@@ -1209,6 +1224,11 @@ export const DEBUFFS_CONFIG = [
 	{
 		config: MeleeAttackSpeedDebuff,
 		picker: MultiIconPicker,
+		stats: [Stat.StatArmor],
+	},
+	{
+		config: curseOfWeaknessDebuff,
+		picker: IconPicker,
 		stats: [Stat.StatArmor],
 	},
 	{

--- a/ui/core/components/inputs/consumables.ts
+++ b/ui/core/components/inputs/consumables.ts
@@ -656,6 +656,14 @@ export const RagePotion: ConsumableInputConfig<Potions> = {
 	value: Potions.RagePotion,
 	showWhen: player => player.getClass() == Class.ClassWarrior,
 };
+export const GreaterStoneshieldPotion: ConsumableInputConfig<Potions> = {
+	actionId: player => player.getMatchingItemActionId([{ id: 13455, minLevel: 46 }]),
+	value: Potions.GreaterStoneshieldPotion,
+};
+export const LesserStoneshieldPotion: ConsumableInputConfig<Potions> = {
+	actionId: player => player.getMatchingItemActionId([{ id: 4623, minLevel: 33 }]),
+	value: Potions.LesserStoneshieldPotion,
+};
 
 export const POTIONS_CONFIG: ConsumableStatOption<Potions>[] = [
 	{ config: MajorManaPotion, stats: [Stat.StatIntellect] },
@@ -666,6 +674,8 @@ export const POTIONS_CONFIG: ConsumableStatOption<Potions>[] = [
 	{ config: MightRagePotion, stats: [] },
 	{ config: GreatRagePotion, stats: [] },
 	{ config: RagePotion, stats: [] },
+	{ config: GreaterStoneshieldPotion, stats: [Stat.StatArmor] },
+	{ config: LesserStoneshieldPotion, stats: [Stat.StatArmor] },
 ];
 
 export const makePotionsInput = makeConsumeInputFactory({ consumesFieldName: 'defaultPotion' });

--- a/ui/core/components/inputs/consumables.ts
+++ b/ui/core/components/inputs/consumables.ts
@@ -641,6 +641,21 @@ export const MajorManaPotion: ConsumableInputConfig<Potions> = {
 	actionId: player => player.getMatchingItemActionId([{ id: 13444, minLevel: 49 }]),
 	value: Potions.MajorManaPotion,
 };
+export const MightRagePotion: ConsumableInputConfig<Potions> = {
+	actionId: player => player.getMatchingItemActionId([{ id: 13442, minLevel: 46 }]),
+	value: Potions.MightyRagePotion,
+	showWhen: player => player.getClass() == Class.ClassWarrior,
+};
+export const GreatRagePotion: ConsumableInputConfig<Potions> = {
+	actionId: player => player.getMatchingItemActionId([{ id: 5633, minLevel: 25 }]),
+	value: Potions.GreatRagePotion,
+	showWhen: player => player.getClass() == Class.ClassWarrior,
+};
+export const RagePotion: ConsumableInputConfig<Potions> = {
+	actionId: player => player.getMatchingItemActionId([{ id: 5631, minLevel: 4 }]),
+	value: Potions.RagePotion,
+	showWhen: player => player.getClass() == Class.ClassWarrior,
+};
 
 export const POTIONS_CONFIG: ConsumableStatOption<Potions>[] = [
 	{ config: MajorManaPotion, stats: [Stat.StatIntellect] },
@@ -648,6 +663,9 @@ export const POTIONS_CONFIG: ConsumableStatOption<Potions>[] = [
 	{ config: GreaterManaPotion, stats: [Stat.StatIntellect] },
 	{ config: ManaPotion, stats: [Stat.StatIntellect] },
 	{ config: LesserManaPotion, stats: [Stat.StatIntellect] },
+	{ config: MightRagePotion, stats: [] },
+	{ config: GreatRagePotion, stats: [] },
+	{ config: RagePotion, stats: [] },
 ];
 
 export const makePotionsInput = makeConsumeInputFactory({ consumesFieldName: 'defaultPotion' });

--- a/ui/core/components/inputs/consumables.ts
+++ b/ui/core/components/inputs/consumables.ts
@@ -1,6 +1,8 @@
 import { Player } from '../../player';
 import {
 	AgilityElixir,
+	Alcohol,
+	ArmorElixir,
 	AttackPowerBuff,
 	Class,
 	Conjured,
@@ -11,6 +13,7 @@ import {
 	Flask,
 	Food,
 	FrostPowerBuff,
+	HealthElixir,
 	ItemSlot,
 	ManaRegenElixir,
 	Potions,
@@ -321,6 +324,98 @@ export const DragonBreathChili = makeBooleanConsumeInput({
 	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 12217, minLevel: 35 }]),
 	fieldName: 'dragonBreathChili',
 });
+
+export const RumseyRumBlackLabel: ConsumableInputConfig<Alcohol> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 21151, minLevel: 1 }]),
+	value: Alcohol.AlcoholRumseyRumLight,
+};
+
+export const GordokGreenGrog: ConsumableInputConfig<Alcohol> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 18269, minLevel: 56 }]),
+	value: Alcohol.AlcoholRumseyRumLight,
+};
+
+export const RumseyRumDark: ConsumableInputConfig<Alcohol> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 21114, minLevel: 1 }]),
+	value: Alcohol.AlcoholRumseyRumLight,
+};
+
+export const RumseyRumLight: ConsumableInputConfig<Alcohol> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 20709, minLevel: 1 }]),
+	value: Alcohol.AlcoholRumseyRumLight,
+};
+
+export const KreegsStoutBeatdown: ConsumableInputConfig<Alcohol> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 18284, minLevel: 56 }]),
+	value: Alcohol.AlcoholRumseyRumLight,
+};
+
+export const ALCOHOL_CONFIG: ConsumableStatOption<Alcohol>[] = [
+	{ config: RumseyRumBlackLabel, stats: [Stat.StatStamina] },
+	{ config: GordokGreenGrog, stats: [Stat.StatStamina] },
+	{ config: RumseyRumDark, stats: [Stat.StatStamina] },
+	{ config: RumseyRumLight, stats: [Stat.StatStamina] },
+	{ config: KreegsStoutBeatdown, stats: [Stat.StatSpirit] },
+];
+
+export const makeAlcoholInput = makeConsumeInputFactory({ consumesFieldName: 'alcohol' });
+
+///////////////////////////////////////////////////////////////////////////
+//                                 DEFENSIVE CONSUMES
+///////////////////////////////////////////////////////////////////////////
+
+// Armor
+export const ElixirOfSuperiorDefense: ConsumableInputConfig<ArmorElixir> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 13445, minLevel: 43 }]),
+	value: ArmorElixir.ElixirOfSuperiorDefense,
+};
+export const ElixirOfGreaterDefense: ConsumableInputConfig<ArmorElixir> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 8951, minLevel: 29 }]),
+	value: ArmorElixir.ElixirOfGreaterDefense,
+};
+export const ElixirOfDefense: ConsumableInputConfig<ArmorElixir> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 3389, minLevel: 16 }]),
+	value: ArmorElixir.ElixirOfDefense,
+};
+export const ElixirOfMinorDefense: ConsumableInputConfig<ArmorElixir> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 5997, minLevel: 1 }]),
+	value: ArmorElixir.ElixirOfMinorDefense,
+};
+export const ScrollOfProtection: ConsumableInputConfig<ArmorElixir> = {
+	actionId: player =>
+		player.getMatchingItemActionId([
+			{ id: 3013, minLevel: 1, maxLevel: 14 },
+			{ id: 1478, minLevel: 15, maxLevel: 29 },
+			{ id: 4421, minLevel: 30, maxLevel: 44 },
+			{ id: 10305, minLevel: 45 },
+		]),
+	value: ArmorElixir.ScrollOfProtection,
+};
+export const ARMOR_CONSUMES_CONFIG: ConsumableStatOption<ArmorElixir>[] = [
+	{ config: ElixirOfSuperiorDefense, stats: [Stat.StatArmor] },
+	{ config: ElixirOfGreaterDefense, stats: [Stat.StatArmor] },
+	{ config: ElixirOfDefense, stats: [Stat.StatArmor] },
+	{ config: ElixirOfMinorDefense, stats: [Stat.StatArmor] },
+	{ config: ScrollOfProtection, stats: [Stat.StatArmor] },
+];
+
+export const makeArmorConsumeInput = makeConsumeInputFactory({ consumesFieldName: 'armorElixir' });
+
+// Health
+export const ElixirOfFortitude: ConsumableInputConfig<HealthElixir> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 3825, minLevel: 25 }]),
+	value: HealthElixir.ElixirOfFortitude,
+};
+export const ElixirOfMinorFortitude: ConsumableInputConfig<HealthElixir> = {
+	actionId: (player: Player<Spec>) => player.getMatchingItemActionId([{ id: 2458, minLevel: 2 }]),
+	value: HealthElixir.ElixirOfMinorFortitude,
+};
+export const HEALTH_CONSUMES_CONFIG: ConsumableStatOption<HealthElixir>[] = [
+	{ config: ElixirOfFortitude, stats: [Stat.StatStamina] },
+	{ config: ElixirOfMinorFortitude, stats: [Stat.StatStamina] },
+];
+
+export const makeHealthConsumeInput = makeConsumeInputFactory({ consumesFieldName: 'healthElixir' });
 
 ///////////////////////////////////////////////////////////////////////////
 //                                 PHYSICAL DAMAGE CONSUMES

--- a/ui/warrior/presets.ts
+++ b/ui/warrior/presets.ts
@@ -9,6 +9,7 @@ import {
 	EnchantedSigil,
 	HealthElixir,
 	IndividualBuffs,
+	Potions,
 	Profession,
 	RaidBuffs,
 	SaygesFortune,
@@ -168,6 +169,7 @@ export const DefaultConsumes = Consumes.create({
 	armorElixir: ArmorElixir.ElixirOfSuperiorDefense,
 	healthElixir: HealthElixir.HealthElixirUnknown,
 	alcohol: Alcohol.AlcoholUnknown,
+	defaultPotion: Potions.MightyRagePotion,
 });
 
 export const DefaultRaidBuffs = RaidBuffs.create({

--- a/ui/warrior/presets.ts
+++ b/ui/warrior/presets.ts
@@ -2,9 +2,12 @@ import { Phase } from '../core/constants/other.js';
 import * as PresetUtils from '../core/preset_utils.js';
 import {
 	AgilityElixir,
+	Alcohol,
+	ArmorElixir,
 	Consumes,
 	Debuffs,
 	EnchantedSigil,
+	HealthElixir,
 	IndividualBuffs,
 	Profession,
 	RaidBuffs,
@@ -162,6 +165,9 @@ export const DefaultConsumes = Consumes.create({
 	mainHandImbue: WeaponImbue.WildStrikes,
 	offHandImbue: WeaponImbue.DenseSharpeningStone,
 	strengthBuff: StrengthBuff.ElixirOfOgresStrength,
+	armorElixir: ArmorElixir.ElixirOfSuperiorDefense,
+	healthElixir: HealthElixir.HealthElixirUnknown,
+	alcohol: Alcohol.AlcoholUnknown,
 });
 
 export const DefaultRaidBuffs = RaidBuffs.create({

--- a/ui/warrior/sim.ts
+++ b/ui/warrior/sim.ts
@@ -16,7 +16,15 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecWarrior, {
 				'Wrecking crew assumed as lowest priority of enrage. Overwritten by regular enrage'],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatStrength, Stat.StatAgility, Stat.StatAttackPower, Stat.StatMeleeHit, Stat.StatMeleeCrit, Stat.StatMeleeHaste, Stat.StatArmor],
+	epStats: [
+		Stat.StatStrength, 
+		Stat.StatAgility, 
+		Stat.StatAttackPower, 
+		Stat.StatMeleeHit, 
+		Stat.StatMeleeCrit, 
+		Stat.StatMeleeHaste, 
+		Stat.StatStamina,
+		Stat.StatArmor],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatAttackPower,


### PR DESCRIPTION
Fixed stats on MotW, Battle Shout, retribution aura, devotion aura, Resistance effects, Rallying cry and Fengus' Ferocity.
Added commanding shout and shadow protection aura.
Changed armor buffs to grant bonus armor instead

Added alcohol, health and armor elixirs and, rage and armor potions
Moved Scroll of Protection from exclusive with devotion aura to exclusive with armor elixir.

tbc version of Blessing of Sanctity has been disabled.
Still missing Oil of Immolation and classic BoSanc