### PR TITLE
Fixes from cata

### DIFF
--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -116,6 +116,7 @@ func (pet *Pet) reset(sim *Simulation, agent PetAgent) {
 }
 func (pet *Pet) doneIteration(sim *Simulation) {
 	pet.Character.doneIteration(sim)
+	pet.Disable(sim)
 	pet.isReset = false
 }
 

--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -221,7 +221,7 @@ func (sim *Simulation) labelRand(label string) Rand {
 	labelRng, ok := sim.testRands[label]
 	if !ok {
 		// Add rseed to the label, so we still have run-run variance for stat weights.
-		labelRng = NewSplitMix(uint64(makeTestRandSeed(sim.rseed, label)))
+		labelRng = NewSplitMix(uint64(makeTestRandSeed(sim.rand.GetSeed(), label)))
 		sim.testRands[label] = labelRng
 	}
 	return labelRng

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -821,7 +821,7 @@ dps_results: {
  key: "TestBalance-Lvl60-Settings-NightElf-phase_4-Default-phase_4-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
   dps: 2404.33845
-  tps: 2419.38687
+  tps: 2419.06317
  }
 }
 dps_results: {
@@ -863,7 +863,7 @@ dps_results: {
  key: "TestBalance-Lvl60-Settings-Tauren-phase_4-Default-phase_4-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
   dps: 2404.14516
-  tps: 2419.19357
+  tps: 2418.86987
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -674,259 +674,259 @@ dps_results: {
  key: "TestFeral-Lvl40-Average-Default"
  value: {
   dps: 821.48053
-  tps: 602.90059
+  tps: 602.90048
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 460.71335
-  tps: 382.63045
+  dps: 460.72429
+  tps: 382.35049
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 460.71335
-  tps: 333.29606
+  dps: 460.72429
+  tps: 333.28945
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.17407
-  tps: 427.78083
+  dps: 574.33823
+  tps: 427.84877
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 275.11689
-  tps: 201.91542
+  dps: 275.2919
+  tps: 201.91029
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 275.11689
-  tps: 197.80467
+  dps: 275.2919
+  tps: 197.92246
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 350.56166
-  tps: 261.25009
+  dps: 350.61166
+  tps: 261.26034
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 460.71335
-  tps: 382.63045
+  dps: 460.72429
+  tps: 382.35049
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 460.71335
-  tps: 333.29606
+  dps: 460.72429
+  tps: 333.28945
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.17407
-  tps: 427.78083
+  dps: 574.33823
+  tps: 427.84877
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 275.11689
-  tps: 201.91542
+  dps: 275.2919
+  tps: 201.91029
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 275.11689
-  tps: 197.80467
+  dps: 275.2919
+  tps: 197.92246
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 350.56166
-  tps: 261.25009
+  dps: 350.61166
+  tps: 261.26034
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 460.71335
-  tps: 382.63045
+  dps: 460.72429
+  tps: 382.35049
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 460.71335
-  tps: 333.29606
+  dps: 460.72429
+  tps: 333.28945
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.17407
-  tps: 427.78083
+  dps: 574.33823
+  tps: 427.84877
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 275.11689
-  tps: 201.91542
+  dps: 275.2919
+  tps: 201.91029
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 275.11689
-  tps: 197.80467
+  dps: 275.2919
+  tps: 197.92246
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-NightElf-phase_2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 350.56166
-  tps: 261.25009
+  dps: 350.61166
+  tps: 261.26034
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 460.61821
-  tps: 381.08283
+  dps: 460.62915
+  tps: 381.0906
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 460.61821
-  tps: 333.19859
+  dps: 460.62915
+  tps: 333.20636
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.49296
-  tps: 428.03014
+  dps: 574.65712
+  tps: 428.17
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 277.34467
-  tps: 211.61788
+  dps: 277.35467
+  tps: 211.62498
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 277.34467
-  tps: 199.78902
+  dps: 277.35467
+  tps: 199.79612
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-NoBleed-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 352.24843
-  tps: 264.46081
+  dps: 352.29843
+  tps: 264.50341
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 460.61821
-  tps: 381.08283
+  dps: 460.62915
+  tps: 381.0906
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 460.61821
-  tps: 333.19859
+  dps: 460.62915
+  tps: 333.20636
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.49296
-  tps: 428.03014
+  dps: 574.65712
+  tps: 428.17
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 277.34467
-  tps: 211.61788
+  dps: 277.35467
+  tps: 211.62498
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 277.34467
-  tps: 199.78902
+  dps: 277.35467
+  tps: 199.79612
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Default-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 352.24843
-  tps: 264.46081
+  dps: 352.29843
+  tps: 264.50341
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 460.61821
-  tps: 381.08283
+  dps: 460.62915
+  tps: 381.0906
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 460.61821
-  tps: 333.19859
+  dps: 460.62915
+  tps: 333.20636
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 574.49296
-  tps: 428.03014
+  dps: 574.65712
+  tps: 428.17
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 277.34467
-  tps: 211.61788
+  dps: 277.35467
+  tps: 211.62498
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 277.34467
-  tps: 199.78902
+  dps: 277.35467
+  tps: 199.79612
  }
 }
 dps_results: {
  key: "TestFeral-Lvl40-Settings-Tauren-phase_2-Flower-Aoe-phase_2-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 352.24843
-  tps: 264.46081
+  dps: 352.29843
+  tps: 264.50341
  }
 }
 dps_results: {
@@ -939,8 +939,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Lvl50-AllItems-FeralheartRaiment"
  value: {
-  dps: 928.51011
-  tps: 679.15617
+  dps: 928.54307
+  tps: 679.14285
   hps: 9.01417
  }
 }
@@ -1273,7 +1273,7 @@ dps_results: {
  key: "TestFeral-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
   dps: 2227.13087
-  tps: 1606.47645
+  tps: 1606.47163
  }
 }
 dps_results: {
@@ -1301,14 +1301,14 @@ dps_results: {
  key: "TestFeral-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
   dps: 2088.41129
-  tps: 1514.12975
+  tps: 1514.10965
  }
 }
 dps_results: {
  key: "TestFeral-Lvl60-AllItems-FeralheartRaiment"
  value: {
   dps: 1537.36272
-  tps: 1112.3848
+  tps: 1112.36435
  }
 }
 dps_results: {
@@ -1343,7 +1343,7 @@ dps_results: {
  key: "TestFeral-Lvl60-Average-Default"
  value: {
   dps: 3503.09036
-  tps: 2512.11727
+  tps: 2512.11726
  }
 }
 dps_results: {

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -107,28 +107,28 @@ dps_results: {
  key: "TestBM-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
   dps: 827.67157
-  tps: 339.55499
+  tps: 339.5542
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Average-Default"
  value: {
   dps: 835.63816
-  tps: 346.99466
+  tps: 346.99465
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 1917.06218
-  tps: 1717.84555
+  tps: 1717.80359
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 848.27173
-  tps: 360.0824
+  tps: 360.08226
  }
 }
 dps_results: {
@@ -218,8 +218,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 549.83186
-  tps: 248.81753
+  dps: 549.95606
+  tps: 248.91958
  }
 }
 dps_results: {
@@ -239,8 +239,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 294.54967
-  tps: 130.97046
+  dps: 294.61134
+  tps: 131.03213
  }
 }
 dps_results: {
@@ -289,21 +289,21 @@ dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 1835.34021
-  tps: 1628.81839
+  tps: 1628.80189
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 833.10168
-  tps: 344.47512
+  tps: 344.47433
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
   dps: 873.5991
-  tps: 347.94147
+  tps: 347.92773
  }
 }
 dps_results: {
@@ -386,8 +386,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 563.54837
-  tps: 239.671
+  dps: 563.67257
+  tps: 239.77305
  }
 }
 dps_results: {
@@ -407,8 +407,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 310.92113
-  tps: 131.7757
+  dps: 310.9828
+  tps: 131.83737
  }
 }
 dps_results: {
@@ -457,6 +457,6 @@ dps_results: {
  key: "TestBM-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
   dps: 798.5747
-  tps: 319.32833
+  tps: 319.32481
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -205,14 +205,14 @@ dps_results: {
  key: "TestSV-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
   dps: 773.33962
-  tps: 376.54586
+  tps: 376.54162
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Average-Default"
  value: {
   dps: 782.83578
-  tps: 383.78353
+  tps: 383.78349
  }
 }
 dps_results: {
@@ -226,7 +226,7 @@ dps_results: {
  key: "TestSV-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 789.98524
-  tps: 389.72275
+  tps: 389.72166
  }
 }
 dps_results: {
@@ -261,14 +261,14 @@ dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
   dps: 1914.91103
-  tps: 1799.20682
+  tps: 1799.16723
  }
 }
 dps_results: {
  key: "TestSV-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
   dps: 782.12653
-  tps: 380.85327
+  tps: 380.84903
  }
 }
 dps_results: {
@@ -318,7 +318,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodGuard'sChain"
  value: {
   dps: 1540.1546
-  tps: 1298.21695
+  tps: 1298.21343
   hps: 13.44102
  }
 }
