### PR TITLE
Stacking Extra Attacks & Ironfoe

### DIFF
--- a/sim/common/sod/item_effects/phase_3.go
+++ b/sim/common/sod/item_effects/phase_3.go
@@ -442,7 +442,7 @@ func init() {
 				}
 
 				if ppmm.Proc(sim, procMask, "Cobra Fang Claw Extra Attack") {
-					character.AutoAttacks.ExtraMHAttack(sim)
+					character.AutoAttacks.ExtraMHAttack(sim, 1)
 				}
 			},
 		})

--- a/sim/common/sod/item_effects/phase_3.go
+++ b/sim/common/sod/item_effects/phase_3.go
@@ -442,7 +442,7 @@ func init() {
 				}
 
 				if ppmm.Proc(sim, procMask, "Cobra Fang Claw Extra Attack") {
-					character.AutoAttacks.ExtraMHAttack(sim, 1)
+					character.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{ItemID: 220588})
 				}
 			},
 		})

--- a/sim/common/sod/items_sets/phase_3.go
+++ b/sim/common/sod/items_sets/phase_3.go
@@ -270,6 +270,7 @@ var ItemSetWailingBerserkersPlateArmor = core.NewItemSet(core.ItemSet{
 				Callback:   core.CallbackOnSpellHitDealt,
 				ProcMask:   core.ProcMaskMelee,
 				ProcChance: 0.03,
+				ICD:        200 * time.Millisecond,
 				Handler:    handler,
 			})
 		},

--- a/sim/common/sod/items_sets/phase_3.go
+++ b/sim/common/sod/items_sets/phase_3.go
@@ -261,7 +261,7 @@ var ItemSetWailingBerserkersPlateArmor = core.NewItemSet(core.ItemSet{
 			c := agent.GetCharacter()
 
 			handler := func(sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
-				c.AutoAttacks.ExtraMHAttack(sim)
+				c.AutoAttacks.ExtraMHAttack(sim, 1)
 			}
 
 			core.MakeProcTriggerAura(&c.Unit, core.ProcTrigger{

--- a/sim/common/sod/items_sets/phase_3.go
+++ b/sim/common/sod/items_sets/phase_3.go
@@ -261,7 +261,7 @@ var ItemSetWailingBerserkersPlateArmor = core.NewItemSet(core.ItemSet{
 			c := agent.GetCharacter()
 
 			handler := func(sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
-				c.AutoAttacks.ExtraMHAttack(sim, 1)
+				c.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{SpellID: 449970})
 			}
 
 			core.MakeProcTriggerAura(&c.Unit, core.ProcTrigger{

--- a/sim/common/vanilla/item_effects.go
+++ b/sim/common/vanilla/item_effects.go
@@ -30,6 +30,7 @@ const (
 	Firebreather             = 10797
 	VilerendSlicer           = 11603
 	HookfangShanker          = 11635
+	Ironfoe                  = 11684
 	HandOfJustice            = 11815
 	LinkensSwordOfMastery    = 11902
 	SearingNeedle            = 12531
@@ -449,6 +450,20 @@ func init() {
 			ThreatMultiplier: 1,
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 				character.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{SpellID: 21919})
+			},
+		})
+	})
+
+	itemhelpers.CreateWeaponProcSpell(Ironfoe, "Ironfoe", 1.0, func(character *core.Character) *core.Spell {
+		return character.RegisterSpell(core.SpellConfig{
+			ActionID:         core.ActionID{SpellID: 15494},
+			SpellSchool:      core.SpellSchoolPhysical,
+			DefenseType:      core.DefenseTypeMelee,
+			ProcMask:         core.ProcMaskEmpty,
+			DamageMultiplier: 1,
+			ThreatMultiplier: 1,
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				character.AutoAttacks.ExtraMHAttack(sim, 2, core.ActionID{SpellID: 15494})
 			},
 		})
 	})

--- a/sim/common/vanilla/item_effects.go
+++ b/sim/common/vanilla/item_effects.go
@@ -129,7 +129,7 @@ func init() {
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				character.AutoAttacks.ExtraMHAttack(sim)
+				character.AutoAttacks.ExtraMHAttack(sim, 1)
 			},
 		})
 	})
