### PR TITLE
Quick Draw & Shiv refund fix

### DIFF
--- a/sim/rogue/expose_armor.go
+++ b/sim/rogue/expose_armor.go
@@ -40,7 +40,8 @@ func (rogue *Rogue) registerExposeArmorSpell() {
 		MetricSplits: 6,
 
 		EnergyCost: core.EnergyCostOptions{
-			Cost: 25,
+			Cost:   25,
+			Refund: 0,
 		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{

--- a/sim/rogue/quick_draw.go
+++ b/sim/rogue/quick_draw.go
@@ -34,7 +34,7 @@ func (rogue *Rogue) registerQuickDrawSpell() {
 
 		EnergyCost: core.EnergyCostOptions{
 			Cost:   []float64{25, 22, 20}[rogue.Talents.ImprovedSinisterStrike],
-			Refund: 0.8,
+			Refund: 0,
 		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{

--- a/sim/rogue/shiv.go
+++ b/sim/rogue/shiv.go
@@ -66,6 +66,10 @@ func (rogue *Rogue) registerShivSpell() {
 					}
 				}
 			}
+
+			if !result.Landed() {
+				spell.IssueRefund(sim)
+			}
 		},
 	})
 }

--- a/sim/shaman/lava_lash.go
+++ b/sim/shaman/lava_lash.go
@@ -31,6 +31,7 @@ func (shaman *Shaman) applyLavaLash() {
 
 		ManaCost: core.ManaCostOptions{
 			BaseCost: manaCost,
+			// Refund: 0.8, -- Not implemented for ManaCostOption
 		},
 
 		Cast: core.CastConfig{
@@ -50,7 +51,11 @@ func (shaman *Shaman) applyLavaLash() {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := (spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower())) *
 				shaman.AutoAttacks.OHConfig().DamageMultiplier
-			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+
+			if !result.Landed() {
+				spell.IssueRefund(sim)
+			}
 		},
 	})
 }


### PR DESCRIPTION
Based on ability flags:
Removed refund from Quick Draw
Added missing part of refund for Shiv.
Added placeholder for refund to Lava Lash, as the only mana ability with refund enabled.