### PR TITLE
Fixed RS and Carve OH

### DIFF
--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestBM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.79193
+  weights: 0.80926
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.2974
-  weights: 8.79855
-  weights: 7.66732
+  weights: 0.30879
+  weights: 9.00917
+  weights: 7.87537
   weights: 0
   weights: 0
   weights: 0
@@ -106,56 +106,56 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 815.45205
+  dps: 838.28766
   tps: 346.58674
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Average-Default"
  value: {
-  dps: 825.76287
+  dps: 848.78039
   tps: 353.72125
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1762.75807
-  tps: 1590.26435
+  dps: 1936.21012
+  tps: 1740.9334
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 815.7637
+  dps: 839.23896
   tps: 353.84526
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 858.45622
+  dps: 881.93605
   tps: 365.97245
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 974.37821
-  tps: 1023.06838
+  dps: 1077.1797
+  tps: 1112.57028
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 409.53976
+  dps: 422.77468
   tps: 183.52783
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 443.92106
+  dps: 457.84637
   tps: 184.6759
  }
 }
@@ -288,42 +288,42 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1745.50524
-  tps: 1557.96395
+  dps: 1916.96239
+  tps: 1706.30445
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 822.6068
+  dps: 845.62006
   tps: 349.54843
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 871.39235
+  dps: 894.33049
   tps: 359.12392
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 965.92233
-  tps: 1011.11273
+  dps: 1067.04795
+  tps: 1098.89339
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 413.44484
+  dps: 426.62328
   tps: 181.64776
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 444.90329
+  dps: 458.36323
   tps: 180.12516
  }
 }
@@ -456,7 +456,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 785.18864
+  dps: 806.00935
   tps: 325.00367
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestBM-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.80926
+  weights: 0.82436
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.30879
-  weights: 9.00917
-  weights: 7.87537
+  weights: 0.31709
+  weights: 9.19259
+  weights: 7.97531
   weights: 0
   weights: 0
   weights: 0
@@ -106,57 +106,57 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 838.28766
-  tps: 346.58674
+  dps: 850.39852
+  tps: 358.6976
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Average-Default"
  value: {
-  dps: 848.78039
-  tps: 353.72125
+  dps: 861.00165
+  tps: 365.9425
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1936.21012
-  tps: 1740.9334
+  dps: 1948.7481
+  tps: 1753.47139
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 839.23896
-  tps: 353.84526
+  dps: 851.53515
+  tps: 366.14145
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 881.93605
-  tps: 365.97245
+  dps: 894.00438
+  tps: 378.04078
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1077.1797
-  tps: 1112.57028
+  dps: 1083.66984
+  tps: 1119.06042
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 422.77468
-  tps: 183.52783
+  dps: 429.3186
+  tps: 190.07175
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 457.84637
-  tps: 184.6759
+  dps: 464.52174
+  tps: 191.35127
  }
 }
 dps_results: {
@@ -288,43 +288,43 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1916.96239
-  tps: 1706.30445
+  dps: 1929.33062
+  tps: 1718.67269
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 845.62006
-  tps: 349.54843
+  dps: 857.6908
+  tps: 361.61917
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 894.33049
-  tps: 359.12392
+  dps: 906.39829
+  tps: 371.19172
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1067.04795
-  tps: 1098.89339
+  dps: 1073.54734
+  tps: 1105.39278
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 426.62328
-  tps: 181.64776
+  dps: 432.81781
+  tps: 187.84228
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 458.36323
-  tps: 180.12516
+  dps: 464.7509
+  tps: 186.51283
  }
 }
 dps_results: {
@@ -456,7 +456,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 806.00935
-  tps: 325.00367
+  dps: 817.46396
+  tps: 336.45828
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestSV-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.79059
+  weights: 0.80771
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.34208
-  weights: 5.04004
-  weights: 7.2062
+  weights: 0.35118
+  weights: 5.116
+  weights: 7.3322
   weights: 0
   weights: 0
   weights: 0
@@ -106,105 +106,105 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 788.09155
-  tps: 384.75806
+  dps: 801.63369
+  tps: 398.30021
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
-  dps: 797.21584
-  tps: 391.15842
+  dps: 810.80775
+  tps: 404.75034
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1995.009
-  tps: 1882.56931
+  dps: 2009.05833
+  tps: 1896.61864
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 786.73495
-  tps: 389.57347
+  dps: 800.80213
+  tps: 403.64064
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 814.10342
-  tps: 407.0731
+  dps: 828.21328
+  tps: 421.18296
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1133.75695
-  tps: 1199.30435
+  dps: 1141.07786
+  tps: 1206.62526
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 408.64905
-  tps: 203.68877
+  dps: 415.91063
+  tps: 210.95035
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 430.25884
-  tps: 204.64835
+  dps: 438.08066
+  tps: 212.47017
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1988.53071
-  tps: 1866.519
+  dps: 2002.33822
+  tps: 1880.3265
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 799.19393
-  tps: 390.93101
+  dps: 812.83807
+  tps: 404.57515
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 822.92681
-  tps: 410.50036
+  dps: 837.22519
+  tps: 424.79873
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1124.10589
-  tps: 1177.66465
+  dps: 1131.26842
+  tps: 1184.82717
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 413.30339
-  tps: 203.4828
+  dps: 420.44565
+  tps: 210.62506
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 439.1544
-  tps: 211.66996
+  dps: 446.23431
+  tps: 218.74987
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 755.03104
-  tps: 363.79328
+  dps: 767.35132
+  tps: 376.11356
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestSV-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.75695
+  weights: 0.79059
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.32805
-  weights: 4.82288
-  weights: 7.01523
+  weights: 0.34208
+  weights: 5.04004
+  weights: 7.2062
   weights: 0
   weights: 0
   weights: 0
@@ -106,105 +106,105 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 758.92644
+  dps: 788.09155
   tps: 384.75806
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
-  dps: 767.81886
+  dps: 797.21584
   tps: 391.15842
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1798.1761
-  tps: 1715.31949
+  dps: 1995.009
+  tps: 1882.56931
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 757.63063
+  dps: 786.73495
   tps: 389.57347
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 783.84359
+  dps: 814.10342
   tps: 407.0731
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1016.33842
-  tps: 1099.32586
+  dps: 1133.75695
+  tps: 1199.30435
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 391.82111
+  dps: 408.64905
   tps: 203.68877
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 412.45057
+  dps: 430.25884
   tps: 204.64835
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1793.9118
-  tps: 1700.79183
+  dps: 1988.53071
+  tps: 1866.519
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 769.52654
+  dps: 799.19393
   tps: 390.93101
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 793.87266
+  dps: 822.92681
   tps: 410.50036
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 1008.99206
-  tps: 1080.07285
+  dps: 1124.10589
+  tps: 1177.66465
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 396.0579
+  dps: 413.30339
   tps: 203.4828
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 421.81469
+  dps: 439.1544
   tps: 211.66996
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 727.47945
+  dps: 755.03104
   tps: 363.79328
  }
 }

