### PR TITLE
Protection Paladin: Correct Shield Specialization/Anticipation

### DIFF
--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -29,11 +29,11 @@ character_stats_results: {
   final_stats: 0
   final_stats: 7343.32
   final_stats: 824
-  final_stats: 147
-  final_stats: 13.88
-  final_stats: 116.792
-  final_stats: 14.87334
-  final_stats: 15.88
+  final_stats: 152
+  final_stats: 14.08
+  final_stats: 89.84
+  final_stats: 15.07334
+  final_stats: 16.08
   final_stats: 0
   final_stats: 7712.15
   final_stats: 35

--- a/sim/paladin/talents.go
+++ b/sim/paladin/talents.go
@@ -11,20 +11,23 @@ import (
 func (paladin *Paladin) ApplyTalents() {
 	paladin.AddStat(stats.MeleeHit, float64(paladin.Talents.Precision)*core.MeleeHitRatingPerHitChance)
 	// TODO: paladin.AddStat(stats.RangedHit, float64(paladin.Talents.Precision)*core.MeleeHitRatingPerHitChance)
-	paladin.AddStat(stats.Defense, float64(paladin.Talents.Anticipation)*core.CritRatingPerCritChance)
+
 	paladin.AddStat(stats.MeleeCrit, float64(paladin.Talents.Conviction)*core.CritRatingPerCritChance)
 	// TODO: paladin.AddStat(stats.RangedCrit, float64(paladin.Talents.Conviction)*core.CritRatingPerCritChance)
-	paladin.ApplyEquipScaling(stats.Armor, 1.0+0.02*float64(paladin.Talents.Toughness))
 
-	if paladin.Talents.DivineStrength > 0 {
-		paladin.MultiplyStat(stats.Strength, 1.0+0.02*float64(paladin.Talents.DivineStrength))
+	if paladin.Talents.Toughness > 0 {
+		paladin.ApplyEquipScaling(stats.Armor, 1.0+0.02*float64(paladin.Talents.Toughness))
 	}
-	if paladin.Talents.DivineIntellect > 0 {
-		paladin.MultiplyStat(stats.Intellect, 1.0+0.02*float64(paladin.Talents.DivineIntellect))
-	}
-	if paladin.Talents.ShieldSpecialization > 0 {
-		paladin.MultiplyStat(stats.BlockValue, 1.0+0.1*float64(paladin.Talents.ShieldSpecialization))
-	}
+
+	// These are no-op if untalented.
+	paladin.MultiplyStat(stats.Strength, 1.0+0.02*float64(paladin.Talents.DivineStrength))
+	paladin.MultiplyStat(stats.Intellect, 1.0+0.02*float64(paladin.Talents.DivineIntellect))
+	paladin.AddStat(stats.Defense, 2*float64(paladin.Talents.Anticipation))
+
+	// Shield Specialization bonus is additive. NOTE: Total SBV will be inflated until
+	// https://github.com/wowsims/sod/issues/1025 gets resolved.
+	paladin.PseudoStats.BlockValueMultiplier += 0.1 * float64(paladin.Talents.ShieldSpecialization)
+
 	paladin.AddStat(stats.Parry, 1*float64(paladin.Talents.Deflection))
 
 	paladin.applyWeaponSpecialization()
@@ -34,13 +37,11 @@ func (paladin *Paladin) ApplyTalents() {
 	if paladin.Talents.Vindication > 0 {
 		paladin.applyVindication()
 	}
-	paladin.PseudoStats.SchoolBonusCritChance[stats.SchoolIndexHoly] +=  core.SpellCritRatingPerCritChance * float64(paladin.Talents.HolyPower)
-	// paladin.applyRighteousVengeance()
+	paladin.PseudoStats.SchoolBonusCritChance[stats.SchoolIndexHoly] += core.SpellCritRatingPerCritChance * float64(paladin.Talents.HolyPower)
+
 	// paladin.applyRedoubt()
 	// paladin.applyReckoning()
-	// paladin.applyArdentDefender()
 }
-
 
 func (paladin *Paladin) improvedSoR() float64 {
 	return []float64{1, 1.03, 1.06, 1.09, 1.12, 1.15}[paladin.Talents.ImprovedSealOfRighteousness]


### PR DESCRIPTION
Changes:
* Anticipation gives 2 points of Defense per talent point.
* Shield Specialization changes the BV multiplier (i.e. additive dynamic scaling).
* Left a comment about the multiplier being off until #1025 gets fixed.
* Some minor hygeine to remove commented code from other expansions and unneeded if-blocks to improve readability.
* Tests updated