### PR TITLE
Updated Berserker Rage rage generation

### DIFF
--- a/sim/warrior/berserker_rage.go
+++ b/sim/warrior/berserker_rage.go
@@ -14,7 +14,6 @@ func (warrior *Warrior) registerBerserkerRageSpell() {
 	actionID := core.ActionID{SpellID: 18499}
 	rageMetrics := warrior.NewRageMetrics(actionID)
 	instantRage := 5 * float64(warrior.Talents.ImprovedBerserkerRage)
-	rageMultiplier := 1.0
 
 	warrior.BerserkerRageAura = warrior.RegisterAura(core.Aura{
 		Label:    "Berserker Rage",
@@ -22,10 +21,21 @@ func (warrior *Warrior) registerBerserkerRageSpell() {
 		Duration: time.Second * 10,
 
 		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-			rageConversionDamageTaken := core.GetRageConversion(spell.Unit.Level)
-			generatedRage := result.Damage * 2.5 / rageConversionDamageTaken
-			generatedRage *= rageMultiplier
-			warrior.AddRage(sim, generatedRage, rageMetrics)
+			if !result.Landed() || result.Damage <= 0 {
+				return
+			}
+
+			if spell.ProcMask.Matches(core.ProcMaskMeleeOrRanged) {
+				// For melee attacks we find that it gives around 2.0 extra rage regardless of attacker level
+				// This may give less rage for fast attacks, but we default to 2.0 for now
+				warrior.AddRage(sim, 2.0, rageMetrics)
+			} else if spell.ProcMask.Matches(core.ProcMaskSpellDamage) {
+				// Spell attacks generally give 1 - 2 times unmodified damage as additional rage.
+				rageConversionDamageTaken := core.GetRageConversion(spell.Unit.Level)
+				generatedRage := result.RawDamage() * 2.5 / rageConversionDamageTaken
+				generatedRage *= 1.0 // Using 1.0 because we don't know why it gives more sometimes
+				warrior.AddRage(sim, generatedRage, rageMetrics)
+			}
 		},
 	})
 


### PR DESCRIPTION
Based on new experiments rage from berserker rage has been updated to
* 2 rage from melee & ranged attacks
* Spell attacks now give 1.0 times the unmodified damage taken.


Note: For anyone reading this in the future these are the experimental results:
* Rage gain is based on unmodified damage unlike how regular rage from damage works. Specifically pre-critical damage and pre damage reduction.
* Melee rage gain is around 1.0-2.5 rage per hit regardless of attacker level. Average is above 2.0 for low level mobs, and at 2.0 for high level mobs, all with 2.0 attack speed.
* There appear to be a clear correlation with attack speed
* Spell attacks give a large amount of rage, with a spell dependent multiplier, that gives either 1.0, 1.5, 2.0 or 2.5 times rage one would expect from the regular rage from damage equation damage dealt.
These are unknowns
* If ranged attacks are treated differently from melee
* If twohanded or offhand attacks are treated differently
* If attack speed slows impact rage gain from melee
* If dots give rage
* If environmental (fire/fall) damage gives rage