### PR TITLE
Implemented Trap Mastery talent

### DIFF
--- a/sim/hunter/explosive_trap.go
+++ b/sim/hunter/explosive_trap.go
@@ -46,6 +46,8 @@ func (hunter *Hunter) getExplosiveTrapConfig(rank int, timer *core.Timer) core.S
 			return hunter.DistanceFromTarget <= hunter.trapRange()
 		},
 
+		BonusHitRating: hunter.trapMastery(),
+
 		DamageMultiplier: (1 + 0.15*float64(hunter.Talents.CleverTraps)) * hunter.tntDamageMultiplier(),
 		ThreatMultiplier: 1,
 

--- a/sim/hunter/frost_trap.go
+++ b/sim/hunter/frost_trap.go
@@ -37,6 +37,8 @@ func (hunter *Hunter) getFrostTrapConfig(timer *core.Timer) core.SpellConfig {
 			return hunter.DistanceFromTarget <= hunter.trapRange()
 		},
 
+		BonusHitRating: hunter.trapMastery(),
+
 		DamageMultiplier: 1 + 0.15*float64(hunter.Talents.CleverTraps),
 		ThreatMultiplier: 1,
 

--- a/sim/hunter/immolation_trap.go
+++ b/sim/hunter/immolation_trap.go
@@ -43,6 +43,8 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 			return hunter.DistanceFromTarget <= hunter.trapRange()
 		},
 
+		BonusHitRating: hunter.trapMastery(),
+
 		DamageMultiplier: (1 + 0.15*float64(hunter.Talents.CleverTraps)) * hunter.tntDamageMultiplier(),
 		ThreatMultiplier: 1,
 

--- a/sim/hunter/talents.go
+++ b/sim/hunter/talents.go
@@ -156,3 +156,7 @@ func (hunter *Hunter) registerBestialWrathCD() {
 func (hunter *Hunter) mortalShots() float64 {
 	return 0.06 * float64(hunter.Talents.MortalShots)
 }
+
+func (hunter *Hunter) trapMastery() float64 {
+	return 5 * float64(hunter.Talents.TrapMastery) * core.SpellHitRatingPerHitChance
+}


### PR DESCRIPTION
https://www.wowhead.com/classic/spell=19377/trap-mastery

This talent was never implemented, adds 5% hit for trap spells per point 