### PR TITLE
Show Honor Among Thieves input for tank rogue

### DIFF
--- a/ui/tank_rogue/inputs.ts
+++ b/ui/tank_rogue/inputs.ts
@@ -11,5 +11,4 @@ export const HonorOfThievesCritRate = InputHelpers.makeSpecOptionsNumberInput<Sp
 	fieldName: 'honorAmongThievesCritRate',
 	label: 'Honor Among Thieves Crit Rate',
 	labelTooltip: 'Number of crits other group members generate within 100 seconds',
-	showWhen: (player: Player<Spec.SpecRogue>) => player.getEquippedItem(ItemSlot.ItemSlotHead)?.rune?.id == RogueRune.RuneHonorAmongThieves,
 });

--- a/ui/tank_rogue/sim.ts
+++ b/ui/tank_rogue/sim.ts
@@ -6,6 +6,7 @@ import { Player } from '../core/player';
 import { Class, Faction, PartyBuffs, PseudoStat, Race, Spec, Stat } from '../core/proto/common';
 import { Stats } from '../core/proto_utils/stats';
 import { getSpecIcon } from '../core/proto_utils/utils';
+import { HonorOfThievesCritRate } from './inputs';
 import * as Presets from './presets.js';
 
 const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankRogue, {
@@ -119,6 +120,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankRogue, {
 			OtherInputs.BurstWindow,
 			OtherInputs.HpPercentForDefensives,
 			OtherInputs.InspirationUptime,
+			HonorOfThievesCritRate,
 		],
 	},
 	encounterPicker: {


### PR DESCRIPTION
Added input field to Tank Rogue sim for Honor Among Thieves to control party contribution of critical strikes.