### PR TITLE
Hunter trapfixes

### DIFF
--- a/sim/hunter/frost_trap.go
+++ b/sim/hunter/frost_trap.go
@@ -21,7 +21,7 @@ func (hunter *Hunter) getFrostTrapConfig(timer *core.Timer) core.SpellConfig {
 		MissileSpeed:  24,
 
 		ManaCost: core.ManaCostOptions{
-			FlatCost: 60,
+			FlatCost: 60 * hunter.resourcefulnessManacostModifier(),
 		},
 		Cast: core.CastConfig{
 			CD: core.Cooldown{
@@ -32,6 +32,9 @@ func (hunter *Hunter) getFrostTrapConfig(timer *core.Timer) core.SpellConfig {
 				GCD: core.GCDDefault,
 			},
 			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
+		},
+		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
+			return hunter.DistanceFromTarget <= hunter.trapRange()
 		},
 
 		DamageMultiplier: 1 + 0.15*float64(hunter.Talents.CleverTraps),
@@ -48,10 +51,6 @@ func (hunter *Hunter) getFrostTrapConfig(timer *core.Timer) core.SpellConfig {
 }
 
 func (hunter *Hunter) registerFrostTrapSpell(timer *core.Timer) {
-	if !hunter.HasRune(proto.HunterRune_RuneBootsTrapLauncher) {
-		return
-	}
-
 	config := hunter.getFrostTrapConfig(timer)
 
 	if config.RequiredLevel <= int(hunter.Level) {

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -119,12 +119,21 @@ func (hunter *Hunter) Initialize() {
 	hunter.registerCarveSpell()
 	hunter.registerWingClipSpell()
 
-	fireTraps := hunter.NewTimer()
-	frostTraps := hunter.NewTimer()
+	// Trap Launcher rune also splits the cooldowns between frost traps and fire traps, without the rune all traps share a cd
+	if hunter.HasRune(proto.HunterRune_RuneBootsTrapLauncher) {
+		fireTraps := hunter.NewTimer()
+		frostTraps := hunter.NewTimer()
+	
+		hunter.registerExplosiveTrapSpell(fireTraps)
+		hunter.registerImmolationTrapSpell(fireTraps)
+		hunter.registerFrostTrapSpell(frostTraps)
+	} else {
+		traps := hunter.NewTimer()
 
-	hunter.registerExplosiveTrapSpell(fireTraps)
-	hunter.registerImmolationTrapSpell(fireTraps)
-	hunter.registerFrostTrapSpell(frostTraps)
+		hunter.registerExplosiveTrapSpell(traps)
+		hunter.registerImmolationTrapSpell(traps)
+		hunter.registerFrostTrapSpell(traps)
+	}
 
 	// hunter.registerKillCommand()
 	hunter.registerRapidFire()

--- a/sim/hunter/immolation_trap.go
+++ b/sim/hunter/immolation_trap.go
@@ -27,7 +27,7 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 		MissileSpeed:  24,
 
 		ManaCost: core.ManaCostOptions{
-			FlatCost: manaCost,
+			FlatCost: manaCost * hunter.resourcefulnessManacostModifier(),
 		},
 		Cast: core.CastConfig{
 			CD: core.Cooldown{
@@ -38,6 +38,9 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 				GCD: core.GCDDefault,
 			},
 			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
+		},
+		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
+			return hunter.DistanceFromTarget <= hunter.trapRange()
 		},
 
 		DamageMultiplier: (1 + 0.15*float64(hunter.Talents.CleverTraps)) * hunter.tntDamageMultiplier(),
@@ -78,10 +81,6 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 }
 
 func (hunter *Hunter) registerImmolationTrapSpell(timer *core.Timer) {
-	if !hunter.HasRune(proto.HunterRune_RuneBootsTrapLauncher) {
-		return
-	}
-
 	maxRank := 5
 	for i := 1; i <= maxRank; i++ {
 		config := hunter.getImmolationTrapConfig(i, timer)

--- a/sim/hunter/runes.go
+++ b/sim/hunter/runes.go
@@ -32,7 +32,7 @@ func (hunter *Hunter) ApplyRunes() {
 	}
 
 	if hunter.HasRune(proto.HunterRune_RuneChestLoneWolf) && hunter.pet == nil {
-		hunter.PseudoStats.DamageDealtMultiplier *= 1.3
+		hunter.PseudoStats.DamageDealtMultiplier *= 1.4
 	}
 
 	if hunter.HasRune(proto.HunterRune_RuneHandsBeastmastery) && hunter.pet != nil {

--- a/sim/hunter/runes.go
+++ b/sim/hunter/runes.go
@@ -279,6 +279,13 @@ func (hunter *Hunter) tntDamageFlatBonus() float64 {
 	return 0.0
 }
 
+func (hunter *Hunter) trapRange() float64 {
+	if hunter.HasRune(proto.HunterRune_RuneBootsTrapLauncher) {
+		return 35;
+	}
+	return 5;
+}
+
 func (hunter *Hunter) resourcefulnessManacostModifier() float64 {
 	if hunter.HasRune(proto.HunterRune_RuneCloakResourcefulness) {
 		return 0.0


### PR DESCRIPTION
Fixed an issue where a target could take Immolation Trap DoT damage and Explosive Trap DoT damage at the same time.

Updated hunter traps to be available all the time rather than just when trap launcher rune is equipped.
trap launcher rune now increases trap range requirements from 5 -> 35
all traps now share a cooldown unless the trap launcher rune is equipped then fire traps and frost traps have independent cooldowns.
![Screenshot 2024-06-28 145823](https://github.com/wowsims/sod/assets/72539181/c1d469c7-9739-403e-8c2c-781dbaa8d3af)


Updated Lone Wolf rune damage bonus from 30% to 40%.
![Screenshot 2024-06-28 145926](https://github.com/wowsims/sod/assets/72539181/4bc29b21-f792-425c-a375-a2727ba62b52)

Corresponding Blue Post: https://us.forums.blizzard.com/en/wow/t/wow-classic-season-of-discovery-phase-4-ptr-development-notes-updated-6282024/1883827 
