### PR TITLE
Warlock: Update T1 6P and Incinerate Modifier

### DIFF
--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.09183
+  weights: -1.78018
   weights: 0
-  weights: 0.4563
-  weights: 0
-  weights: 0
+  weights: 1.37581
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 10.59981
-  weights: 20.95501
+  weights: 0
+  weights: 0
+  weights: 13.45991
+  weights: 20.6946
   weights: 0
   weights: 0
   weights: 0
@@ -456,8 +456,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2969.45422
-  tps: 2801.69596
+  dps: 2978.29801
+  tps: 2811.98943
  }
 }
 dps_results: {
@@ -470,8 +470,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 3018.47903
-  tps: 2853.94466
+  dps: 3012.49946
+  tps: 2848.49264
  }
 }
 dps_results: {
@@ -498,56 +498,56 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl60-Average-Default"
  value: {
-  dps: 3070.82291
-  tps: 2905.21655
+  dps: 3069.84332
+  tps: 2904.22331
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 3033.9252
-  tps: 4270.74773
+  dps: 3028.86428
+  tps: 4277.33106
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3033.9252
-  tps: 2867.44864
+  dps: 3028.86428
+  tps: 2863.40499
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 2904.17293
-  tps: 2706.79597
+  dps: 2898.25195
+  tps: 2700.81566
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 1520.46533
-  tps: 2951.33398
+  dps: 1516.28004
+  tps: 2948.76934
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1520.46533
-  tps: 1464.6899
+  dps: 1516.28004
+  tps: 1460.45722
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1447.33308
-  tps: 1365.97884
+  dps: 1446.74644
+  tps: 1364.95834
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3034.08515
-  tps: 2867.68856
+  dps: 3040.13334
+  tps: 2873.56342
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -53,18 +53,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.24735
+  weights: 0.27696
   weights: 0
-  weights: 0.61323
-  weights: 0
-  weights: 0
+  weights: 0.68645
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.59008
-  weights: 1.88055
+  weights: 0
+  weights: 0
+  weights: 4.01446
+  weights: 2.10504
   weights: 0
   weights: 0
   weights: 0
@@ -106,63 +106,63 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 441.34292
-  tps: 461.32874
+  dps: 493.94227
+  tps: 514.20663
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 436.73916
-  tps: 456.19442
+  dps: 488.79879
+  tps: 508.4786
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 435.97222
-  tps: 790.19747
+  dps: 487.93095
+  tps: 842.44812
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 435.97222
-  tps: 455.99944
+  dps: 487.93095
+  tps: 508.25009
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 471.1421
-  tps: 490.2715
+  dps: 526.23747
+  tps: 547.20151
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 293.1177
-  tps: 665.49955
+  dps: 328.08361
+  tps: 700.62839
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 293.1177
-  tps: 313.02666
+  dps: 328.08361
+  tps: 348.1555
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-fire.succubus-Demonology Warlock-demonology-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 331.5311
-  tps: 337.00741
+  dps: 370.27373
+  tps: 376.4072
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 435.97222
-  tps: 455.99944
+  dps: 487.93095
+  tps: 508.25009
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.05577
+  weights: -0.06703
   weights: 0
-  weights: 0.50991
-  weights: 0
-  weights: 0
+  weights: 0.56226
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.27804
+  weights: 0
+  weights: 0
+  weights: 1.40291
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.02549
+  weights: 0.05663
   weights: 0
-  weights: 1.37021
-  weights: 0
-  weights: 0
+  weights: 1.53237
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.53735
-  weights: 4.97634
+  weights: 0
+  weights: 0
+  weights: 7.04538
+  weights: 5.50394
   weights: 0
   weights: 0
   weights: 0
@@ -298,18 +298,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.69761
+  weights: 0.76086
   weights: 0
-  weights: 1.5031
-  weights: 0
-  weights: 0
+  weights: 1.67038
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 13.72772
-  weights: 10.28802
+  weights: 0
+  weights: 0
+  weights: 15.13605
+  weights: 11.41256
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.04183
+  weights: 2.29462
   weights: 0
-  weights: 3.66052
-  weights: 0
-  weights: 0
+  weights: 4.16894
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.21817
-  weights: 20.58767
+  weights: 0
+  weights: 0
+  weights: 4.03944
+  weights: 22.79723
   weights: 0
   weights: 0
   weights: 0
@@ -400,64 +400,64 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 261.98444
-  tps: 219.41754
+  dps: 287.18424
+  tps: 244.61733
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 254.79419
-  tps: 213.61165
+  dps: 279.30497
+  tps: 238.12243
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 253.94205
-  tps: 357.15972
+  dps: 278.34166
+  tps: 381.55933
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 253.94205
-  tps: 212.74971
+  dps: 278.34166
+  tps: 237.14932
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 263.97652
-  tps: 218.36216
+  dps: 289.3672
+  tps: 243.75284
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 198.56477
-  tps: 309.03227
+  dps: 217.24795
+  tps: 327.71545
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 198.56477
-  tps: 164.29511
+  dps: 217.24795
+  tps: 182.97829
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 207.13405
-  tps: 172.24116
+  dps: 227.21248
+  tps: 192.31958
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 254.24852
-  tps: 213.05619
+  dps: 278.6848
+  tps: 237.49246
  }
 }
 dps_results: {
@@ -470,64 +470,64 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 697.95786
-  tps: 601.5865
+  dps: 766.89375
+  tps: 670.85824
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 695.60224
-  tps: 600.3325
+  dps: 764.39941
+  tps: 669.4626
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 689.38202
-  tps: 928.72334
+  dps: 757.42045
+  tps: 997.02664
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 689.38202
-  tps: 592.96017
+  dps: 757.42045
+  tps: 661.26346
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 739.56319
-  tps: 638.36052
+  dps: 810.59974
+  tps: 710.98848
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 457.49071
-  tps: 756.36335
+  dps: 501.87269
+  tps: 800.91676
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 457.49071
-  tps: 394.15745
+  dps: 501.87269
+  tps: 438.71086
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 493.37528
-  tps: 431.67446
+  dps: 541.57111
+  tps: 480.73296
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 693.4964
-  tps: 598.53908
+  dps: 762.10918
+  tps: 667.51029
  }
 }
 dps_results: {
@@ -540,71 +540,71 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl50-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 1551.26201
-  tps: 1377.5745
+  dps: 1710.29597
+  tps: 1537.22885
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Average-Default"
  value: {
-  dps: 1563.00056
-  tps: 1388.01207
+  dps: 1723.42274
+  tps: 1548.94475
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 2409.17293
-  tps: 2882.10772
+  dps: 2670.48248
+  tps: 3141.80251
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 1561.43707
-  tps: 1389.28046
+  dps: 1721.68984
+  tps: 1550.05508
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-FullBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 1678.27829
-  tps: 1500.49249
+  dps: 1846.83709
+  tps: 1671.22647
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongMultiTarget"
  value: {
-  dps: 1511.87724
-  tps: 2109.45397
+  dps: 1675.90678
+  tps: 2272.14001
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-LongSingleTarget"
  value: {
-  dps: 882.80086
-  tps: 787.92302
+  dps: 971.75357
+  tps: 877.17285
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-Settings-Orc-backdraft-Destruction Warlock-backdraft-NoBuffs-Phase 3 Consumes-ShortSingleTarget"
  value: {
-  dps: 938.56835
-  tps: 851.53372
+  dps: 1033.82709
+  tps: 947.93125
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1547.70926
-  tps: 1373.79879
+  dps: 1706.36206
+  tps: 1533.06477
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1740.72947
-  tps: 1524.2641
+  dps: 1900.0672
+  tps: 1684.06105
  }
 }
 dps_results: {
@@ -617,15 +617,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1731.01351
-  tps: 1516.65367
+  dps: 1889.34424
+  tps: 1675.63812
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 3055.57066
-  tps: 2720.82342
+  dps: 3347.1861
+  tps: 3013.37403
  }
 }
 dps_results: {
@@ -638,91 +638,91 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 3074.11843
-  tps: 2740.61381
+  dps: 3367.62298
+  tps: 3035.16444
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1740.72947
-  tps: 1524.2641
+  dps: 1900.0672
+  tps: 1684.06105
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 2303.98062
-  tps: 2077.95586
+  dps: 2536.93061
+  tps: 2311.28042
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 2288.16856
-  tps: 2064.62981
+  dps: 2520.49022
+  tps: 2297.51066
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 3035.70609
-  tps: 2705.6147
+  dps: 3326.69394
+  tps: 2997.5841
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Average-Default"
  value: {
-  dps: 3142.38586
-  tps: 2803.0093
+  dps: 3444.66859
+  tps: 3106.0635
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 3120.96302
-  tps: 3832.34318
+  dps: 3420.53722
+  tps: 4132.92387
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3120.96302
-  tps: 2784.48651
+  dps: 3420.53722
+  tps: 3085.0672
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 3205.37114
-  tps: 2864.05424
+  dps: 3513.62196
+  tps: 3172.96565
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 1751.28442
-  tps: 2706.30066
+  dps: 1915.86281
+  tps: 2871.22712
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1751.28442
-  tps: 1565.46599
+  dps: 1915.86281
+  tps: 1730.39244
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1745.1576
-  tps: 1546.43076
+  dps: 1906.22348
+  tps: 1707.96469
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3107.00618
-  tps: 2769.42562
+  dps: 3404.80195
+  tps: 3068.14644
  }
 }

--- a/sim/warlock/incinerate.go
+++ b/sim/warlock/incinerate.go
@@ -23,10 +23,10 @@ func (warlock *Warlock) registerIncinerateSpell() {
 		ActionID: core.ActionID{SpellID: int32(proto.WarlockRune_RuneBracerIncinerate)},
 		Duration: time.Second * 15,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			warlock.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFire] *= 1.25
+			warlock.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFire] *= 1.40
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			warlock.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFire] /= 1.25
+			warlock.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFire] /= 1.40
 		},
 	})
 