@@ -326,7 +326,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodGuard'sMail"
  value: {
   dps: 1457.68772
-  tps: 1225.3766
+  tps: 1225.37217
   hps: 13.44102
  }
 }
@@ -342,7 +342,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
   dps: 3599.79039
-  tps: 3219.47342
+  tps: 3219.4699
   hps: 19.89862
  }
 }
@@ -350,7 +350,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
   dps: 3568.74133
-  tps: 3191.47468
+  tps: 3191.47116
   hps: 19.89862
  }
 }
@@ -358,7 +358,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-DreadHunter'sChain"
  value: {
   dps: 2156.3985
-  tps: 1897.1972
+  tps: 1897.19368
   hps: 14.24293
  }
 }
@@ -366,7 +366,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-EmeraldScalemail"
  value: {
   dps: 1472.33676
-  tps: 1239.70203
+  tps: 1239.69852
   hps: 13.44102
  }
 }
@@ -382,7 +382,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
   dps: 1540.1546
-  tps: 1298.21695
+  tps: 1298.21343
   hps: 13.44102
  }
 }
@@ -390,7 +390,7 @@ dps_results: {
  key: "TestSV-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
   dps: 3532.92434
-  tps: 3155.67924
+  tps: 3155.67572
   hps: 19.65676
  }
 }