@@ -390,7 +390,7 @@ func init() {
 
 				if sim.RandomFloat("HandOfJustice") < 0.02 {
 					icd.Use(sim)
-					aura.Unit.AutoAttacks.ExtraMHAttack(sim)
+					aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1)
 				}
 			},
 		})
@@ -448,7 +448,7 @@ func init() {
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				character.AutoAttacks.ExtraMHAttack(sim)
+				character.AutoAttacks.ExtraMHAttack(sim, 1)
 			},
 		})
 	})

--- a/sim/common/vanilla/item_effects.go
+++ b/sim/common/vanilla/item_effects.go
@@ -129,7 +129,7 @@ func init() {
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				character.AutoAttacks.ExtraMHAttack(sim, 1)
+				character.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{SpellID: 18797})
 			},
 		})
 	})
@@ -390,7 +390,7 @@ func init() {
 
 				if sim.RandomFloat("HandOfJustice") < 0.02 {
 					icd.Use(sim)
-					aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1)
+					aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{SpellID: 15600})
 				}
 			},
 		})
@@ -448,7 +448,7 @@ func init() {
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				character.AutoAttacks.ExtraMHAttack(sim, 1)
+				character.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{SpellID: 21919})
 			},
 		})
 	})

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -240,8 +240,9 @@ type WeaponAttack struct {
 
 	replaceSwing ReplaceMHSwing
 
-	swingAt     time.Duration
-	lastSwingAt time.Duration
+	swingAt      time.Duration
+	lastSwingAt  time.Duration
+	extraAttacks int32
 
 	curSwingSpeed    float64
 	curSwingDuration time.Duration
@@ -284,6 +285,8 @@ func (wa *WeaponAttack) swing(sim *Simulation) time.Duration {
 		isExtraAttack := wa.spell.Tag == tagExtraAttack
 
 		attackSpell.Cast(sim, wa.unit.CurrentTarget)
+
+		wa.extraAttacks = 0
 
 		if isExtraAttack {
 			wa.spell.SetMetricsSplit(0)
@@ -620,10 +623,11 @@ func (aa *AutoAttacks) UpdateSwingTimers(sim *Simulation) {
 }
 
 // ExtraMHAttack should be used for all "extra attack" procs in Classic Era versions, including Wild Strikes and Hand of Justice. In vanilla, these procs don't actually grant a full extra attack, but instead just advance the MH swing timer.
-func (aa *AutoAttacks) ExtraMHAttack(sim *Simulation) {
+func (aa *AutoAttacks) ExtraMHAttack(sim *Simulation, attacks int32) {
 	aa.mh.swingAt = sim.CurrentTime + SpellBatchWindow
 	aa.mh.spell.SetMetricsSplit(1)
 	sim.rescheduleWeaponAttack(aa.mh.swingAt)
+	aa.mh.extraAttacks += attacks
 }
 
 // StopMeleeUntil should be used whenever a non-melee spell is cast. It stops melee, then restarts it

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -286,7 +286,14 @@ func (wa *WeaponAttack) swing(sim *Simulation) time.Duration {
 
 		attackSpell.Cast(sim, wa.unit.CurrentTarget)
 
-		wa.extraAttacks = 0
+		if wa.extraAttacks > 0 {
+			// Ignore the first extra attack, that was used to speed up next attack
+			for i := int32(1); i < wa.extraAttacks; i++ {
+				// use original attacks for subsequent extra Attacks
+				wa.spell.Cast(sim, wa.unit.CurrentTarget)
+			}
+			wa.extraAttacks = 0
+		}
 
 		if isExtraAttack {
 			wa.spell.SetMetricsSplit(0)

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -623,7 +623,10 @@ func (aa *AutoAttacks) UpdateSwingTimers(sim *Simulation) {
 }
 
 // ExtraMHAttack should be used for all "extra attack" procs in Classic Era versions, including Wild Strikes and Hand of Justice. In vanilla, these procs don't actually grant a full extra attack, but instead just advance the MH swing timer.
-func (aa *AutoAttacks) ExtraMHAttack(sim *Simulation, attacks int32) {
+func (aa *AutoAttacks) ExtraMHAttack(sim *Simulation, attacks int32, actionID ActionID) {
+	if sim.Log != nil {
+		aa.mh.unit.Log(sim, "gains %d extra attacks from %s", attacks, actionID)
+	}
 	aa.mh.swingAt = sim.CurrentTime + SpellBatchWindow
 	aa.mh.spell.SetMetricsSplit(1)
 	sim.rescheduleWeaponAttack(aa.mh.swingAt)

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1947,7 +1947,7 @@ func ApplyWildStrikes(character *Character) *Aura {
 				wsBuffAura.Activate(sim)
 				// aura is up _after_ the triggering swing lands, so the aura always stays up after the extra attack
 				wsBuffAura.SetStacks(sim, 2)
-				aura.Unit.AutoAttacks.ExtraMHAttack(sim)
+				aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1)
 			}
 		},
 	}))
@@ -2017,7 +2017,7 @@ func ApplyWindfury(character *Character) *Aura {
 				} else {
 					windfuryBuffAura.SetStacks(sim, 2)
 				}
-				aura.Unit.AutoAttacks.ExtraMHAttack(sim)
+				aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1)
 			}
 		},
 	}))

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1947,7 +1947,7 @@ func ApplyWildStrikes(character *Character) *Aura {
 				wsBuffAura.Activate(sim)
 				// aura is up _after_ the triggering swing lands, so the aura always stays up after the extra attack
 				wsBuffAura.SetStacks(sim, 2)
-				aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1)
+				aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1, buffActionID)
 			}
 		},
 	}))
