### PR TITLE
Updates several rogue runes to latest patch

### DIFF
--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -32,7 +32,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 		Flags:       rogue.builderFlags(),
 
 		EnergyCost: core.EnergyCostOptions{
-			Cost:   60 - core.TernaryFloat64(rogue.HasRune(proto.RogueRune_RuneSlaughterFromTheShadows), 20, 0),
+			Cost:   60 - core.TernaryFloat64(rogue.HasRune(proto.RogueRune_RuneSlaughterFromTheShadows), 30, 0),
 			Refund: 0.8,
 		},
 		Cast: core.CastConfig{
@@ -55,7 +55,7 @@ func (rogue *Rogue) registerBackstabSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.BreakStealth(sim)
-			baseDamage := flatDamageBonus + spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
+			baseDamage := (flatDamageBonus + spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())) * core.TernaryFloat64(rogue.HasRune(proto.RogueRune_RuneSlaughterFromTheShadows), 1.6, 1)
 
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 

--- a/sim/rogue/runes.go
+++ b/sim/rogue/runes.go
@@ -2,7 +2,7 @@ package rogue
 
 import (
 	"time"
-	"fmt"
+	
 	"github.com/wowsims/sod/sim/core"
 	"github.com/wowsims/sod/sim/core/proto"
 	"github.com/wowsims/sod/sim/core/stats"

--- a/sim/rogue/runes.go
+++ b/sim/rogue/runes.go
@@ -2,7 +2,7 @@ package rogue
 
 import (
 	"time"
-
+	"fmt"
 	"github.com/wowsims/sod/sim/core"
 	"github.com/wowsims/sod/sim/core/proto"
 	"github.com/wowsims/sod/sim/core/stats"
@@ -190,15 +190,14 @@ func (rogue *Rogue) registerBladeDance() {
 	cachedBonusAP := 0.0
 	apProcAura := rogue.RegisterAura(core.Aura{
 		Label: "Defender's Resolve",
-		// TODO: Verify ID. I couldn't find a separate one at the moment
 		ActionID: core.ActionID{SpellID: 462230},
 		Duration: rogue.bladeDanceDurations[5],
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			cachedBonusAP = 4 * max(rogue.GetStat(stats.Defense)-float64(5*rogue.Level), 0)
+			cachedBonusAP = 4 * max(rogue.GetStat(stats.Defense), 0)
 			rogue.AddStatDynamic(sim, stats.AttackPower, cachedBonusAP)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			rogue.AddStatDynamic(sim, stats.AttackPower, cachedBonusAP)
+			rogue.AddStatDynamic(sim, stats.AttackPower, -cachedBonusAP)
 		},
 	})
 

--- a/sim/rogue/runes.go
+++ b/sim/rogue/runes.go
@@ -187,6 +187,21 @@ func (rogue *Rogue) registerBladeDance() {
 		time.Duration(time.Second * 30),
 	}
 
+	cachedBonusAP := 0.0
+	apProcAura := rogue.RegisterAura(core.Aura{
+		Label: "Defender's Resolve",
+		// TODO: Verify ID. I couldn't find a separate one at the moment
+		ActionID: core.ActionID{SpellID: 462230},
+		Duration: rogue.bladeDanceDurations[5],
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			cachedBonusAP = 4 * max(rogue.GetStat(stats.Defense)-float64(5*rogue.Level), 0)
+			rogue.AddStatDynamic(sim, stats.AttackPower, cachedBonusAP)
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			rogue.AddStatDynamic(sim, stats.AttackPower, cachedBonusAP)
+		},
+	})
+
 	rogue.BladeDanceAura = rogue.RegisterAura(core.Aura{
 		Label:    "Blade Dance",
 		ActionID: core.ActionID{SpellID: int32(proto.RogueRune_RuneBladeDance)},
@@ -231,6 +246,7 @@ func (rogue *Rogue) registerBladeDance() {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.BladeDanceAura.Duration = rogue.bladeDanceDurations[rogue.ComboPoints()]
 			rogue.BladeDanceAura.Activate(sim)
+			apProcAura.Activate(sim)
 			rogue.ApplyFinisher(sim, spell)
 		},
 	})

--- a/sim/rogue/saber_slash.go
+++ b/sim/rogue/saber_slash.go
@@ -26,7 +26,7 @@ func (rogue *Rogue) registerSaberSlashSpell() {
 				Label:     "Saber Slash - Bleed",
 				Tag:       RogueBleedTag,
 				Duration:  time.Second * 12,
-				MaxStacks: 5,
+				MaxStacks: 3,
 			},
 			NumberOfTicks: 6,
 			TickLength:    time.Second * 2,
@@ -44,7 +44,7 @@ func (rogue *Rogue) registerSaberSlashSpell() {
 				}
 
 				// each stack snapshots the AP it was applied with
-				dot.SnapshotBaseDamage += 0.03 * dot.Spell.MeleeAttackPower()
+				dot.SnapshotBaseDamage += 0.05 * dot.Spell.MeleeAttackPower()
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickCounted)
@@ -109,5 +109,5 @@ func (rogue *Rogue) saberSlashMultiplier(target *core.Unit) float64 {
 	if rogue.saberSlashTick == nil {
 		return 1
 	}
-	return 1 + 0.2*float64(rogue.saberSlashTick.Dot(target).GetStacks())
+	return 1 + 0.33*float64(rogue.saberSlashTick.Dot(target).GetStacks())
 }

