### PR TITLE
Warrior threat values and Shield Slam SoD change

### DIFF
--- a/sim/warrior/demoralizing_shout.go
+++ b/sim/warrior/demoralizing_shout.go
@@ -28,8 +28,8 @@ func (warrior *Warrior) registerDemoralizingShoutSpell() {
 			IgnoreHaste: true,
 		},
 
-		ThreatMultiplier: 1,
-		FlatThreatBonus:  63.2,
+		ThreatMultiplier: 0.4,
+		FlatThreatBonus:  0.4 * 2 * float64(core.DemoralizingShoutLevel[rank]),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for _, aoeTarget := range sim.Encounter.TargetUnits {

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -100,97 +100,97 @@ dps_results: {
  key: "TestArms-Lvl50-Average-Default"
  value: {
   dps: 1331.10887
-  tps: 1159.07418
+  tps: 1126.48341
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
   dps: 171.61837
-  tps: 282.87932
+  tps: 279.69585
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
   dps: 119.04686
-  tps: 110.07977
+  tps: 106.7459
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 221.89652
-  tps: 198.35303
+  tps: 194.34236
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
   dps: 77.75978
-  tps: 202.05109
+  tps: 198.86762
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
   dps: 53.69889
-  tps: 55.93633
+  tps: 52.60247
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 114.28005
-  tps: 109.30438
+  tps: 105.29371
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
   dps: 181.44018
-  tps: 291.70926
+  tps: 288.66366
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
   dps: 125.27482
-  tps: 115.29709
+  tps: 112.01336
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 233.04211
-  tps: 207.23154
+  tps: 203.59687
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
   dps: 82.03602
-  tps: 205.67519
+  tps: 202.62959
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
   dps: 56.60186
-  tps: 58.33397
+  tps: 55.05024
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 120.48751
-  tps: 113.94817
+  tps: 110.3135
  }
 }
 dps_results: {
  key: "TestArms-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
   dps: 1227.63319
-  tps: 1069.86661
+  tps: 1039.01461
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -100,97 +100,97 @@ dps_results: {
  key: "TestFury-Lvl40-Average-Default"
  value: {
   dps: 810.63111
-  tps: 755.50169
+  tps: 707.87732
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
   dps: 20.37359
-  tps: 56.34753
+  tps: 55.06913
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
   dps: 16.76075
-  tps: 17.99829
+  tps: 16.37989
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 32.51052
-  tps: 32.33025
+  tps: 29.67825
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
   dps: 10.06521
-  tps: 47.38368
+  tps: 46.10528
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
   dps: 8.31915
-  tps: 11.06471
+  tps: 9.44631
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Human-phase_2_dw-Fury-phase_2_fury-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 14.52074
-  tps: 17.84164
+  tps: 15.18964
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
   dps: 21.95139
-  tps: 57.74891
+  tps: 56.48411
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
   dps: 18.04809
-  tps: 19.04224
+  tps: 17.42384
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 37.52428
-  tps: 36.36404
+  tps: 33.71204
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
   dps: 10.85473
-  tps: 48.07875
+  tps: 46.81395
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
   dps: 8.89801
-  tps: 11.53668
+  tps: 9.91828
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-Settings-Orc-phase_2_dw-Fury-phase_2_fury-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
   dps: 16.67627
-  tps: 19.57853
+  tps: 16.92653
  }
 }
 dps_results: {
  key: "TestFury-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 756.3503
-  tps: 707.39878
+  tps: 661.82838
  }
 }

--- a/sim/warrior/hamstring.go
+++ b/sim/warrior/hamstring.go
@@ -19,6 +19,13 @@ func (warrior *Warrior) registerHamstringSpell() {
 		60: 27584,
 	}[warrior.Level]
 
+	spell_level := map[int32]int32{
+		25: 8,
+		40: 32,
+		50: 32,
+		60: 54,
+	}[warrior.Level]
+
 	warrior.Hamstring = warrior.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: spellID},
 		SpellSchool: core.SpellSchoolPhysical,