@@ -2017,7 +2017,7 @@ func ApplyWindfury(character *Character) *Aura {
 				} else {
 					windfuryBuffAura.SetStacks(sim, 2)
 				}
-				aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1)
+				aura.Unit.AutoAttacks.ExtraMHAttack(sim, 1, ActionID{SpellID: 10610})
 			}
 		},
 	}))

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestBM-Lvl25-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.46929
+  weights: 0.4664
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02212
-  weights: 2.33325
-  weights: 1.99622
+  weights: 0.02213
+  weights: 2.36452
+  weights: 1.99061
   weights: 0
   weights: 0
   weights: 0
@@ -126,7 +126,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.12943
+  weights: 0.12947
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestBM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.76922
+  weights: 0.76926
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.33548
-  weights: 9.97552
-  weights: 8.30309
+  weights: 0.3356
+  weights: 9.93351
+  weights: 8.34283
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +175,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.06401
+  weights: 0.06397
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestBM-Lvl25-Average-Default"
  value: {
-  dps: 229.99576
-  tps: 101.07065
+  dps: 230.08241
+  tps: 101.14104
  }
 }
 dps_results: {
@@ -211,15 +211,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 222.24485
-  tps: 98.54786
+  dps: 222.74304
+  tps: 99.00951
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 269.10295
-  tps: 111.57336
+  dps: 269.21689
+  tps: 111.72258
  }
 }
 dps_results: {
@@ -232,15 +232,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 110.69835
-  tps: 55.75383
+  dps: 110.7661
+  tps: 55.77544
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 131.55269
-  tps: 60.70392
+  dps: 131.55101
+  tps: 60.6926
  }
 }
 dps_results: {
@@ -253,15 +253,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 223.59412
-  tps: 96.80934
+  dps: 223.6765
+  tps: 96.78394
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 271.48448
-  tps: 109.60168
+  dps: 271.5931
+  tps: 109.74743
  }
 }
 dps_results: {
@@ -274,15 +274,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 111.19525
-  tps: 54.89322
+  dps: 111.16644
+  tps: 54.8084
  }
 }
 dps_results: {
  key: "TestBM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 132.09049
-  tps: 61.24651
+  dps: 131.8852
+  tps: 61.2339
  }
 }
 dps_results: {
@@ -295,8 +295,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 879.24113
-  tps: 267.91747
+  dps: 879.07634
+  tps: 268.32235
  }
 }
 dps_results: {

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestMM-Lvl25-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.41653
+  weights: 0.41626
   weights: 0
   weights: 0
   weights: 0
@@ -117,8 +117,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.02327
-  weights: 2.30994
-  weights: 1.61791
+  weights: 2.28519
+  weights: 1.59397
   weights: 0
   weights: 0
   weights: 0
@@ -126,7 +126,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.12016
+  weights: 0.12005
   weights: 0
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestMM-Lvl25-Average-Default"
  value: {
-  dps: 209.87
-  tps: 101.46482
+  dps: 209.95274
+  tps: 101.5374
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 210.59446
-  tps: 109.92364
+  dps: 210.49104
+  tps: 109.86498
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 197.84134
-  tps: 96.42495
+  dps: 197.92217
+  tps: 96.2358
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 246.58924
-  tps: 115.38404
+  dps: 246.83243
+  tps: 115.27243
  }
 }
 dps_results: {
@@ -232,15 +232,15 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 98.88615
-  tps: 55.0393
+  dps: 99.02204
+  tps: 55.13582
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Dwarf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 119.78955
-  tps: 63.05469
+  dps: 119.91997
+  tps: 63.18492
  }
 }
 dps_results: {
@@ -253,15 +253,15 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 201.89376
-  tps: 96.84123
+  dps: 201.88357
+  tps: 96.90499
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 251.82752
-  tps: 115.81576
+  dps: 252.08806
+  tps: 115.70406
  }
 }
 dps_results: {
@@ -274,22 +274,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 101.72302
-  tps: 55.53138
+  dps: 101.64771
+  tps: 55.52753
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 121.76784
-  tps: 62.70285
+  dps: 121.81706
+  tps: 62.68916
  }
 }
 dps_results: {
  key: "TestMM-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 207.30519
-  tps: 100.54611
+  dps: 207.33817
+  tps: 100.59725
  }
 }
 dps_results: {

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestSV-Lvl25-Average-Default"
  value: {
-  dps: 209.27722
-  tps: 99.58194
+  dps: 209.34676
+  tps: 99.6615
  }
 }
 dps_results: {
@@ -211,15 +211,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 202.44
-  tps: 97.11311
+  dps: 202.27027
+  tps: 96.98789
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 257.33083
-  tps: 114.33382
+  dps: 257.32355
+  tps: 114.48659
  }
 }
 dps_results: {
@@ -232,15 +232,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 100.55451
-  tps: 54.18102
+  dps: 100.62444
+  tps: 54.26406
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-NightElf-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 125.21638
-  tps: 60.60317
+  dps: 125.21504
+  tps: 60.53762
  }
 }
 dps_results: {
@@ -253,15 +253,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 203.58847
-  tps: 95.91106
+  dps: 203.34542
+  tps: 95.6315
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 258.69044
-  tps: 112.50165
+  dps: 258.46288
+  tps: 112.44074
  }
 }
 dps_results: {
@@ -274,22 +274,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 100.47232
-  tps: 53.50536
+  dps: 100.43025
+  tps: 53.46346
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-Settings-Orc-phase1-Basic-p1_weave-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 124.46336
-  tps: 61.93222
+  dps: 124.41494
+  tps: 61.84778
  }
 }
 dps_results: {
  key: "TestSV-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 206.32254
-  tps: 98.70545
+  dps: 206.37504
+  tps: 98.78682
  }
 }
 dps_results: {
@@ -302,8 +302,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
-  dps: 878.17862
-  tps: 305.13898
+  dps: 878.17624
+  tps: 305.14763
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -148,12 +148,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestRetribution-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.44446
-  weights: 0.23392
+  weights: 0.44437
+  weights: 0.24099
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.132
+  weights: 0.13219
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.4256
+  weights: 0.46322
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.20203
-  weights: 1.23045
-  weights: 2.08601
+  weights: 0.20199
+  weights: 1.29612
+  weights: 2.087
   weights: 0
   weights: 0
   weights: 0
@@ -386,8 +386,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 223.6379
-  tps: 229.85482
+  dps: 224.00222
+  tps: 230.21914
  }
 }
 dps_results: {

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestAssassination-Lvl25-Average-Default"
  value: {
-  dps: 292.58782
-  tps: 207.73735
+  dps: 292.58557
+  tps: 207.73575
  }
 }
 dps_results: {
@@ -295,8 +295,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Lvl40-Average-Default"
  value: {
-  dps: 634.70159
-  tps: 450.63813
+  dps: 634.69923
+  tps: 450.63646
  }
 }
 dps_results: {

--- a/sim/rogue/sword_specialization.go
+++ b/sim/rogue/sword_specialization.go
@@ -36,7 +36,7 @@ func (rogue *Rogue) registerSwordSpecialization(mask core.ProcMask) {
 			}
 			if sim.RandomFloat("Sword Specialization") < procChance {
 				icd.Use(sim)
-				rogue.AutoAttacks.ExtraMHAttack(sim)
+				rogue.AutoAttacks.ExtraMHAttack(sim, 1)
 			}
 		},
 	})

