### PR TITLE
Seal of Righteousness

### DIFF
--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -518,16 +518,6 @@ func (spell *Spell) Cast(sim *Simulation, target *Unit) bool {
 	return spell.castFn(sim, target)
 }
 
-// Skips the actual cast and applies spell effects immediately.
-func (spell *Spell) SkipCastAndApplyEffects(sim *Simulation, target *Unit) {
-	if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
-		spell.Unit.Log(sim, "Casting %s (Cost = %0.03f, Cast Time = %s)",
-			spell.ActionID, spell.DefaultCast.Cost, time.Duration(0))
-		spell.Unit.Log(sim, "Completed cast %s", spell.ActionID)
-	}
-	spell.applyEffects(sim, target)
-}
-
 func (spell *Spell) applyEffects(sim *Simulation, target *Unit) {
 	spell.SpellMetrics[target.UnitIndex].Casts++
 	spell.casts++

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -339,7 +339,7 @@ func (spell *Spell) dealDamageInternal(sim *Simulation, isPeriodic bool, result 
 		sim.Encounter.DamageTaken += result.Damage
 	}
 
-	if sim.Log != nil {
+	if sim.Log != nil && !spell.Flags.Matches(SpellFlagNoLogs) {
 		if isPeriodic {
 			spell.Unit.Log(sim, "%s %s tick %s. (Threat: %0.3f)", result.Target.LogLabel(), spell.ActionID, result.DamageString(), result.Threat)
 		} else {
@@ -505,10 +505,6 @@ func (spell *Spell) attackerDamageMultiplierInternal(attackTable *AttackTable) f
 }
 
 func (result *SpellResult) applyTargetModifiers(spell *Spell, attackTable *AttackTable, isPeriodic bool) {
-	if spell.Flags.Matches(SpellFlagIgnoreTargetModifiers) {
-		return
-	}
-
 	if isPeriodic {
 		if dot := spell.DotOrAOEDot(attackTable.Defender); dot.BonusCoefficient > 0 {
 			result.Damage += attackTable.Defender.GetSchoolBonusDamageTaken(spell) * dot.BonusCoefficient

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -102,17 +102,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.14218
+  weights: -0.14235
   weights: 0
-  weights: 0.62902
-  weights: 0
-  weights: 0
+  weights: 0.62915
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.64568
+  weights: 0
+  weights: 0
+  weights: 3.64584
   weights: 1.78293
   weights: 0
   weights: 0
@@ -151,17 +151,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.2968
+  weights: 2.29377
   weights: 0
-  weights: 0.75365
-  weights: 0
-  weights: 0
+  weights: 0.75349
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 12.28448
+  weights: 0
+  weights: 0
+  weights: 12.27979
   weights: 8.02564
   weights: 0
   weights: 0
@@ -197,29 +197,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-Average-Default"
  value: {
-  dps: 589.02381
-  tps: 558.31485
+  dps: 589.22603
+  tps: 558.51706
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 585.30386
-  tps: 1187.38523
+  dps: 585.50819
+  tps: 1187.58956
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 585.30386
-  tps: 554.19023
+  dps: 585.50819
+  tps: 554.39457
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 575.10165
-  tps: 534.11193
+  dps: 575.26832
+  tps: 534.27859
  }
 }
 dps_results: {
@@ -246,63 +246,63 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 589.59543
-  tps: 558.41429
+  dps: 589.7996
+  tps: 558.61846
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Average-Default"
  value: {
-  dps: 1376.85817
-  tps: 1152.25445
+  dps: 1377.24262
+  tps: 1152.63891
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1961.00017
-  tps: 2688.50556
+  dps: 1961.38637
+  tps: 2688.89176
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1357.71388
-  tps: 1132.53756
+  dps: 1358.10008
+  tps: 1132.92376
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1455.82732
-  tps: 1217.21464
+  dps: 1456.24516
+  tps: 1217.63248
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1223.04728
-  tps: 2092.75699
+  dps: 1223.31478
+  tps: 2093.02449
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 770.38712
-  tps: 640.724
+  dps: 770.65462
+  tps: 640.9915
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-Settings-Orc-nf.ruin-Destruction Warlock-nf.ruin-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 758.49633
-  tps: 649.68819
+  dps: 758.9755
+  tps: 650.16736
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1365.28313
-  tps: 1139.51599
+  dps: 1365.65773
+  tps: 1139.89059
  }
 }

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -53,9 +53,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.17667
+  weights: 0.17664
   weights: 0
-  weights: 0.67825
+  weights: 0.67821
   weights: 0
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Average-Default"
  value: {
-  dps: 174.72622
-  tps: 327.21329
+  dps: 174.91342
+  tps: 327.49408
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 211.02064
-  tps: 613.78737
+  dps: 211.17991
+  tps: 614.02627
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 174.97843
-  tps: 327.67162
+  dps: 175.1658
+  tps: 327.95267
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-AffItemSwap-p1.affi.tank-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 183.48171
-  tps: 348.70497
+  dps: 183.66304
+  tps: 348.97697
  }
 }
 dps_results: {
@@ -148,22 +148,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 211.02064
-  tps: 613.78737
+  dps: 211.17991
+  tps: 614.02627
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 174.97843
-  tps: 327.67162
+  dps: 175.1658
+  tps: 327.95267
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 183.48171
-  tps: 348.70497
+  dps: 183.66304
+  tps: 348.97697
  }
 }
 dps_results: {
@@ -190,7 +190,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 175.05525
-  tps: 327.78685
+  dps: 175.24262
+  tps: 328.0679
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -53,17 +53,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.03124
+  weights: -0.03185
   weights: 0
-  weights: 1.21203
-  weights: 0
-  weights: 0
+  weights: 1.21226
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.56627
+  weights: 0
+  weights: 0
+  weights: 6.56805
   weights: 1.41855
   weights: 0
   weights: 0
@@ -99,29 +99,29 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 583.51479
-  tps: 1116.35268
+  dps: 583.69669
+  tps: 1116.62553
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 547.17913
-  tps: 1566.36708
+  dps: 547.35956
+  tps: 1566.63773
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 547.17913
-  tps: 1054.1079
+  dps: 547.35956
+  tps: 1054.37855
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 573.74021
-  tps: 1105.31698
+  dps: 573.91938
+  tps: 1105.58573
  }
 }
 dps_results: {
@@ -148,7 +148,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 578.5522
-  tps: 1106.04337
+  dps: 578.73776
+  tps: 1106.32172
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -249,17 +249,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.57289
+  weights: -1.57537
   weights: 0
-  weights: 1.22065
-  weights: 0
-  weights: 0
+  weights: 1.22057
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.46623
+  weights: 0
+  weights: 0
+  weights: 5.46997
   weights: 5.26549
   weights: 0
   weights: 0
@@ -407,32 +407,32 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1312.79728
-  tps: 2149.2677
+  dps: 1312.98918
+  tps: 2149.55556
   hps: 19.38905
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1878.02588
-  tps: 3940.4153
+  dps: 1878.22128
+  tps: 3940.7084
   hps: 15.26058
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1243.3602
-  tps: 2017.04243
+  dps: 1243.55137
+  tps: 2017.32918
   hps: 15.20799
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1240.30471
-  tps: 2021.38175
+  dps: 1240.49971
+  tps: 2021.67425
   hps: 15.50589
  }
 }
@@ -463,8 +463,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1277.24381
-  tps: 2084.94784
+  dps: 1277.43261
+  tps: 2085.23104
   hps: 19.74617
  }
 }


### PR DESCRIPTION
[paladin] update SoR to reflect test results (higher ranks scale with 20% instead of 18.4% SP, and include the slightly weird bonus damage taken interaction)

[core] SpellFlagIgnoreAttackerModifiers and SpellFlagIgnoreTargetModifiers now both suppress multipliers, but leave bonusCoefficient scaling working, for consistency

[warlock] ... which causes minimal test changes (cp. Drain Life's and Siphon Life's "How does it interact with bonus damage taken" comments)