@@ -39,7 +46,8 @@ func (warrior *Warrior) registerHamstringSpell() {
 		CritDamageBonus: warrior.impale(),
 
 		DamageMultiplier: 1,
-		ThreatMultiplier: 1,
+		ThreatMultiplier: 1.25,
+		FlatThreatBonus:  1.25 * 2 * float64(spell_level),
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -19,6 +19,14 @@ func (warrior *Warrior) registerHeroicStrikeSpell() {
 		60: 11567,
 	}[warrior.Level]
 
+	// No known equation
+	threat := map[int32]float64{
+		25: 68,  //guess
+		40: 103, //guess
+		50: 120,
+		60: 173,
+	}[warrior.Level]
+
 	warrior.HeroicStrike = warrior.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: spellID},
 		SpellSchool: core.SpellSchoolPhysical,
@@ -35,7 +43,7 @@ func (warrior *Warrior) registerHeroicStrikeSpell() {
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		FlatThreatBonus:  259,
+		FlatThreatBonus:  threat,
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -72,6 +80,13 @@ func (warrior *Warrior) registerCleaveSpell() {
 		60: 20569,
 	}[warrior.Level]
 
+	threat := map[int32]float64{
+		25: 20, //guess
+		40: 60, //guess
+		50: 80,
+		60: 100,
+	}[warrior.Level]
+
 	flatDamageBonus += []float64{1, 1.4, 1.8, 2.2}[warrior.Talents.ImprovedCleave]
 
 	results := make([]*core.SpellResult, min(int32(2), warrior.Env.GetNumTargets()))
@@ -91,7 +106,7 @@ func (warrior *Warrior) registerCleaveSpell() {
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		FlatThreatBonus:  225,
+		FlatThreatBonus:  threat,
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/revenge.go
+++ b/sim/warrior/revenge.go
@@ -72,8 +72,8 @@ func (warrior *Warrior) registerRevengeSpell(cdTimer *core.Timer) {
 		CritDamageBonus: warrior.impale(),
 
 		DamageMultiplier: 1,
-		ThreatMultiplier: 1,
-		FlatThreatBonus:  121,
+		ThreatMultiplier: 2.25,
+		FlatThreatBonus:  2.25 * 2 * float64(RevengeLevel[rank]),
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/shield_slam.go
+++ b/sim/warrior/shield_slam.go
@@ -15,10 +15,11 @@ func (warrior *Warrior) registerShieldSlamSpell() {
 		spellID    int32
 		damageLow  float64
 		damageHigh float64
+		threat     float64
 	}{
-		40: {spellID: 23922, damageLow: 225, damageHigh: 235},
-		50: {spellID: 23923, damageLow: 264, damageHigh: 276},
-		60: {spellID: 23925, damageLow: 342, damageHigh: 358},
+		40: {spellID: 23922, damageLow: 225, damageHigh: 235, threat: 178},
+		50: {spellID: 23923, damageLow: 264, damageHigh: 276, threat: 203},
+		60: {spellID: 23925, damageLow: 342, damageHigh: 358, threat: 254},
 	}[warrior.Level]
 
 	warrior.ShieldSlam = warrior.RegisterSpell(core.SpellConfig{
@@ -49,12 +50,12 @@ func (warrior *Warrior) registerShieldSlamSpell() {
 		CritDamageBonus: warrior.impale(),
 
 		DamageMultiplier: 1,
-		ThreatMultiplier: 1.3,
-		FlatThreatBonus:  770, // TODO level-dependent
+		ThreatMultiplier: 2,
+		FlatThreatBonus:  rank.threat * 2,
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			damage := sim.Roll(rank.damageLow, rank.damageHigh) + warrior.BlockValue()
+			damage := sim.Roll(rank.damageLow, rank.damageHigh) + warrior.BlockValue()*2
 
 			result := spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMeleeSpecialHitAndCrit)
 

--- a/sim/warrior/shouts.go
+++ b/sim/warrior/shouts.go
@@ -8,7 +8,7 @@ import (
 
 const ShoutExpirationThreshold = time.Second * 3
 
-func (warrior *Warrior) newShoutSpellConfig(actionID core.ActionID, allyAuras core.AuraArray) *core.Spell {
+func (warrior *Warrior) newShoutSpellConfig(actionID core.ActionID, rank int32, allyAuras core.AuraArray) *core.Spell {
 	return warrior.RegisterSpell(core.SpellConfig{
 		ActionID: actionID,
 		Flags:    core.SpellFlagNoOnCastComplete | core.SpellFlagAPL | core.SpellFlagHelpful,
@@ -22,6 +22,8 @@ func (warrior *Warrior) newShoutSpellConfig(actionID core.ActionID, allyAuras co
 			},
 			IgnoreHaste: true,
 		},
+
+		FlatThreatBonus: float64(core.BattleShoutLevel[rank]),
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
 			for _, aura := range allyAuras {
@@ -39,7 +41,7 @@ func (warrior *Warrior) registerBattleShout() {
 	rank := core.LevelToBuffRank[core.BattleShout][warrior.Level]
 	actionId := core.BattleShoutSpellId[rank]
 
-	warrior.BattleShout = warrior.newShoutSpellConfig(core.ActionID{SpellID: actionId}, warrior.NewPartyAuraArray(func(unit *core.Unit) *core.Aura {
+	warrior.BattleShout = warrior.newShoutSpellConfig(core.ActionID{SpellID: actionId}, rank, warrior.NewPartyAuraArray(func(unit *core.Unit) *core.Aura {
 		return core.BattleShoutAura(unit, warrior.Talents.ImprovedBattleShout, warrior.Talents.BoomingVoice)
 	}))
 }

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -31,6 +31,12 @@ func (warrior *Warrior) registerSlamSpell() {
 		60: 87,
 	}[warrior.Level]
 
+	spell_level := map[int32]float64{
+		40: 38,
+		50: 46,
+		60: 54,
+	}[warrior.Level]
+
 	spellID := map[int32]int32{
 		40: 8820,
 		50: 11604,
@@ -66,7 +72,7 @@ func (warrior *Warrior) registerSlamSpell() {
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		FlatThreatBonus:  140,
+		FlatThreatBonus:  1 * spell_level,
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/warrior/sunder_armor.go
+++ b/sim/warrior/sunder_armor.go
@@ -15,6 +15,13 @@ func (warrior *Warrior) newSunderArmorSpell() *core.Spell {
 		60: 11597,
 	}[warrior.Level]
 
+	spell_level := map[int32]int32{
+		25: 22,
+		40: 34,
+		50: 46,
+		60: 58,
+	}[warrior.Level]
+
 	var effectiveStacks int32
 	var canApplySunder bool
 
@@ -72,7 +79,7 @@ func (warrior *Warrior) newSunderArmorSpell() *core.Spell {
 		},
 
 		ThreatMultiplier: 1,
-		FlatThreatBonus:  360, // TODO Warrior: set threat according to spell's level
+		FlatThreatBonus:  2.25 * 2 * float64(spell_level),
 
 		RelatedAuras: []core.AuraArray{warrior.SunderArmorAuras},
 


### PR DESCRIPTION
Updated threat values for warrior abilities. Most still have leftover tbc values. Almost all abilities derive their threat bonuses directly from spell level, except Heroic Strike, Cleave and Shield Slam. 

Shield slam was tested for all ranks, but guesses via interpolation had to be made for Heroic Strike rank 4 and 6 and Cleave rank 1 and 3 for levels 25 and 40 respectively. Theses guesses are marked in the code for future developers or anyone with a level 25 / 40 warrior to find.

The testing methodology from [Threat Values in https://github.com/magey/classic-warrior/wiki/Threat-Mechanic](https://github.com/magey/classic-warrior/wiki/Threat-Mechanics#threat-values) was used