### PR TITLE
Fix Heart of the Lion and remove ammo normalize

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -898,6 +898,7 @@ func BlessingOfKingsAura(character *Character) *Aura {
 
 func HeartOfTheLionAura(character *Character) *Aura {
 	character.AddStat(stats.AttackPower, float64(40+4*(character.Level-20)))
+	character.AddStat(stats.RangedAttackPower, float64(40+4*(character.Level-20)))
 	character.MultiplyStat(stats.Strength, 1.1)
 	character.MultiplyStat(stats.Stamina, 1.1)
 	character.MultiplyStat(stats.Agility, 1.1)

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 730
-  final_stats: 20
+  final_stats: 80
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1139.2
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1360.576
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -175,7 +175,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1923
-  final_stats: 580
+  final_stats: 780
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1154.4
-  final_stats: 52
+  final_stats: 112
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1568
-  final_stats: 152
+  final_stats: 272
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2079.904
-  final_stats: 165
+  final_stats: 325
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -175,7 +175,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2164.4
-  final_stats: 555
+  final_stats: 755
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1932.24
-  final_stats: 879.24
+  final_stats: 999.24
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestBM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.79
+  weights: 0.79193
   weights: 0
   weights: 0
   weights: 0
@@ -68,8 +68,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.2974
-  weights: 8.74159
-  weights: 7.60499
+  weights: 8.79855
+  weights: 7.66732
   weights: 0
   weights: 0
   weights: 0
@@ -99,364 +99,364 @@ stat_weights_results: {
 dps_results: {
  key: "TestBM-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 527.06296
+  dps: 534.70322
   tps: 238.97786
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 807.55786
+  dps: 815.45205
   tps: 346.58674
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Average-Default"
  value: {
-  dps: 817.91407
+  dps: 825.76287
   tps: 353.72125
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1755.31042
+  dps: 1762.75807
   tps: 1590.26435
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 808.27355
+  dps: 815.7637
   tps: 353.84526
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 850.31745
+  dps: 858.45622
   tps: 365.97245
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 968.90761
+  dps: 974.37821
   tps: 1023.06838
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 404.072
+  dps: 409.53976
   tps: 183.52783
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 437.82455
+  dps: 443.92106
   tps: 184.6759
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 571.76822
-  tps: 537.25877
+  dps: 594.62057
+  tps: 552.86673
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 508.97166
-  tps: 240.81173
+  dps: 529.64056
+  tps: 254.30442
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 557.96569
-  tps: 257.68491
+  dps: 580.86214
+  tps: 272.70683
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 302.85613
-  tps: 442.89201
+  dps: 317.94309
+  tps: 452.7695
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 260.62997
-  tps: 143.33714
+  dps: 274.08504
+  tps: 151.56569
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 292.39784
-  tps: 152.15465
+  dps: 307.54671
+  tps: 161.59526
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 512.55838
+  dps: 519.75953
   tps: 564.61171
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 512.55838
+  dps: 519.75953
   tps: 240.05141
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 548.8634
+  dps: 556.67533
   tps: 257.91959
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 246.07684
+  dps: 251.36132
   tps: 449.92796
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 246.07684
+  dps: 251.36132
   tps: 125.69401
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 269.9229
+  dps: 275.77387
   tps: 130.908
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 759.1919
-  tps: 841.49683
+  dps: 793.41758
+  tps: 868.63173
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 681.41005
-  tps: 411.78159
+  dps: 710.68922
+  tps: 433.94728
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 745.05798
-  tps: 449.98263
+  dps: 777.37387
+  tps: 475.12863
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 421.90324
-  tps: 659.78385
+  dps: 444.97324
+  tps: 677.6651
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 375.56475
-  tps: 258.92839
+  dps: 395.31395
+  tps: 273.46575
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 402.79696
-  tps: 277.77076
+  dps: 424.21583
+  tps: 293.82806
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1737.66519
+  dps: 1745.50524
   tps: 1557.96395
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 814.7024
+  dps: 822.6068
   tps: 349.54843
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 862.54611
+  dps: 871.39235
   tps: 359.12392
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 960.22303
+  dps: 965.92233
   tps: 1011.11273
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 407.72653
+  dps: 413.44484
   tps: 181.64776
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 438.48048
+  dps: 444.90329
   tps: 180.12516
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 580.56283
-  tps: 532.28673
+  dps: 603.7361
+  tps: 547.86078
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 519.21243
-  tps: 237.96768
+  dps: 540.22558
+  tps: 251.44217
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 567.47888
-  tps: 254.48372
+  dps: 590.71022
+  tps: 269.47735
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 304.89071
-  tps: 454.26772
+  dps: 320.15776
+  tps: 464.06456
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 262.69418
-  tps: 141.19423
+  dps: 276.31585
+  tps: 149.36786
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 295.86181
-  tps: 150.65039
+  dps: 311.24528
+  tps: 160.07805
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 526.86689
+  dps: 534.46537
   tps: 562.12478
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 526.86689
+  dps: 534.46537
   tps: 239.40739
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 563.62273
+  dps: 571.88409
   tps: 254.61929
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 253.22927
+  dps: 258.80012
   tps: 447.1994
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 253.22927
+  dps: 258.80012
   tps: 126.12835
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 282.13349
+  dps: 288.50918
   tps: 130.23571
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 763.72126
-  tps: 841.85412
+  dps: 798.20966
+  tps: 868.92603
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 687.41608
-  tps: 408.31964
+  dps: 717.05256
+  tps: 430.5574
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 751.84902
-  tps: 444.32377
+  dps: 784.43461
+  tps: 469.38622
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 423.73589
-  tps: 656.74645
+  dps: 447.03511
+  tps: 674.60532
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 377.1788
-  tps: 255.52663
+  dps: 397.12064
+  tps: 270.01804
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 404.19487
-  tps: 273.08206
+  dps: 425.78688
+  tps: 289.0332
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 777.32405
+  dps: 785.18864
   tps: 325.00367
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1698.36
-  final_stats: 936.36
+  final_stats: 1056.36
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestMM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.43842
+  weights: 0.43956
   weights: 0
   weights: 0
   weights: 0
@@ -68,8 +68,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.12437
-  weights: 4.3279
-  weights: 4.18932
+  weights: 4.36405
+  weights: 4.22378
   weights: 0
   weights: 0
   weights: 0
@@ -99,112 +99,112 @@ stat_weights_results: {
 dps_results: {
  key: "TestMM-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 355.57818
+  dps: 359.82524
   tps: 183.50732
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 364.48238
+  dps: 368.73134
   tps: 195.04026
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Average-Default"
  value: {
-  dps: 368.39511
+  dps: 372.63028
   tps: 198.58883
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 719.13294
-  tps: 891.20039
+  dps: 756.03461
+  tps: 924.28268
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 630.50363
-  tps: 488.78482
+  dps: 661.53088
+  tps: 515.98974
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 652.64718
-  tps: 509.73428
+  dps: 685.01338
+  tps: 538.86824
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 421.43138
-  tps: 654.57042
+  dps: 445.32383
+  tps: 675.6936
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 364.17648
-  tps: 303.06232
+  dps: 384.14453
+  tps: 320.21418
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 392.36014
-  tps: 326.72333
+  dps: 413.75402
+  tps: 345.66734
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 727.0865
-  tps: 892.42789
+  dps: 764.12285
+  tps: 925.44495
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 637.91973
-  tps: 487.35771
+  dps: 669.12479
+  tps: 514.52476
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 660.42102
-  tps: 508.99381
+  dps: 692.91864
+  tps: 538.04796
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 426.95872
-  tps: 645.10535
+  dps: 451.02397
+  tps: 666.23631
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 366.90878
-  tps: 301.30586
+  dps: 386.88549
+  tps: 318.32541
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 393.34556
-  tps: 323.06576
+  dps: 414.6347
+  tps: 341.72273
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 352.71723
+  dps: 356.92197
   tps: 183.84602
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2012.826
-  final_stats: 959.826
+  final_stats: 1079.826
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestSV-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.75558
+  weights: 0.75695
   weights: 0
   weights: 0
   weights: 0
@@ -68,8 +68,8 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.32805
-  weights: 4.79586
-  weights: 6.97709
+  weights: 4.82288
+  weights: 7.01523
   weights: 0
   weights: 0
   weights: 0
@@ -99,112 +99,112 @@ stat_weights_results: {
 dps_results: {
  key: "TestSV-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 434.39369
+  dps: 438.75447
   tps: 271.32762
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 754.42584
+  dps: 758.92644
   tps: 384.75806
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
-  dps: 763.35831
+  dps: 767.81886
   tps: 391.15842
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1793.90062
+  dps: 1798.1761
   tps: 1715.31949
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 753.38201
+  dps: 757.63063
   tps: 389.57347
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 779.48915
+  dps: 783.84359
   tps: 407.0731
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1013.23726
+  dps: 1016.33842
   tps: 1099.32586
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 388.70207
+  dps: 391.82111
   tps: 203.68877
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 409.18147
+  dps: 412.45057
   tps: 204.64835
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1789.44185
+  dps: 1793.9118
   tps: 1700.79183
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 765.06101
+  dps: 769.52654
   tps: 390.93101
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 789.23531
+  dps: 793.87266
   tps: 410.50036
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1005.7189
+  dps: 1008.99206
   tps: 1080.07285
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 392.79294
+  dps: 396.0579
   tps: 203.4828
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 418.41221
+  dps: 421.81469
   tps: 211.66996
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 723.01773
+  dps: 727.47945
   tps: 363.79328
  }
 }

--- a/sim/hunter/aimed_shot.go
+++ b/sim/hunter/aimed_shot.go
@@ -67,7 +67,7 @@ func (hunter *Hunter) getAimedShotConfig(rank int, timer *core.Timer) core.Spell
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target)) +
-				hunter.NormalizedAmmoDamageBonus +
+				hunter.AmmoDamageBonus +
 				baseDamage
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)

--- a/sim/hunter/chimera_shot.go
+++ b/sim/hunter/chimera_shot.go
@@ -56,7 +56,7 @@ func (hunter *Hunter) registerChimeraShotSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target)) +
-				hunter.NormalizedAmmoDamageBonus
+				hunter.AmmoDamageBonus
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)
 

--- a/sim/hunter/multi_shot.go
+++ b/sim/hunter/multi_shot.go
@@ -71,7 +71,7 @@ func (hunter *Hunter) getMultiShotConfig(rank int, timer *core.Timer) core.Spell
 			for hitIndex := int32(0); hitIndex < numHits; hitIndex++ {
 				baseDamage := baseDamage +
 					hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target)) +
-					hunter.NormalizedAmmoDamageBonus
+					hunter.AmmoDamageBonus
 
 				results[hitIndex] = spell.CalcDamage(sim, curTarget, baseDamage, spell.OutcomeRangedHitAndCrit)
 

--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 487.6
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 944.4
-  final_stats: 540
+  final_stats: 740
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 487.6
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 751.064
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 929.4
-  final_stats: 540
+  final_stats: 740
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/mage/TestFrost.results
+++ b/sim/mage/TestFrost.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1221.064
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1541.2
-  final_stats: 38
+  final_stats: 98
   final_stats: 8
   final_stats: 0
   final_stats: 9.95
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2299
-  final_stats: 174
+  final_stats: 294
   final_stats: 0
   final_stats: 0
   final_stats: 15.25
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 4229.552
-  final_stats: 299
+  final_stats: 459
   final_stats: 0
   final_stats: 0
   final_stats: 24.53836

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2316.6
-  final_stats: 174
+  final_stats: 294
   final_stats: 0
   final_stats: 0
   final_stats: 16.3515

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 363.8
-  final_stats: 20
+  final_stats: 80
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 507
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 755.192
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -175,7 +175,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 976.4
-  final_stats: 540
+  final_stats: 740
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 928.4
-  final_stats: 235.2
+  final_stats: 295.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1273.6
-  final_stats: 418.8
+  final_stats: 538.8
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 928.4
-  final_stats: 235.2
+  final_stats: 295.2
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1273.6
-  final_stats: 418.8
+  final_stats: 538.8
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 742
-  final_stats: 20
+  final_stats: 80
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1842.8
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2037.704
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -175,7 +175,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 3173.4
-  final_stats: 580
+  final_stats: 780
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1063.6
-  final_stats: 74
+  final_stats: 134
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2044.2
-  final_stats: 298
+  final_stats: 418
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2778.048
-  final_stats: 361
+  final_stats: 521
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -175,7 +175,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 3286.2
-  final_stats: 729
+  final_stats: 929
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1335.2
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1585.32
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1909.4
-  final_stats: 540
+  final_stats: 740
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1307.2
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 729.6
-  final_stats: 20
+  final_stats: 80
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1307.2
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1691.32
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -175,7 +175,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1899.4
-  final_stats: 540
+  final_stats: 740
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 754.2
-  final_stats: 20
+  final_stats: 80
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1667.8
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 754.2
-  final_stats: 20
+  final_stats: 80
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 1667.8
-  final_stats: 100
+  final_stats: 220
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -126,7 +126,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2079.32
-  final_stats: 150
+  final_stats: 310
   final_stats: 0
   final_stats: 0
   final_stats: 0

--- a/sim/warrior/dps/TestArms.results
+++ b/sim/warrior/dps/TestArms.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2879.848
-  final_stats: 201
+  final_stats: 361
   final_stats: 0
   final_stats: 0
   final_stats: 18.9218

--- a/sim/warrior/dps/TestFury.results
+++ b/sim/warrior/dps/TestFury.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2128.2
-  final_stats: 202
+  final_stats: 322
   final_stats: 0
   final_stats: 0
   final_stats: 14.205


### PR DESCRIPTION
Fixed Heart of the Lion by addind ranged AP.

Fixed couple of hunter spells to use non normalized ammo damage.