### PR TITLE
Add R12/R13 Set for Hunter

### DIFF
--- a/sim/hunter/item_sets_pvp.go
+++ b/sim/hunter/item_sets_pvp.go
@@ -162,19 +162,23 @@ var ItemSetWarlordsPursuit = core.NewItemSet(core.ItemSet{
 var ItemSetWarlordsProwess = core.NewItemSet(core.ItemSet{
 	Name: "Warlord's Prowess",
 	Bonuses: map[int32]core.ApplyEffect{
-		// +20 Agility.
+		// +20 Agility, 20 stamina
 		2: func(agent core.Agent) {
 			c := agent.GetCharacter()
-			c.AddStat(stats.Agility, 20)
+			c.AddStats(stats.Stats{
+				stats.Agility:       20,
+				stats.Stamina:       20,
 		},
 		// Increases the duration of your Wing Clip by 2 sec.
 		4: func(agent core.Agent) {
 			// Nothing to do
 		},
-		// +40 Attack Power.
+		// +40 Agnostic Attack Power
 		6: func(agent core.Agent) {
 			c := agent.GetCharacter()
-			c.AddStat(stats.AttackPower, 40)
+			c.AddStats(stats.Stats{
+				stats.AttackPower:       40,
+				stats.RangedAttackPower: 40,
 		},
 	},
 })
@@ -182,7 +186,7 @@ var ItemSetWarlordsProwess = core.NewItemSet(core.ItemSet{
 var ItemSetFieldMarshalsPursuit = core.NewItemSet(core.ItemSet{
 	Name: "Field Marshal's Pursuit",
 	Bonuses: map[int32]core.ApplyEffect{
-		// +20 Agility, 20 stam
+		// +20 Agility, 20 stamina
 		2: func(agent core.Agent) {
 			c := agent.GetCharacter()
 			c.AddStats(stats.Stats{
@@ -208,19 +212,23 @@ var ItemSetFieldMarshalsPursuit = core.NewItemSet(core.ItemSet{
 var ItemSetFieldMarshalsProwess = core.NewItemSet(core.ItemSet{
 	Name: "Field Marshal's Prowess",
 	Bonuses: map[int32]core.ApplyEffect{
-		// +20 Agility.
+		// +20 Agility, 20 stamina
 		2: func(agent core.Agent) {
 			c := agent.GetCharacter()
-			c.AddStat(stats.Agility, 20)
+			c.AddStats(stats.Stats{
+				stats.Agility:       20,
+				stats.Stamina:       20,
 		},
 		// Increases the duration of your Wing Clip by 2 sec.
 		4: func(agent core.Agent) {
 			// Nothing to do
 		},
-		// +40 Attack Power.
+		// +40 Agnostic Attack Power.
 		6: func(agent core.Agent) {
 			c := agent.GetCharacter()
-			c.AddStat(stats.AttackPower, 40)
+			c.AddStats(stats.Stats{
+				stats.AttackPower:       40,
+				stats.RangedAttackPower: 40,
 		},
 	},
 })

--- a/sim/hunter/item_sets_pvp.go
+++ b/sim/hunter/item_sets_pvp.go
@@ -128,3 +128,99 @@ var ItemSetLieutenantCommandersProwess = core.NewItemSet(core.ItemSet{
 		},
 	},
 })
+
+///////////////////////////////////////////////////////////////////////////
+//                            SoD Phase 5 Item Sets
+///////////////////////////////////////////////////////////////////////////
+
+var ItemSetWarlordsPursuit = core.NewItemSet(core.ItemSet{
+	Name: "Warlord's Pursuit",
+	Bonuses: map[int32]core.ApplyEffect{
+		// +20 Agility, 20 Stamina
+		2: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStats(stats.Stats{
+				stats.Agility:       20,
+				stats.Stamina:       20,
+			})
+		},
+		// Reduces the cooldown of your Concussive Shot by 1 sec.
+		4: func(agent core.Agent) {
+			// Nothing to do
+		},
+		// +20 Agi, 23 Spellpower.
+		6: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStats(stats.Stats{
+				stats.Agility:           20,
+				stats.Spellpower:        23,
+			})
+		},
+	},
+})
+
+var ItemSetWarlordsProwess = core.NewItemSet(core.ItemSet{
+	Name: "Warlord's Prowess",
+	Bonuses: map[int32]core.ApplyEffect{
+		// +20 Agility.
+		2: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStat(stats.Agility, 20)
+		},
+		// Increases the duration of your Wing Clip by 2 sec.
+		4: func(agent core.Agent) {
+			// Nothing to do
+		},
+		// +40 Attack Power.
+		6: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStat(stats.AttackPower, 40)
+		},
+	},
+})
+
+var ItemSetFieldMarshalsPursuit = core.NewItemSet(core.ItemSet{
+	Name: "Field Marshal's Pursuit",
+	Bonuses: map[int32]core.ApplyEffect{
+		// +20 Agility, 20 stam
+		2: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStats(stats.Stats{
+				stats.Agility:       20,
+				stats.Stamina:       20,
+			})
+		},
+		// Reduces the cooldown of your Concussive Shot by 1 sec.
+		4: func(agent core.Agent) {
+			// Nothing to do
+		},
+		// +20 Agi, 23 Spellpower.
+		6: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStats(stats.Stats{
+				stats.Agility:           20,
+				stats.Spellpower:        23,
+			})
+		},
+	},
+})
+
+var ItemSetFieldMarshalsProwess = core.NewItemSet(core.ItemSet{
+	Name: "Field Marshal's Prowess",
+	Bonuses: map[int32]core.ApplyEffect{
+		// +20 Agility.
+		2: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStat(stats.Agility, 20)
+		},
+		// Increases the duration of your Wing Clip by 2 sec.
+		4: func(agent core.Agent) {
+			// Nothing to do
+		},
+		// +40 Attack Power.
+		6: func(agent core.Agent) {
+			c := agent.GetCharacter()
+			c.AddStat(stats.AttackPower, 40)
+		},
+	},
+})


### PR DESCRIPTION
This is my second attempt to try and provide to this project; I am still rather inexperienced and unsure of what I'm doing, BUT here I am attempting to add both factions PvP set bonuses, linked here: https://www.wowhead.com/classic/item-set=1725/warlords-pursuit https://www.wowhead.com/classic/item-set=1726/warlords-prowess https://www.wowhead.com/classic/item-set=1739/field-marshals-pursuit https://www.wowhead.com/classic/item-set=1738/field-marshals-prowess

If there's any issues / errors with these changes, assistance may be necessary / extremely appreciated!