### PR TITLE
Add Mongoose Bite reset procs to Raptor Strike and Mongoose Bite

### DIFF
--- a/sim/hunter/mongoose_bite.go
+++ b/sim/hunter/mongoose_bite.go
@@ -56,6 +56,7 @@ func (hunter *Hunter) getMongooseBiteConfig(rank int) core.SpellConfig {
 
 			if hasMeleeSpecialist && sim.Proc(0.3, "Raptor Strike Reset") {
 				hunter.RaptorStrike.CD.Reset()
+				spell.CD.Reset()
 			}
 
 			multiplier := 1.0

--- a/sim/hunter/raptor_strike.go
+++ b/sim/hunter/raptor_strike.go
@@ -70,6 +70,7 @@ func (hunter *Hunter) getRaptorStrikeConfig(rank int) core.SpellConfig {
 
 			if hasMeleeSpecialist && sim.Proc(0.3, "Raptor Strike Reset") {
 				spell.CD.Reset()
+				hunter.MongooseBite.CD.Reset()
 			}
 
 			if hasRaptorFury {


### PR DESCRIPTION
Fixes https://github.com/wowsims/sod/issues/967
Add mongoose bite reset to raptor strike and mongoose bite spells to match behavior in game

Sample iteration sim results post change
![image](https://github.com/user-attachments/assets/258c0c2a-fd0b-4a4d-91ee-73cd2d9b8b27)

The same reset behavior observed in logs
![image](https://github.com/user-attachments/assets/2a774190-64cb-455d-9246-65daf2429f30)