--- a/sim/rogue/sword_specialization.go
+++ b/sim/rogue/sword_specialization.go
@@ -36,7 +36,7 @@ func (rogue *Rogue) registerSwordSpecialization(mask core.ProcMask) {
 			}
 			if sim.RandomFloat("Sword Specialization") < procChance {
 				icd.Use(sim)
-				rogue.AutoAttacks.ExtraMHAttack(sim, 1)
+				rogue.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{SpellID: 13964})
 			}
 		},
 	})

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -50,8 +50,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestArms-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.22892
-  weights: 0.83088
+  weights: 1.21516
+  weights: 0.95892
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42284
-  weights: 15.43844
-  weights: 13.87321
+  weights: 0.37515
+  weights: 16.11781
+  weights: 13.06259
   weights: 0
   weights: 0
   weights: 0
@@ -99,8 +99,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestArms-Lvl50-Average-Default"
  value: {
-  dps: 1331.10887
-  tps: 1126.48341
+  dps: 1348.89873
+  tps: 1141.30113
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestArms-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1227.63319
-  tps: 1039.01461
+  dps: 1245.05006
+  tps: 1055.23141
  }
 }

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -68,7 +68,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.04525
-  weights: 10.99655
+  weights: 10.94364
   weights: 11.09269
   weights: 0
   weights: 0

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -148,7 +148,7 @@ func (warrior *Warrior) registerSwordSpecialization(procMask core.ProcMask) {
 			}
 			if sim.RandomFloat("Sword Specialization") < procChance {
 				icd.Use(sim)
-				warrior.AutoAttacks.ExtraMHAttack(sim, 1)
+				warrior.AutoAttacks.ExtraMHAttack(sim, 1, core.ActionID{SpellID: 12815})
 			}
 		},
 	})

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -148,7 +148,7 @@ func (warrior *Warrior) registerSwordSpecialization(procMask core.ProcMask) {
 			}
 			if sim.RandomFloat("Sword Specialization") < procChance {
 				icd.Use(sim)
-				warrior.AutoAttacks.ExtraMHAttack(sim)
+				warrior.AutoAttacks.ExtraMHAttack(sim, 1)
 			}
 		},
 	})


### PR DESCRIPTION
Does so multiple extra attack procs can cause multiple extra attacks.
Adds 200ms cooldown to Wailing Berserker set bonus
Adds Ironfoe
Displays extra attack source in log events
Additional auto attacks beyound the first will always use the default auto attack rather then replacement spell.

Proof of stacking extra attacks here: (Thrash, Wild Strike)
https://sod.warcraftlogs.com/reports/Qtq7GBn1ZYNxFTJK#fight=5&type=summary&source=19&view=events&eventstart=1574000

And triple proc here: (Wild strike, Thrash, Thrash)
https://sod.warcraftlogs.com/reports/Qtq7GBn1ZYNxFTJK#fight=6&type=summary&source=19&view=events&eventstart=2251550


