### PR TITLE
Add missing ilvl filters

### DIFF
--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -1103,6 +1103,13 @@ export class Player<SpecType extends Spec> {
 			return itemData.filter(itemElem => filterFunc(getItemFunc(itemElem)));
 		};
 
+		if (filters.minIlvl != 0) {
+			itemData = filterItems(itemData, item => item.ilvl >= filters.minIlvl);
+		}
+		if (filters.maxIlvl != 0) {
+			itemData = filterItems(itemData, item => item.ilvl <= filters.maxIlvl);
+		}
+
 		if (filters.factionRestriction != UIItem_FactionRestriction.UNSPECIFIED) {
 			itemData = filterItems(
 				itemData,


### PR DESCRIPTION
Seems like this was just missed when it was back ported? Pulled the exact changes from https://github.com/wowsims/cata/blob/master/ui/core/player.ts#L1275 and everything works fine.