### PR TITLE
Updates Blade Flurry to not include the offhand portion of FoK

### DIFF
--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -313,10 +313,17 @@ func (rogue *Rogue) registerBladeFlurryCD() {
 			rogue.MultiplyMeleeSpeed(sim, 1/1.2)
 		},
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+			isFoKOH := false
+			
+			if spell.ActionID.SpellID == 409240 && spell.ActionID.Tag == 2 {
+				isFoKOH = true
+			}
+			
 			if sim.GetNumTargets() < 2 {
 				return
 			}
-			if result.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMelee) {
+						
+			if result.Damage == 0 || !spell.ProcMask.Matches(core.ProcMaskMelee) || isFoKOH {
 				return
 			}
 


### PR DESCRIPTION
Only FoK MH hits are replicated by Blade Flurry. 

https://vanilla.warcraftlogs.com/reports/X4WRLC2ynzAjHbav#fight=last&view=events

![image](https://github.com/user-attachments/assets/bba46c02-5793-4bdd-8f3f-112966513c9e)