@@ -398,7 +398,7 @@ dps_results: {
  key: "TestSV-Lvl60-Average-Default"
  value: {
   dps: 3617.54033
-  tps: 3229.86818
+  tps: 3229.86813
   hps: 19.68639
  }
 }
@@ -406,7 +406,7 @@ dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
   dps: 9709.07986
-  tps: 9794.16491
+  tps: 9794.08012
   hps: 20.29481
  }
 }
@@ -414,7 +414,7 @@ dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
   dps: 3641.90333
-  tps: 3262.7117
+  tps: 3262.70727
   hps: 19.98446
  }
 }
@@ -454,7 +454,7 @@ dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
   dps: 10193.04241
-  tps: 10264.96154
+  tps: 10264.89117
   hps: 20.19748
  }
 }
@@ -462,7 +462,7 @@ dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
   dps: 3855.23192
-  tps: 3469.29012
+  tps: 3469.2866
   hps: 19.73965
  }
 }
@@ -502,7 +502,7 @@ dps_results: {
  key: "TestSV-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
   dps: 3501.69933
-  tps: 3153.80442
+  tps: 3153.80091
   hps: 19.87436
  }
 }

--- a/sim/mage/TestFire.results
+++ b/sim/mage/TestFire.results
@@ -415,7 +415,7 @@ dps_results: {
  key: "TestFire-Lvl50-Settings-Gnome-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 1313.60688
-  tps: 942.48458
+  tps: 942.24667
  }
 }
 dps_results: {
@@ -457,7 +457,7 @@ dps_results: {
  key: "TestFire-Lvl50-Settings-Troll-p3_fire-Fire-p3_fire-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
   dps: 1352.02758
-  tps: 964.85751
+  tps: 964.71076
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -107,7 +107,7 @@ dps_results: {
  key: "TestShockadin-Lvl40-Average-Default"
  value: {
   dps: 520.13184
-  tps: 544.46875
+  tps: 544.46874
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -442,7 +442,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 98.65435
+  dps: 99.84051
   tps: 79.72751
  }
 }
@@ -484,7 +484,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 95.65083
+  dps: 96.54095
   tps: 76.36982
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -400,8 +400,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Orc-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 104.01874
-  tps: 187.35031
+  dps: 104.00806
+  tps: 187.27386
  }
 }
 dps_results: {
@@ -421,8 +421,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Orc-phase_1-Adaptive-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 82.71734
-  tps: 179.51144
+  dps: 82.68594
+  tps: 179.43779
  }
 }
 dps_results: {
@@ -442,8 +442,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Troll-phase_1-Adaptive-phase_1-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 104.00069
-  tps: 187.2909
+  dps: 103.99316
+  tps: 187.21446
  }
 }
 dps_results: {
@@ -463,8 +463,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Lvl25-Settings-Troll-phase_1-Adaptive-phase_1-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 82.71484
-  tps: 178.2906
+  dps: 82.68344
+  tps: 178.21696
  }
 }
 dps_results: {
@@ -772,7 +772,7 @@ dps_results: {
  key: "TestElemental-Lvl60-Settings-Orc-phase_4-Adaptive-phase_4-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
   dps: 2582.60988
-  tps: 1638.35302
+  tps: 1638.23123
  }
 }
 dps_results: {
@@ -793,7 +793,7 @@ dps_results: {
  key: "TestElemental-Lvl60-Settings-Orc-phase_4-Adaptive-phase_4-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
   dps: 1454.08232
-  tps: 941.24927
+  tps: 941.2255
  }
 }
 dps_results: {
@@ -814,7 +814,7 @@ dps_results: {
  key: "TestElemental-Lvl60-Settings-Troll-phase_4-Adaptive-phase_4-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
   dps: 2586.46331
-  tps: 1637.52179
+  tps: 1637.4
  }
 }
 dps_results: {
@@ -835,7 +835,7 @@ dps_results: {
  key: "TestElemental-Lvl60-Settings-Troll-phase_4-Adaptive-phase_4-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
   dps: 1457.85068
-  tps: 943.45165
+  tps: 943.21374
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -702,7 +702,7 @@ dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Auto-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 421.04246
-  tps: 312.50346
+  tps: 312.48586
  }
 }
 dps_results: {
@@ -744,7 +744,7 @@ dps_results: {
  key: "TestEnhancement-Lvl50-Settings-Orc-phase_3-Sync Delay OH-phase_3-NoBuffs-Phase 3 Consumes WF/WF-ShortSingleTarget"
  value: {
   dps: 421.04246
-  tps: 312.50346
+  tps: 312.48586
  }
 }
 dps_results: {


### PR DESCRIPTION
Moved here from the concurrency PR so results there do not change.
- Fix labeled rand seed (Purely affects test results slightly) https://github.com/wowsims/cata/pull/333
- Disable pet after iteration, was fixed there (Shadowfiend dps fix) https://github.com/wowsims/cata/pull/416