--- a/sim/hunter/carve.go
+++ b/sim/hunter/carve.go
@@ -72,7 +72,7 @@ func (hunter *Hunter) newCarveHitSpell(isMH bool) *core.Spell {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := damageFunc(sim, spell.MeleeAttackPower())
-			if target == hunter.CurrentTarget && isMH {
+			if target == hunter.CurrentTarget {
 				baseDamage *= 1.5
 			}
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/hunter/carve.go
+++ b/sim/hunter/carve.go
@@ -51,10 +51,12 @@ func (hunter *Hunter) registerCarveSpell() {
 
 func (hunter *Hunter) newCarveHitSpell(isMH bool) *core.Spell {
 	procMask := core.ProcMaskMeleeMHSpecial
+	damageMultiplier := 0.65
 	damageFunc := hunter.MHWeaponDamage
 
 	if !isMH {
 		procMask = core.ProcMaskMeleeOHSpecial
+		damageMultiplier = hunter.AutoAttacks.OHConfig().DamageMultiplier * 0.65
 		damageFunc = hunter.OHWeaponDamage
 	}
 
@@ -65,12 +67,12 @@ func (hunter *Hunter) newCarveHitSpell(isMH bool) *core.Spell {
 		ProcMask:    procMask,
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagNoOnCastComplete,
 
-		DamageMultiplier: 0.65,
+		DamageMultiplier: damageMultiplier,
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := damageFunc(sim, spell.MeleeAttackPower())
-			if target == hunter.CurrentTarget {
+			if target == hunter.CurrentTarget && isMH {
 				baseDamage *= 1.5
 			}
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -102,11 +102,13 @@ func (hunter *Hunter) newRaptorStrikeHitSpell(rank int, isMH bool) *core.Spell {
 	baseDamage := RaptorStrikeBaseDamage[rank]
 
 	procMask := core.ProcMaskMeleeMHSpecial
+	damageMultiplier := 1.0
 	damageFunc := core.Ternary(hasMeleeSpecialist, hunter.MHNormalizedWeaponDamage, hunter.MHWeaponDamage)
 
 	if !isMH {
 		baseDamage /= 2
 		procMask = core.ProcMaskMeleeOHSpecial
+		damageMultiplier = hunter.AutoAttacks.OHConfig().DamageMultiplier
 		damageFunc = core.Ternary(hasMeleeSpecialist, hunter.OHNormalizedWeaponDamage, hunter.OHWeaponDamage)
 	}
 
@@ -119,7 +121,7 @@ func (hunter *Hunter) newRaptorStrikeHitSpell(rank int, isMH bool) *core.Spell {
 
 		BonusCritRating:  float64(hunter.Talents.SavageStrikes) * 10 * core.CritRatingPerCritChance,
 		CritDamageBonus:  hunter.mortalShots(),
-		DamageMultiplier: 1,
+		DamageMultiplier: damageMultiplier,
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {


### PR DESCRIPTION
Reverted to the original code.

Sims with it look very close to ingame behaviour.

Carve OH got fixed too, so no separate multipliers for it like originally planned.