### PR TITLE
Warlock and druid reset fixes

### DIFF
--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -249,6 +249,10 @@ func (aura *Aura) RemainingDuration(sim *Simulation) time.Duration {
 	}
 }
 
+func (aura *Aura) IsPermanent() bool {
+	return aura.Duration == NeverExpires
+}
+
 func (aura *Aura) StartedAt() time.Duration {
 	return aura.startTime
 }

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -607,7 +607,7 @@ func MarkOfChaosDebuffAura(target *Unit) *Aura {
 	aura := target.GetOrRegisterAura(Aura{
 		Label:    "Mark of Chaos",
 		ActionID: ActionID{SpellID: 461615},
-		Duration: NeverExpires, // Duration is set by the applying curse
+		Duration: time.Second, // Duration is set by the applying curse
 	})
 
 	// 0.01 priority as this overwrites the other spells of this category and does not allow them to be recast

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -827,22 +827,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl60-Settings-NightElf-phase_4-Default-phase_4-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 2339.82881
-  tps: 2518.28545
+  dps: 2339.83214
+  tps: 2518.28878
  }
 }
 dps_results: {
  key: "TestBalance-Lvl60-Settings-NightElf-phase_4-Default-phase_4-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1431.71111
-  tps: 1440.74845
+  dps: 1431.72551
+  tps: 1440.76285
  }
 }
 dps_results: {
  key: "TestBalance-Lvl60-Settings-NightElf-phase_4-Default-phase_4-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1569.62877
-  tps: 1584.81252
+  dps: 1569.66743
+  tps: 1584.85119
  }
 }
 dps_results: {
@@ -869,22 +869,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Lvl60-Settings-Tauren-phase_4-Default-phase_4-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 2332.68749
-  tps: 2510.21576
+  dps: 2332.68082
+  tps: 2510.20909
  }
 }
 dps_results: {
  key: "TestBalance-Lvl60-Settings-Tauren-phase_4-Default-phase_4-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1432.99889
-  tps: 1441.86676
+  dps: 1433.01662
+  tps: 1441.8845
  }
 }
 dps_results: {
  key: "TestBalance-Lvl60-Settings-Tauren-phase_4-Default-phase_4-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1566.49478
-  tps: 1581.67854
+  dps: 1566.53344
+  tps: 1581.7172
  }
 }
 dps_results: {

--- a/sim/druid/insect_swarm.go
+++ b/sim/druid/insect_swarm.go
@@ -17,6 +17,8 @@ var InsectSwarmLevel = [InsectSwarmRanks + 1]int{0, 20, 30, 40, 50, 60}
 func (druid *Druid) registerInsectSwarmSpell() {
 	druid.InsectSwarm = make([]*DruidSpell, InsectSwarmRanks+1)
 
+	druid.InsectSwarmAuras = druid.NewEnemyAuraArray(core.InsectSwarmAura)
+
 	for rank := 1; rank <= InsectSwarmRanks; rank++ {
 		level := InsectSwarmLevel[rank]
 		if int32(level) <= druid.Level {
@@ -27,8 +29,6 @@ func (druid *Druid) registerInsectSwarmSpell() {
 			baseDamage := InsectSwarmBaseDamage[rank] / float64(numTicks)
 			manaCost := InsectSwarmManaCost[rank]
 			spellCoef := .158
-
-			druid.InsectSwarmAuras = druid.NewEnemyAuraArray(core.InsectSwarmAura)
 
 			druid.InsectSwarm[rank] = druid.RegisterSpell(Humanoid|Moonkin, core.SpellConfig{
 				SpellCode:   SpellCode_DruidInsectSwarm,
@@ -57,7 +57,10 @@ func (druid *Druid) registerInsectSwarmSpell() {
 							druid.InsectSwarmAuras.Get(aura.Unit).Activate(sim)
 						},
 						OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-							druid.InsectSwarmAuras.Get(aura.Unit).Deactivate(sim)
+							insectSwarmAura := druid.InsectSwarmAuras.Get(aura.Unit)
+							if !insectSwarmAura.IsPermanent() {
+								insectSwarmAura.Deactivate(sim)
+							}
 						},
 					},
 

--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -87,12 +87,10 @@ func init() {
 	core.NewItemEffect(IdolOfTheSwarm, func(agent core.Agent) {
 		druid := agent.(DruidAgent).GetDruid()
 
-		var originalAuraArray core.AuraArray
+		bonusDuration := time.Second * 12
+
 		core.MakePermanent(druid.GetOrRegisterAura(core.Aura{
 			Label: "Idol of the Swarm",
-			OnReset: func(aura *core.Aura, sim *core.Simulation) {
-				originalAuraArray = druid.InsectSwarmAuras
-			},
 			OnGain: func(aura *core.Aura, sim *core.Simulation) {
 				for _, spell := range druid.InsectSwarm {
 					if spell != nil {
@@ -105,11 +103,11 @@ func init() {
 					}
 				}
 
-				druid.InsectSwarmAuras = druid.NewEnemyAuraArray(func(target *core.Unit, level int32) *core.Aura {
-					aura := core.InsectSwarmAura(target, level)
-					aura.Duration += time.Second * 12
-					return aura
-				})
+				for _, aura := range druid.InsectSwarmAuras {
+					if aura != nil && !aura.IsPermanent() {
+						aura.Duration += bonusDuration
+					}
+				}
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 				for _, spell := range druid.InsectSwarm {
@@ -123,7 +121,11 @@ func init() {
 					}
 				}
 
-				druid.InsectSwarmAuras = originalAuraArray
+				for _, aura := range druid.InsectSwarmAuras {
+					if aura != nil && !aura.IsPermanent() {
+						aura.Duration -= bonusDuration
+					}
+				}
 			},
 		}))
 	})

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -603,8 +603,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2666.61465
-  tps: 2407.93287
+  dps: 2678.43346
+  tps: 2419.33617
  }
 }
 dps_results: {
@@ -638,36 +638,36 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2649.00186
-  tps: 2392.35294
+  dps: 2661.81745
+  tps: 2404.73916
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Average-Default"
  value: {
-  dps: 2685.52016
-  tps: 2426.52961
+  dps: 2698.55647
+  tps: 2439.25518
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 2660.45725
-  tps: 3456.07127
+  dps: 2673.10031
+  tps: 3468.29249
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 2660.45725
-  tps: 2405.10042
+  dps: 2673.10031
+  tps: 2417.32164
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 2776.4559
-  tps: 2521.17516
+  dps: 2785.14999
+  tps: 2529.86925
  }
 }
 dps_results: {
@@ -694,7 +694,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2649.00186
-  tps: 2392.35294
+  dps: 2661.81745
+  tps: 2404.73916
  }
 }

--- a/sim/warlock/runes.go
+++ b/sim/warlock/runes.go
@@ -176,8 +176,11 @@ func (warlock *Warlock) applyMarkOfChaos() {
 
 func (warlock *Warlock) applyMarkOfChaosDebuff(sim *core.Simulation, target *core.Unit, duration time.Duration) {
 	aura := warlock.MarkOfChaosAuras.Get(target)
-	aura.Duration = duration
-	aura.UpdateExpires(sim, sim.CurrentTime+duration)
+	// Only expire if not set as a permanent raid debuff.
+	if aura.Duration != core.NeverExpires {
+		aura.Duration = duration
+		aura.UpdateExpires(sim, sim.CurrentTime+duration)
+	}
 	aura.Activate(sim)
 }
 

--- a/sim/warlock/runes.go
+++ b/sim/warlock/runes.go
@@ -177,7 +177,7 @@ func (warlock *Warlock) applyMarkOfChaos() {
 func (warlock *Warlock) applyMarkOfChaosDebuff(sim *core.Simulation, target *core.Unit, duration time.Duration) {
 	aura := warlock.MarkOfChaosAuras.Get(target)
 	// Only expire if not set as a permanent raid debuff.
-	if aura.Duration != core.NeverExpires {
+	if !aura.IsPermanent() {
 		aura.Duration = duration
 		aura.UpdateExpires(sim, sim.CurrentTime+duration)
 	}

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -164,6 +164,7 @@ func (warlock *Warlock) AddRaidBuffs(raidBuffs *proto.RaidBuffs) {
 
 func (warlock *Warlock) Reset(sim *core.Simulation) {
 	warlock.setDefaultActivePet()
+	warlock.ActiveCurseAura = nil
 
 	// warlock.ItemSwap.SwapItems(sim, []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand,
 	// 	proto.ItemSlot_ItemSlotOffHand, proto.ItemSlot_ItemSlotRanged}, false)


### PR DESCRIPTION
Fixes warlock and druid sim reset errors for https://github.com/wowsims/sod/pull/918
- Make warlock.ActiveCurseAura reset to nil on sim reset.
- Set default duration of Mark of Chaos auras to 1s (arbitrary value, just can't be NeverExpires) and only alter the duration on curse application if it wasn't made permanent.
- Make Idol of the Swarm only change Insect Swarm hit debuff duration if it's not a permanent raid debuff.
- Only deactivate Insect Swarm hit debuff on Insect Swarm DoT expiration if it's not a permanent raid debuff.