--- a/sim/warlock/runes.go
+++ b/sim/warlock/runes.go
@@ -130,7 +130,7 @@ func (warlock *Warlock) applyDecimation() {
 
 	affectedSpellCodes := []int32{SpellCode_WarlockShadowBolt, SpellCode_WarlockShadowCleave, SpellCode_WarlockIncinerate, SpellCode_WarlockSoulFire}
 
-	decimationAura := warlock.RegisterAura(core.Aura{
+	warlock.DecimationAura = warlock.RegisterAura(core.Aura{
 		Label:    "Decimation",
 		ActionID: core.ActionID{SpellID: 440873},
 		Duration: time.Second * 10,
@@ -151,7 +151,7 @@ func (warlock *Warlock) applyDecimation() {
 		Label: "Decimation Trigger",
 		OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if result.Landed() && sim.IsExecutePhase35() && slices.Contains(affectedSpellCodes, spell.SpellCode) {
-				decimationAura.Activate(sim)
+				warlock.DecimationAura.Activate(sim)
 			}
 		},
 	}))

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13415
+  weights: 0.12218
   weights: 0
-  weights: 0.43904
-  weights: 0
-  weights: 0
+  weights: 0.44779
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.62247
+  weights: 0
+  weights: 0
+  weights: 0.67012
   weights: 0
   weights: 0
   weights: 0
@@ -204,64 +204,64 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Lvl25-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 215.33652
-  tps: 492.54397
+  dps: 225.8131
+  tps: 526.41635
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Average-Default"
  value: {
-  dps: 207.32205
-  tps: 474.81657
+  dps: 217.28247
+  tps: 507.18429
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 314.34421
-  tps: 1334.46201
+  dps: 317.24577
+  tps: 1344.09632
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 206.82468
-  tps: 473.76249
+  dps: 216.64913
+  tps: 505.69559
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 213.54286
-  tps: 486.93074
+  dps: 224.98804
+  tps: 523.32434
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 234.433
-  tps: 1147.19963
+  dps: 236.46998
+  tps: 1153.81722
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 154.66503
-  tps: 352.97156
+  dps: 162.16533
+  tps: 377.10551
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-Settings-Orc-p1.affi.tank-Affliction Warlock-p1.affi.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 161.39822
-  tps: 367.05579
+  dps: 170.2128
+  tps: 395.09211
  }
 }
 dps_results: {
  key: "TestAffliction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 206.89015
-  tps: 473.87839
+  dps: 216.7146
+  tps: 505.81149
  }
 }
 dps_results: {

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -102,18 +102,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.01696
+  weights: -0.01044
   weights: 0
-  weights: 0.47138
-  weights: 0
-  weights: 0
+  weights: 0.51249
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.02492
-  weights: 1.13156
+  weights: 0
+  weights: 0
+  weights: 4.32697
+  weights: 1.24176
   weights: 0
   weights: 0
   weights: 0
@@ -204,64 +204,64 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Lvl40-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 342.73597
-  tps: 1010.23617
+  dps: 366.70291
+  tps: 1095.07914
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Average-Default"
  value: {
-  dps: 336.86424
-  tps: 996.02632
+  dps: 360.5694
+  tps: 1079.94257
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 317.14633
-  tps: 1870.97886
+  dps: 340.44261
+  tps: 1953.44771
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 317.14633
-  tps: 954.10073
+  dps: 340.44261
+  tps: 1036.56958
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 338.45322
-  tps: 993.16605
+  dps: 363.95488
+  tps: 1083.44192
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 208.98459
-  tps: 1634.59521
+  dps: 224.25559
+  tps: 1688.65456
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 208.98459
-  tps: 647.12228
+  dps: 224.25559
+  tps: 701.18163
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-Settings-Orc-p2.demo.tank-Demonology Warlock-p2.demo.tank-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 227.58362
-  tps: 675.58029
+  dps: 244.74552
+  tps: 736.33345
  }
 }
 dps_results: {
  key: "TestDemonology-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 332.70369
-  tps: 987.71776
+  dps: 356.35141
+  tps: 1071.4307
  }
 }
 dps_results: {

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.08735
+  weights: 0.0408
   weights: 0
-  weights: 0.36427
-  weights: 0
-  weights: 0
+  weights: 0.39526
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.84889
+  weights: 0
+  weights: 0
+  weights: 0.91066
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13811
+  weights: 0.14064
   weights: 0
-  weights: 0.59046
-  weights: 0
-  weights: 0
+  weights: 0.64073
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.1219
-  weights: 3.08804
+  weights: 0
+  weights: 0
+  weights: 5.50587
+  weights: 3.36695
   weights: 0
   weights: 0
   weights: 0
@@ -400,64 +400,64 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl25-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 190.94299
-  tps: 448.8768
+  dps: 203.19417
+  tps: 492.24599
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Average-Default"
  value: {
-  dps: 185.2764
-  tps: 431.72435
+  dps: 196.99001
+  tps: 473.19055
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 184.64593
-  tps: 733.97324
+  dps: 196.30928
+  tps: 775.2615
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 184.64593
-  tps: 429.93222
+  dps: 196.30928
+  tps: 471.22047
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-FullBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 191.68327
-  tps: 455.90601
+  dps: 204.92656
+  tps: 502.78725
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongMultiTarget"
  value: {
-  dps: 147.29143
-  tps: 640.54525
+  dps: 156.20431
+  tps: 672.09684
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-LongSingleTarget"
  value: {
-  dps: 147.29143
-  tps: 329.98537
+  dps: 156.20431
+  tps: 361.53697
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-Settings-Orc-p1.destro.tank-Destruction Warlock-p1.destro.tank-NoBuffs-Phase 1 Consumes-ShortSingleTarget"
  value: {
-  dps: 149.45675
-  tps: 351.96304
+  dps: 159.77284
+  tps: 388.482
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 184.71141
-  tps: 430.04812
+  dps: 196.37476
+  tps: 471.33637
  }
 }
 dps_results: {
@@ -470,64 +470,64 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Lvl40-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 434.64877
-  tps: 1195.62861
+  dps: 470.09332
+  tps: 1320.79863
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Average-Default"
  value: {
-  dps: 431.60606
-  tps: 1186.8443
+  dps: 466.82418
+  tps: 1311.22106
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 418.94237
-  tps: 1754.35944
+  dps: 454.95922
+  tps: 1876.37817
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 407.64512
-  tps: 1137.03703
+  dps: 442.22499
+  tps: 1259.14511
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 420.56889
-  tps: 1159.96662
+  dps: 457.10957
+  tps: 1287.79732
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 282.25337
-  tps: 1440.13605
+  dps: 305.72159
+  tps: 1518.81312
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 272.01915
-  tps: 745.63445
+  dps: 294.20811
+  tps: 823.93961
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 289.82333
-  tps: 773.95369
+  dps: 314.43639
+  tps: 859.86505
  }
 }
 dps_results: {
  key: "TestDestruction-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 424.65376
-  tps: 1171.95576
+  dps: 459.61861
+  tps: 1295.42766
  }
 }
 dps_results: {

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -110,6 +110,7 @@ type Warlock struct {
 	ImprovedShadowBoltAuras core.AuraArray
 	MarkOfChaosAuras        core.AuraArray
 	SoulLinkAura            *core.Aura
+	DecimationAura          *core.Aura
 
 	// The sum total of demonic pact spell power * seconds.
 	DPSPAggregate float64


### PR DESCRIPTION
## Some September PTR Warlock Updates
1. DPS Tier 1 6 Piece
  -  Fire Trance has been removed 
  -  Incinerate has a 4% chance to trigger the Warlock’s Decimation regardless of the health of the target.
2. Incinerate 
  - Increases Fire damage by 40% (was 25%).