--- a/sim/rogue/shuriken_toss.go
+++ b/sim/rogue/shuriken_toss.go
@@ -32,6 +32,10 @@ func (rogue *Rogue) registerShurikenTossSpell() {
 				GCD: time.Second,
 			},
 			IgnoreHaste: true,
+			CD: core.Cooldown{
+				Timer:    rogue.NewTimer(),
+				Duration: time.Second * 30,
+			},
 		},
 
 		DamageMultiplier: 1,
@@ -39,7 +43,8 @@ func (rogue *Rogue) registerShurikenTossSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.BreakStealth(sim)
-			baseDamage := spell.MeleeAttackPower() * 0.15
+			baseDamage := spell.MeleeAttackPower() * 0.50
+			var combopoints int32 = 0
 
 			for idx := range results {
 				results[idx] = spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)
@@ -48,10 +53,11 @@ func (rogue *Rogue) registerShurikenTossSpell() {
 
 			for _, result := range results {
 				spell.DealDamage(sim, result)
+				combopoints++
 			}
 
 			if results[0].Landed() {
-				rogue.AddComboPoints(sim, 1, spell.ComboPointMetrics())
+				rogue.AddComboPoints(sim, combopoints, spell.ComboPointMetrics())
 			}
 		},
 	})

--- a/sim/rogue/unfair_advantage.go
+++ b/sim/rogue/unfair_advantage.go
@@ -46,7 +46,7 @@ func (rogue *Rogue) applyUnfairAdvantage() {
 		},
 		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			// need to add parry
-			if result.Outcome == core.OutcomeDodge && icd.IsReady(sim) {
+			if result.Outcome.Matches(core.OutcomeDodge | core.OutcomeParry) && icd.IsReady(sim) {
 				unfairAdvantage.Cast(sim, spell.Unit)
 				rogue.AddComboPoints(sim, 1, comboMetrics)
 				icd.Use(sim)

--- a/sim/rogue/unfair_advantage.go
+++ b/sim/rogue/unfair_advantage.go
@@ -11,6 +11,7 @@ func (rogue *Rogue) applyUnfairAdvantage() {
 	if !rogue.HasRune(proto.RogueRune_RuneUnfairAdvantage) {
 		return
 	}
+	comboMetrics := rogue.NewComboPointMetrics(core.ActionID{SpellID: 432274})
 
 	unfairAdvantage := rogue.GetOrRegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 432274},
@@ -44,8 +45,10 @@ func (rogue *Rogue) applyUnfairAdvantage() {
 			aura.Activate(sim)
 		},
 		OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			// need to add parry
 			if result.Outcome == core.OutcomeDodge && icd.IsReady(sim) {
 				unfairAdvantage.Cast(sim, spell.Unit)
+				rogue.AddComboPoints(sim, 1, comboMetrics)
 				icd.Use(sim)
 			}
 		},

--- a/sim/shaman/runes.go
+++ b/sim/shaman/runes.go
@@ -169,7 +169,7 @@ func (shaman *Shaman) applyShieldMastery() {
 		ActionID: core.ActionID{SpellID: 408525},
 		Duration: time.Second * 15,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			cachedBonusAP = 4 * max(shaman.GetStat(stats.Defense)-float64(5*shaman.Level), 0)
+			cachedBonusAP = 4 * max(shaman.GetStat(stats.Defense), 0)
 			shaman.AddStatDynamic(sim, stats.SpellPower, cachedBonusAP)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {


### PR DESCRIPTION
1. Shuriken Toss - Adjusted AP to 50%, added CP for targets and 30s cooldown
2. Poisoned Knife - Added energy return scaling on DP stacks, removed minimum range
3. Saber Slash - Dropped from 5 to 3 stacks, increased scaling to 33% and did 5% AP scaling per wowhead
4. Slaughter from Shadows - 60% damage increase + reduction in cost
5. Unfair Advantage - I tried several syntax to test dodge + parry but couldnt get it right, works with just dodge right now
6. Blade Dance - AP scaling not working, not sure issue


@catszeid If you could take a look at this and let me know on 5 and 6.