### PR TITLE
Defense stat, level 60

### DIFF
--- a/sim/mage/TestArcane.results
+++ b/sim/mage/TestArcane.results
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestArcane-Lvl40-Average-Default"
  value: {
-  dps: 406.32196
-  tps: 251.69294
+  dps: 406.32322
+  tps: 251.69372
  }
 }
 dps_results: {

--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -65,7 +65,7 @@ export const simLaunchStatuses: Record<Spec, SimStatus> = {
 		status: LaunchStatus.Alpha,
 	},
 	[Spec.SpecTankRogue]: {
-		phase: Phase.Phase3,
+		phase: Phase.Phase4,
 		status: LaunchStatus.Alpha,
 	},
 	[Spec.SpecHolyPaladin]: {

--- a/ui/rogue/sim.ts
+++ b/ui/rogue/sim.ts
@@ -63,6 +63,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 		Stat.StatSpellHit,
 		Stat.StatSpellCrit,
 		Stat.StatMeleeHaste,
+		Stat.StatDefense,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP.
@@ -80,6 +81,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRogue, {
 		Stat.StatMeleeCrit,
 		Stat.StatSpellCrit,
 		Stat.StatMeleeHaste,
+		Stat.StatDefense,
 	],
 
 	defaults: {

--- a/ui/tank_rogue/sim.ts
+++ b/ui/tank_rogue/sim.ts
@@ -29,6 +29,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankRogue, {
 		Stat.StatSpellCrit,
 
 		// Tank stats
+		Stat.StatDefense,
 		Stat.StatArmor,
 		Stat.StatBonusArmor,
 		Stat.StatStamina,
@@ -51,6 +52,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankRogue, {
 
 		// Tank stats
 		Stat.StatStamina,
+		Stat.StatDefense,
 		Stat.StatDodge,
 		Stat.StatParry,
 		Stat.StatArmor,
@@ -66,6 +68,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecTankRogue, {
 				[Stat.StatAgility]: 1.69,
 				[Stat.StatStrength]: 1.1,
 				[Stat.StatAttackPower]: 1,
+				[Stat.StatDefense]: 4,
 				[Stat.StatSpellDamage]: 0.68,
 				[Stat.StatNaturePower]: 0.68,
 				[Stat.StatSpellCrit]: 2.0,


### PR DESCRIPTION
Update Tank Rogue sim to level 60 and display the Defense stat