### PR TITLE
Hunter Trap changes - August 5, 2024

### DIFF
--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestMM-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.55584
+  weights: 0.53624
   weights: 0
   weights: 0
   weights: 0
@@ -165,17 +165,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.29285
+  weights: 0.20776
   weights: 0
-  weights: 5.08336
-  weights: 0
-  weights: 0
+  weights: 4.97536
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
+  weights: 0
+  weights: 0.04125
   weights: 0
   weights: 0
   weights: 0
@@ -317,192 +317,192 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 827.10773
-  tps: 827.21818
+  dps: 708.51151
+  tps: 708.62196
   hps: 9.28289
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 807.18613
-  tps: 807.29658
+  dps: 679.47159
+  tps: 679.58204
   hps: 9.28289
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 953.49863
-  tps: 953.60908
+  dps: 875.4432
+  tps: 875.55365
   hps: 12.58016
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 951.1679
-  tps: 951.27835
+  dps: 874.07035
+  tps: 874.1808
   hps: 12.58016
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 942.81681
-  tps: 942.92726
+  dps: 866.9121
+  tps: 867.02255
   hps: 12.58016
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 675.40227
-  tps: 675.52217
+  dps: 622.46596
+  tps: 622.58586
   hps: 8.86045
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 808.68837
-  tps: 808.79882
+  dps: 686.01928
+  tps: 686.12973
   hps: 9.28289
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 955.78937
-  tps: 955.89982
+  dps: 877.02544
+  tps: 877.13589
   hps: 12.58016
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 827.10773
-  tps: 827.21818
+  dps: 708.51151
+  tps: 708.62196
   hps: 9.28289
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 936.63083
-  tps: 936.74128
+  dps: 862.8419
+  tps: 862.95235
   hps: 12.58016
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Average-Default"
  value: {
-  dps: 960.48555
-  tps: 960.5928
+  dps: 884.42142
+  tps: 884.52868
   hps: 12.54582
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 7522.39816
-  tps: 8192.58728
+  dps: 6040.53706
+  tps: 6710.72619
   hps: 17.11074
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3138.01856
-  tps: 3171.52238
+  dps: 2968.39455
+  tps: 3001.89837
   hps: 17.10091
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 3155.35373
-  tps: 3190.59308
+  dps: 2975.5697
+  tps: 3010.80904
   hps: 16.21919
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 3725.30477
-  tps: 4318.07183
+  dps: 3408.76433
+  tps: 4001.53139
   hps: 10.0459
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1589.33644
-  tps: 1618.9748
+  dps: 1557.59644
+  tps: 1587.2348
   hps: 9.74277
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1698.99126
-  tps: 1722.71914
+  dps: 1667.21824
+  tps: 1690.94611
   hps: 9.6408
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 7679.93869
-  tps: 8332.82915
+  dps: 6326.11207
+  tps: 6979.00253
   hps: 17.32729
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3299.40164
-  tps: 3332.0134
+  dps: 3144.46904
+  tps: 3177.08081
   hps: 17.28657
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 3335.75586
-  tps: 3370.40536
+  dps: 3187.3433
+  tps: 3221.9928
   hps: 17.01861
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 3737.22596
-  tps: 4314.9049
+  dps: 3408.19565
+  tps: 3985.87459
   hps: 9.69642
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1597.68516
-  tps: 1626.5691
+  dps: 1564.51973
+  tps: 1593.40368
   hps: 9.778
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1715.30621
-  tps: 1738.26009
+  dps: 1685.68358
+  tps: 1708.63746
   hps: 10.15065
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 893.26838
-  tps: 893.37883
+  dps: 817.99299
+  tps: 818.10344
   hps: 12.07773
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestSV-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 3.01112
+  weights: 2.93152
   weights: 0
   weights: 0
   weights: 0
@@ -165,17 +165,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.54343
+  weights: 0.37499
   weights: 0
-  weights: 21.3011
-  weights: 0
-  weights: 0
+  weights: 21.27165
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43845
+  weights: 0
+  weights: 0
+  weights: 0.51269
   weights: 0
   weights: 0
   weights: 0
@@ -317,192 +317,192 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 1540.1546
-  tps: 1298.21343
+  dps: 1421.61993
+  tps: 1179.67876
   hps: 13.44102
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 1457.68772
-  tps: 1225.37217
+  dps: 1332.42887
+  tps: 1100.11332
   hps: 13.44102
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 1404.44574
-  tps: 1407.80441
+  dps: 1399.43656
+  tps: 1402.79523
   hps: 11.44815
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 3599.79039
-  tps: 3219.4699
+  dps: 3402.77132
+  tps: 3022.45083
   hps: 19.89862
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 3568.74133
-  tps: 3191.47116
+  dps: 3374.79362
+  tps: 2997.52346
   hps: 19.89862
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 2156.3985
-  tps: 1897.19368
+  dps: 2027.25898
+  tps: 1768.05416
   hps: 14.24293
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 1472.33676
-  tps: 1239.69852
+  dps: 1351.45141
+  tps: 1118.81317
   hps: 13.44102
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 1433.9198
-  tps: 1437.27847
+  dps: 1428.91062
+  tps: 1432.26929
   hps: 11.44815
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 1540.1546
-  tps: 1298.21343
+  dps: 1421.61993
+  tps: 1179.67876
   hps: 13.44102
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 3532.92434
-  tps: 3155.67572
+  dps: 3342.06763
+  tps: 2964.819
   hps: 19.65676
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Average-Default"
  value: {
-  dps: 3617.54033
-  tps: 3229.86813
+  dps: 3423.23466
+  tps: 3035.56246
   hps: 19.68639
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 9709.07986
-  tps: 9794.08012
+  dps: 8001.89283
+  tps: 8086.89309
   hps: 20.29481
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3641.90333
-  tps: 3262.70727
+  dps: 3449.39064
+  tps: 3070.19458
   hps: 19.98446
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 3519.62279
-  tps: 3146.59973
+  dps: 3335.24585
+  tps: 2962.22279
   hps: 18.70695
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 4652.07251
-  tps: 4940.32591
+  dps: 4164.54786
+  tps: 4452.80126
   hps: 11.14454
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1688.96479
-  tps: 1519.77829
+  dps: 1639.85466
+  tps: 1470.66816
   hps: 10.95835
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1691.83357
-  tps: 1495.59945
+  dps: 1640.44065
+  tps: 1444.20653
   hps: 10.88483
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 10193.04241
-  tps: 10264.89117
+  dps: 8487.73211
+  tps: 8559.58087
   hps: 20.19748
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3855.23192
-  tps: 3469.2866
+  dps: 3661.68713
+  tps: 3275.74181
   hps: 19.73965
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 3740.23377
-  tps: 3367.7293
+  dps: 3556.16997
+  tps: 3183.6655
   hps: 18.51523
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 4680.69931
-  tps: 4951.26758
+  dps: 4176.70141
+  tps: 4447.26969
   hps: 11.01087
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1681.19843
-  tps: 1509.99572
+  dps: 1631.56207
+  tps: 1460.35936
   hps: 10.67382
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1664.08153
-  tps: 1479.17347
+  dps: 1612.31005
+  tps: 1427.40199
   hps: 10.45517
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3501.69933
-  tps: 3153.80091
+  dps: 3308.35919
+  tps: 2960.46077
   hps: 19.87436
  }
 }

--- a/sim/hunter/runes.go
+++ b/sim/hunter/runes.go
@@ -305,7 +305,7 @@ func (hunter *Hunter) tntDamageMultiplier() float64 {
 
 func (hunter *Hunter) tntDamageFlatBonus() float64 {
 	if hunter.HasRune(proto.HunterRune_RuneBracersTNT) {
-		return hunter.GetStat(stats.AttackPower) * 0.5
+		return math.Max(hunter.GetStat(stats.AttackPower), hunter.GetStat(stats.RangedAttackPower)) * 0.25
 	}
 	return 0.0
 }


### PR DESCRIPTION
Hunter tnt trap damage now scales with the higher of mAP / rAP as well as for only 25% of the value rather than 50%

https://www.wowhead.com/blue-tracker/topic/us/season-of-discovery-hotfixes-august-5-1788040