### PR TITLE
Missing warrior talents

### DIFF
--- a/sim/warrior/berserker_rage.go
+++ b/sim/warrior/berserker_rage.go
@@ -13,6 +13,7 @@ func (warrior *Warrior) registerBerserkerRageSpell() {
 
 	actionID := core.ActionID{SpellID: 18499}
 	rageMetrics := warrior.NewRageMetrics(actionID)
+	instantRage := 5 * float64(warrior.Talents.ImprovedBerserkerRage)
 	rageMultiplier := 1.0
 
 	warrior.BerserkerRageAura = warrior.RegisterAura(core.Aura{
@@ -42,6 +43,9 @@ func (warrior *Warrior) registerBerserkerRageSpell() {
 			},
 		},
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+			if instantRage > 0 {
+				warrior.AddRage(sim, instantRage, rageMetrics)
+			}
 			warrior.BerserkerRageAura.Activate(sim)
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {

--- a/sim/warrior/heroic_strike_cleave.go
+++ b/sim/warrior/heroic_strike_cleave.go
@@ -87,7 +87,7 @@ func (warrior *Warrior) registerCleaveSpell() {
 		60: 100,
 	}[warrior.Level]
 
-	flatDamageBonus += []float64{1, 1.4, 1.8, 2.2}[warrior.Talents.ImprovedCleave]
+	flatDamageBonus *= []float64{1, 1.4, 1.8, 2.2}[warrior.Talents.ImprovedCleave]
 
 	results := make([]*core.SpellResult, min(int32(2), warrior.Env.GetNumTargets()))
 

--- a/sim/warrior/runes.go
+++ b/sim/warrior/runes.go
@@ -140,7 +140,9 @@ func (warrior *Warrior) applyConsumedByRage() {
 			}
 
 			warrior.ConsumedByRageAura.Activate(sim)
-			warrior.ConsumedByRageAura.SetStacks(sim, 12)
+			if warrior.ConsumedByRageAura.IsActive() {
+				warrior.ConsumedByRageAura.SetStacks(sim, 12)
+			}
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if !warrior.ConsumedByRageAura.IsActive() {

--- a/sim/warrior/shield_wall.go
+++ b/sim/warrior/shield_wall.go
@@ -45,7 +45,7 @@ func (warrior *Warrior) RegisterShieldWallCD() {
 			},
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return warrior.StanceMatches(DefensiveStance) || warrior.StanceMatches(GladiatorStance)
+			return warrior.PseudoStats.CanBlock && (warrior.StanceMatches(DefensiveStance) || warrior.StanceMatches(GladiatorStance))
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -22,7 +22,7 @@ func (warrior *Warrior) registerSlamSpell() {
 			Duration: 6 * time.Second,
 		}
 	} else {
-		castTime = time.Millisecond*1500 - time.Millisecond*500*time.Duration(warrior.Talents.ImprovedSlam)
+		castTime = time.Millisecond*1500 - time.Millisecond*100*time.Duration(warrior.Talents.ImprovedSlam)
 	}
 
 	flatDamageBonus := map[int32]float64{

--- a/sim/warrior/stances.go
+++ b/sim/warrior/stances.go
@@ -84,12 +84,12 @@ func (warrior *Warrior) registerDefensiveStanceAura() {
 		ActionID: core.ActionID{SpellID: 71},
 		Duration: core.NeverExpires,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.ThreatMultiplier *= 1.3
+			aura.Unit.PseudoStats.ThreatMultiplier *= 1.3 * []float64{1, 1.03, 1.06, 1.09, 1.12, 1.15}[warrior.Talents.Defiance]
 			aura.Unit.PseudoStats.DamageDealtMultiplier *= 0.9
 			aura.Unit.PseudoStats.DamageTakenMultiplier *= 0.9
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.PseudoStats.ThreatMultiplier /= 1.3
+			aura.Unit.PseudoStats.ThreatMultiplier /= 1.3 * []float64{1, 1.03, 1.06, 1.09, 1.12, 1.15}[warrior.Talents.Defiance]
 			aura.Unit.PseudoStats.DamageDealtMultiplier /= 0.9
 			aura.Unit.PseudoStats.DamageTakenMultiplier /= 0.9
 		},

--- a/sim/warrior/sunder_armor.go
+++ b/sim/warrior/sunder_armor.go
@@ -38,6 +38,10 @@ func (warrior *Warrior) newSunderArmorSpell() *core.Spell {
 
 			ThreatMultiplier: 1,
 
+			ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
+				return warrior.PseudoStats.CanBlock && (warrior.StanceMatches(DefensiveStance) || warrior.StanceMatches(GladiatorStance))
+			},
+
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 				weapon := warrior.AutoAttacks.MH()
 				baseDamage := weapon.CalculateAverageWeaponDamage(spell.MeleeAttackPower()) / weapon.SwingSpeed
@@ -84,7 +88,7 @@ func (warrior *Warrior) newSunderArmorSpell() *core.Spell {
 		RelatedAuras: []core.AuraArray{warrior.SunderArmorAuras},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMeleeWeaponSpecialNoCrit) // completely stopped by blocks
+			result := spell.CalcAndDealOutcome(sim, target, spell.OutcomeMeleeWeaponSpecialNoCrit) // Cannot be blocked
 
 			if !result.Landed() {
 				spell.IssueRefund(sim)

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -243,7 +243,7 @@ func (warrior *Warrior) applyShieldSpecialization() {
 			aura.Activate(sim)
 		},
 		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			if result.Outcome.Matches(core.OutcomeBlock | core.OutcomeDodge | core.OutcomeParry) {
+			if result.Outcome.Matches(core.OutcomeBlock) {
 				if sim.Proc(procChance, "Shield Specialization") {
 					warrior.AddRage(sim, 1.0, rageMetrics)
 				}

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -25,6 +25,7 @@ func (warrior *Warrior) ApplyTalents() {
 	warrior.applyTwoHandedWeaponSpecialization()
 	warrior.applyWeaponSpecializations()
 	warrior.applyUnbridledWrath()
+	warrior.applyEnrage()
 	warrior.applyFlurry()
 	warrior.applyShieldSpecialization()
 	warrior.registerDeathWishCD()
@@ -176,6 +177,58 @@ func (warrior *Warrior) applyUnbridledWrath() {
 
 			if spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) && sim.RandomFloat("Unbrided Wrath") < procChance {
 				warrior.AddRage(sim, 1, rageMetrics)
+			}
+		},
+	})
+}
+
+func (warrior *Warrior) applyEnrage() {
+	if warrior.Talents.Enrage == 0 {
+		return
+	}
+
+	warrior.EnrageAura = warrior.GetOrRegisterAura(core.Aura{
+		Label:     "Enrage",
+		ActionID:  core.ActionID{SpellID: 13048},
+		Duration:  time.Second * 12,
+		MaxStacks: 12,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			warrior.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= 1 + 0.05*float64(warrior.Talents.Enrage)
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			warrior.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] /= 1 + 0.05*float64(warrior.Talents.Enrage)
+		},
+	})
+
+	warrior.EnrageAura.NewExclusiveEffect("Enrage", true, core.ExclusiveEffect{Priority: 5 * float64(warrior.Talents.Enrage)})
+
+	warrior.RegisterAura(core.Aura{
+		Label:    "Enrage Trigger",
+		Duration: core.NeverExpires,
+		OnReset: func(aura *core.Aura, sim *core.Simulation) {
+			aura.Activate(sim)
+		},
+		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !warrior.EnrageAura.IsActive() {
+				return
+			}
+
+			if spell.ProcMask.Matches(core.ProcMaskMelee) {
+				warrior.EnrageAura.RemoveStack(sim)
+			}
+		},
+		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			if !spell.ProcMask.Matches(core.ProcMaskMelee) {
+				return
+			}
+
+			if !result.Outcome.Matches(core.OutcomeCrit) {
+				return
+			}
+
+			warrior.EnrageAura.Activate(sim)
+			if warrior.EnrageAura.IsActive() {
+				warrior.EnrageAura.SetStacks(sim, 12)
 			}
 		},
 	})

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -138,6 +138,7 @@ func (warrior *Warrior) Initialize() {
 	warrior.SunderArmor = warrior.newSunderArmorSpell()
 
 	warrior.registerBloodrageCD()
+	warrior.RegisterShieldBlockCD()
 }
 
 func (warrior *Warrior) Reset(_ *core.Simulation) {

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -45,6 +45,7 @@ type Warrior struct {
 	RampageAura            *core.Aura
 	rampageValidAura       *core.Aura
 	WreckingCrewEnrageAura *core.Aura
+	EnrageAura             *core.Aura
 
 	// Rune passive
 	FocusedRageDiscount float64


### PR DESCRIPTION
Adds Enrage and Defiance talents
Fixes Imp Cleave typo
Reverts Shield Spec, and Imp Slam to classic version
Adds stance & shield requirements to Devastate and Shield Wall
Implemented vanilla version of Shield Block, and added Imp Shield Block.

Now only missing: Blood Craze, Piercing howl and the talents that do not work vs bosses.

Note: Shield block is now available for all warriors. But, it is disabled with regard to auto cooldown usage.