### PR TITLE
fix: dreadmist set bonus should grant health instead of mana

### DIFF
--- a/sim/common/sod/items_sets/dungeon_set_1.go
+++ b/sim/common/sod/items_sets/dungeon_set_1.go
@@ -377,12 +377,10 @@ var ItemSetDreadmistRaiment = core.NewItemSet(core.ItemSet{
 		6: func(agent core.Agent) {
 			c := agent.GetCharacter()
 			actionID := core.ActionID{SpellID: 450585}
-			manaMetrics := c.NewManaMetrics(core.ActionID{SpellID: 450583})
+			healthMetrics := c.NewHealthMetrics(core.ActionID{SpellID: 450583})
 
 			handler := func(sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
-				if c.HasManaBar() {
-					c.AddMana(sim, sim.Roll(270, 300), manaMetrics)
-				}
+				c.GainHealth(sim, sim.Roll(270, 300), healthMetrics)
 			}
 
 			core.MakeProcTriggerAura(&c.Unit, core.ProcTrigger{


### PR DESCRIPTION
Probably just a typo, [proc](https://www.wowhead.com/classic/spell=450583/dark-reward) tooltip and effect are both `heal`