### PR TITLE
Blazefury flametongue

### DIFF
--- a/sim/common/vanilla/item_effects.go
+++ b/sim/common/vanilla/item_effects.go
@@ -2316,11 +2316,24 @@ func init() {
 	core.NewItemEffect(BlazefuryMedallion, func(agent core.Agent) {
 		character := agent.GetCharacter()
 
-		procSpell := character.GetOrRegisterSpell(core.SpellConfig{
+		procSpellMH := character.GetOrRegisterSpell(core.SpellConfig{
+			ActionID:    core.ActionID{SpellID: 7712},
+			SpellSchool: core.SpellSchoolFire,
+			DefenseType: core.DefenseTypeMagic,
+			ProcMask:    core.ProcMaskTriggerInstant,
+
+			DamageMultiplier: 1,
+			ThreatMultiplier: 1,
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				spell.CalcAndDealDamage(sim, target, 2, spell.OutcomeMagicCrit)
+			},
+		})
+
+		procSpellOH := character.RegisterSpell(core.SpellConfig{
 			ActionID:         core.ActionID{SpellID: 7712},
 			SpellSchool:      core.SpellSchoolFire,
 			DefenseType:      core.DefenseTypeMagic,
-			ProcMask:         core.ProcMaskTriggerInstant,
+			ProcMask:         core.ProcMaskTriggerInstantOH,
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -2334,7 +2347,15 @@ func init() {
 			Outcome:  core.OutcomeLanded,
 			ProcMask: core.ProcMaskMelee,
 			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				procSpell.Cast(sim, result.Target)
+				if spell.ProcMask.Matches(core.ProcMaskTriggerInstant) {
+					return
+				}
+
+				if spell.IsMH() {
+					procSpellMH.Cast(sim, result.Target)
+				} else {
+					procSpellOH.Cast(sim, result.Target)
+				}
 			},
 		})
 	})

--- a/sim/common/vanilla/item_effects.go
+++ b/sim/common/vanilla/item_effects.go
@@ -2347,10 +2347,6 @@ func init() {
 			Outcome:  core.OutcomeLanded,
 			ProcMask: core.ProcMaskMelee,
 			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if spell.ProcMask.Matches(core.ProcMaskTriggerInstant) {
-					return
-				}
-
 				if spell.IsMH() {
 					procSpellMH.Cast(sim, result.Target)
 				} else {

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -55,7 +55,8 @@ const (
 	// Mask for Seal of Righteousness, it does not proc Wild Strikes
 	ProcMaskSupressExtraAttack
 	// Mask for Fiery Weapon and Blazefury Medalion that trigger melee procs like Art of War Rune or Vengeance Talent
-	ProcMaskTriggerInstant 
+	ProcMaskTriggerInstant
+	ProcMaskTriggerInstantOH
 )
 
 const (

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -56,6 +56,7 @@ const (
 	ProcMaskSupressExtraAttack
 	// Mask for Fiery Weapon and Blazefury Medalion that trigger melee procs like Art of War Rune or Vengeance Talent
 	ProcMaskTriggerInstant
+	// Mask for Blazefury Medallion triggering on offhand
 	ProcMaskTriggerInstantOH
 )
 

--- a/sim/shaman/flametongue_weapon.go
+++ b/sim/shaman/flametongue_weapon.go
@@ -76,6 +76,13 @@ func (shaman *Shaman) RegisterFlametongueImbue(procMask core.ProcMask) {
 	mhSpell := shaman.newFlametongueImbueSpell(shaman.MainHand())
 	ohSpell := shaman.newFlametongueImbueSpell(shaman.OffHand())
 
+	// Blazefury Medallion procs flametongue
+	if procMask.Matches(core.ProcMaskMeleeMH) {
+		procMask |= core.ProcMaskTriggerInstant
+	} else {
+		procMask |= core.ProcMaskTriggerInstantOH
+	}
+
 	aura := shaman.RegisterAura(core.Aura{
 		Label:    "Flametongue Imbue",
 		Duration: core.NeverExpires,
@@ -87,7 +94,7 @@ func (shaman *Shaman) RegisterFlametongueImbue(procMask core.ProcMask) {
 				return
 			}
 
-			if spell.IsMH() {
+			if spell.IsMH() || procMask.Matches(core.ProcMaskTriggerInstant) {
 				mhSpell.Cast(sim, result.Target)
 			} else {
 				ohSpell.Cast(sim, result.Target)


### PR DESCRIPTION
Blazefury medallion's fire strike is causing an additional flametongue weapon proc when the FT imbued weapon strikes.

![image](https://github.com/user-attachments/assets/7b9c5ccc-836e-4924-a91b-83fda03f810a)

![image](https://github.com/user-attachments/assets/9f93f397-7819-4eff-8458-897ab21885e2)