### PR TITLE
Minor fixes for Ranged Attack Power bonuses and applications

### DIFF
--- a/sim/_hunter/kill_shot.go
+++ b/sim/_hunter/kill_shot.go
@@ -40,7 +40,7 @@ func (hunter *Hunter) registerKillShotSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			// 0.2 rap from normalized weapon (2.8/14) and 0.2 from bonus ratio
-			baseDamage := 0.4*spell.RangedAttackPower(target) +
+			baseDamage := 0.4*spell.RangedAttackPower(target, false) +
 				hunter.AutoAttacks.Ranged().BaseDamage(sim) +
 				hunter.AmmoDamageBonus +
 				spell.BonusWeaponDamage() +

--- a/sim/_hunter/silencing_shot.go
+++ b/sim/_hunter/silencing_shot.go
@@ -34,7 +34,7 @@ func (hunter *Hunter) registerSilencingShotSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := hunter.RangedWeaponDamage(sim, spell.RangedAttackPower(target)) +
+			baseDamage := hunter.RangedWeaponDamage(sim, spell.RangedAttackPower(target, false)) +
 				hunter.AmmoDamageBonus +
 				spell.BonusWeaponDamage()
 

--- a/sim/_hunter/volley.go
+++ b/sim/_hunter/volley.go
@@ -42,7 +42,7 @@ func (hunter *Hunter) registerVolleySpell() {
 
 			OnSnapshot: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot, isRollover bool) {
 				target := hunter.CurrentTarget
-				baseDamage = 353 + 0.0837*dot.Spell.RangedAttackPower(target)
+				baseDamage = 353 + 0.0837*dot.spell.RangedAttackPower(target, false)
 				baseDamage *= sim.Encounter.AOECapMultiplier()
 				dot.Snapshot(target, baseDamage, isRollover)
 			},

--- a/sim/_hunter/volley.go
+++ b/sim/_hunter/volley.go
@@ -42,7 +42,7 @@ func (hunter *Hunter) registerVolleySpell() {
 
 			OnSnapshot: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot, isRollover bool) {
 				target := hunter.CurrentTarget
-				baseDamage = 353 + 0.0837*dot.spell.RangedAttackPower(target, false)
+				baseDamage = 353 + 0.0837*dot.Spell.RangedAttackPower(target, false)
 				baseDamage *= sim.Encounter.AOECapMultiplier()
 				dot.Snapshot(target, baseDamage, isRollover)
 			},

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -499,7 +499,7 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		BonusCoefficient: TernaryFloat64(options.Ranged.GetSpellSchool() == SpellSchoolPhysical, 1, 0),
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
-			baseDamage := spell.Unit.RangedWeaponDamage(sim, spell.RangedAttackPower(target))
+			baseDamage := spell.Unit.RangedWeaponDamage(sim, spell.RangedAttackPower(target, false))
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)
 
 			spell.WaitTravelTime(sim, func(sim *Simulation) {

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -476,6 +476,7 @@ func applyPhysicalBuffConsumes(character *Character, consumes *proto.Consumes) {
 		case proto.AttackPowerBuff_JujuMight:
 			character.AddStats(stats.Stats{
 				stats.AttackPower: 40,
+				stats.RangedAttackPower: 40,
 			})
 		case proto.AttackPowerBuff_WinterfallFirewater:
 			character.AddStats(stats.Stats{

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -95,10 +95,12 @@ func (spell *Spell) MeleeAttackPower() float64 {
 	return spell.Unit.stats[stats.AttackPower] + spell.Unit.PseudoStats.MobTypeAttackPower
 }
 
-func (spell *Spell) RangedAttackPower(target *Unit) float64 {
-	return spell.Unit.stats[stats.RangedAttackPower] +
+func (spell *Spell) RangedAttackPower(target *Unit, ignorePseudoStats bool) float64 {
+	return TernaryFloat64(ignorePseudoStats, 
+		spell.Unit.stats[stats.RangedAttackPower], 
+		spell.Unit.stats[stats.RangedAttackPower] +
 		spell.Unit.PseudoStats.MobTypeAttackPower +
-		target.PseudoStats.BonusRangedAttackPowerTaken
+		target.PseudoStats.BonusRangedAttackPowerTaken)
 }
 
 func (spell *Spell) PhysicalHitChance(attackTable *AttackTable) float64 {

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -95,8 +95,8 @@ func (spell *Spell) MeleeAttackPower() float64 {
 	return spell.Unit.stats[stats.AttackPower] + spell.Unit.PseudoStats.MobTypeAttackPower
 }
 
-func (spell *Spell) RangedAttackPower(target *Unit, ignorePseudoStats bool) float64 {
-	return TernaryFloat64(ignorePseudoStats, 
+func (spell *Spell) RangedAttackPower(target *Unit, ignoreTargetModifiers bool) float64 {
+	return TernaryFloat64(ignoreTargetModifiers, 
 		spell.Unit.stats[stats.RangedAttackPower], 
 		spell.Unit.stats[stats.RangedAttackPower] +
 		spell.Unit.PseudoStats.MobTypeAttackPower +

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -175,7 +175,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 2431.74
-  final_stats: 791
+  final_stats: 831
   final_stats: 0
   final_stats: 5
   final_stats: 0

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -274,43 +274,43 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 765.71837
-  tps: 875.71988
+  dps: 765.77392
+  tps: 872.19738
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 688.92293
-  tps: 435.46306
+  dps: 688.45576
+  tps: 437.09722
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 752.28843
-  tps: 476.13001
+  dps: 751.03593
+  tps: 478.30952
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 445.74592
-  tps: 681.65454
+  dps: 445.53334
+  tps: 681.10709
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 395.33018
-  tps: 273.28011
+  dps: 395.01456
+  tps: 272.85904
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 425.68851
-  tps: 297.55497
+  dps: 426.59765
+  tps: 297.57584
  }
 }
 dps_results: {
@@ -442,43 +442,43 @@ dps_results: {
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 768.70494
-  tps: 874.24255
+  dps: 762.34993
+  tps: 870.07555
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 691.05957
-  tps: 432.42499
+  dps: 687.1767
+  tps: 430.25594
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 754.99549
-  tps: 470.94052
+  dps: 754.60568
+  tps: 472.63074
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 447.37958
-  tps: 680.61258
+  dps: 447.28641
+  tps: 683.63115
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 396.9941
-  tps: 269.14662
+  dps: 398.18515
+  tps: 270.19187
  }
 }
 dps_results: {
  key: "TestBM-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 426.04029
-  tps: 290.22293
+  dps: 426.99223
+  tps: 291.72811
  }
 }
 dps_results: {

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 3895.6774
-  final_stats: 2357.6774
+  final_stats: 2397.6774
   final_stats: 0
   final_stats: 5
   final_stats: 0
@@ -246,85 +246,85 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 742.82918
-  tps: 923.52467
+  dps: 741.03819
+  tps: 922.18963
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 647.03652
-  tps: 515.22895
+  dps: 644.67925
+  tps: 512.95724
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 670.21558
-  tps: 537.95926
+  dps: 670.2869
+  tps: 537.63551
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 445.0823
-  tps: 675.36792
+  dps: 444.52058
+  tps: 672.56457
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 383.85284
-  tps: 319.83423
+  dps: 384.6012
+  tps: 321.2392
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Dwarf-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 414.23025
-  tps: 345.7023
+  dps: 414.05625
+  tps: 346.35485
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 743.665
-  tps: 928.63267
+  dps: 747.46482
+  tps: 934.54796
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 650.89151
-  tps: 513.09055
+  dps: 644.73434
+  tps: 506.68974
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-FullBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 675.37599
-  tps: 537.14397
+  dps: 677.79602
+  tps: 538.95708
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongMultiTarget"
  value: {
-  dps: 450.72931
-  tps: 665.85732
+  dps: 450.15718
+  tps: 665.82299
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-LongSingleTarget"
  value: {
-  dps: 386.70624
-  tps: 318.05791
+  dps: 386.28758
+  tps: 317.47869
  }
 }
 dps_results: {
  key: "TestMM-Lvl40-Settings-Orc-p2_ranged_mm-Basic-p2_ranged_mm-NoBuffs-Phase 2 Consumes-ShortSingleTarget"
  value: {
-  dps: 415.12675
-  tps: 341.77351
+  dps: 412.26325
+  tps: 340.15503
  }
 }
 dps_results: {
@@ -345,96 +345,96 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 705.97961
-  tps: 706.09006
+  dps: 708.64963
+  tps: 708.76008
   hps: 9.62094
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 676.1827
-  tps: 676.29315
+  dps: 678.86461
+  tps: 678.97506
   hps: 9.62094
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 845.26122
-  tps: 845.37167
+  dps: 846.87355
+  tps: 846.984
   hps: 12.45241
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 844.16825
-  tps: 844.2787
+  dps: 845.79496
+  tps: 845.90541
   hps: 12.45241
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 837.27285
-  tps: 837.3833
+  dps: 838.89956
+  tps: 839.01001
   hps: 12.45241
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 622.47504
-  tps: 622.59494
+  dps: 623.67131
+  tps: 623.79121
   hps: 9.19313
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 683.10287
-  tps: 683.21332
+  dps: 685.78478
+  tps: 685.89523
   hps: 9.62094
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 846.75674
-  tps: 846.86719
+  dps: 848.36557
+  tps: 848.47602
   hps: 12.45241
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 705.97961
-  tps: 706.09006
+  dps: 708.64963
+  tps: 708.76008
   hps: 9.62094
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 845.79914
-  tps: 845.90959
+  dps: 847.41372
+  tps: 847.52417
   hps: 12.28955
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 833.19663
-  tps: 833.30708
+  dps: 834.81823
+  tps: 834.92868
   hps: 12.45241
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 794.21846
-  tps: 794.32891
+  dps: 795.84005
+  tps: 795.9505
   hps: 12.45241
  }
 }
@@ -449,120 +449,120 @@ dps_results: {
 dps_results: {
  key: "TestMM-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 830.34268
-  tps: 830.45313
+  dps: 831.96684
+  tps: 832.07729
   hps: 12.45241
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Average-Default"
  value: {
-  dps: 849.43787
-  tps: 849.54385
+  dps: 851.03195
+  tps: 851.13793
   hps: 12.50848
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 5598.04905
-  tps: 5969.89574
+  dps: 5648.43567
+  tps: 6020.28235
   hps: 15.63561
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 2575.49093
-  tps: 2594.07413
+  dps: 2598.6271
+  tps: 2617.2103
   hps: 15.78273
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 2575.77373
-  tps: 2596.61737
+  dps: 2599.16412
+  tps: 2620.00775
   hps: 15.34107
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 3161.50759
-  tps: 3550.84844
+  dps: 3192.88397
+  tps: 3582.22482
   hps: 8.73296
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1357.21975
-  tps: 1376.68679
+  dps: 1370.85632
+  tps: 1390.32337
   hps: 8.77313
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Dwarf-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1384.14674
-  tps: 1393.92462
+  dps: 1398.18546
+  tps: 1407.96334
   hps: 8.92667
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 5962.21656
-  tps: 6337.4211
+  dps: 6013.16513
+  tps: 6388.36967
   hps: 15.62722
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 2781.3791
-  tps: 2800.13845
+  dps: 2805.14203
+  tps: 2823.90138
   hps: 15.56648
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 2806.63892
-  tps: 2827.75972
+  dps: 2830.99965
+  tps: 2852.12045
   hps: 14.83128
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 3171.66553
-  tps: 3557.07577
+  dps: 3203.2108
+  tps: 3588.62104
   hps: 8.67672
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1366.43852
-  tps: 1385.70903
+  dps: 1380.24547
+  tps: 1399.51598
   hps: 8.46427
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-Settings-Orc-p4_ranged-Weave-p4_ranged-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1404.99701
-  tps: 1414.77488
+  dps: 1419.43941
+  tps: 1429.21728
   hps: 8.52497
  }
 }
 dps_results: {
  key: "TestMM-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 703.16927
-  tps: 703.27945
+  dps: 704.77376
+  tps: 704.88394
   hps: 10.64513
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 4046.54081
-  final_stats: 2468.54081
+  final_stats: 2508.54081
   final_stats: 0
   final_stats: 5
   final_stats: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestSV-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 2.86817
+  weights: 2.87486
   weights: 0
   weights: 0
   weights: 0
@@ -165,17 +165,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.34674
+  weights: 0.34255
   weights: 0
-  weights: 20.40378
-  weights: 0
-  weights: 0
+  weights: 20.53626
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.5079
+  weights: 0
+  weights: 0
+  weights: 0.51139
   weights: 0
   weights: 0
   weights: 0
@@ -337,232 +337,232 @@ dps_results: {
 dps_results: {
  key: "TestSV-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 1172.65266
-  tps: 955.2693
+  dps: 1178.41876
+  tps: 961.0354
   hps: 13.9332
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 1434.78487
-  tps: 1192.74789
+  dps: 1443.10629
+  tps: 1201.06931
   hps: 13.9332
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 1344.79528
-  tps: 1112.47435
+  dps: 1353.00754
+  tps: 1120.6866
   hps: 13.9332
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 1367.67607
-  tps: 1371.3323
+  dps: 1383.00371
+  tps: 1386.65994
   hps: 11.41474
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 3314.55218
-  tps: 2945.46297
+  dps: 3335.20925
+  tps: 2966.12004
   hps: 19.87709
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 3287.64654
-  tps: 2921.56836
+  dps: 3308.30361
+  tps: 2942.22543
   hps: 19.87709
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 2059.00598
-  tps: 1801.67145
+  dps: 2072.92382
+  tps: 1815.58929
   hps: 14.9599
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 1364.28174
-  tps: 1131.59301
+  dps: 1372.49256
+  tps: 1139.80383
   hps: 13.9332
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 1396.3897
-  tps: 1400.04593
+  dps: 1411.71734
+  tps: 1415.37357
   hps: 11.41474
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 1434.78487
-  tps: 1192.74789
+  dps: 1443.10629
+  tps: 1201.06931
   hps: 13.9332
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 3338.60265
-  tps: 2972.35032
+  dps: 3359.17284
+  tps: 2992.92051
   hps: 19.6034
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 3248.55596
-  tps: 2882.17368
+  dps: 3268.60531
+  tps: 2902.22303
   hps: 19.73878
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 2980.94118
-  tps: 2655.72806
+  dps: 3000.90358
+  tps: 2675.69045
   hps: 19.29815
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 2956.14763
-  tps: 2604.60946
+  dps: 2972.84396
+  tps: 2621.30579
   hps: 19.29815
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 3213.29659
-  tps: 2861.84835
+  dps: 3233.24013
+  tps: 2881.79189
   hps: 19.29815
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Average-Default"
  value: {
-  dps: 3335.32153
-  tps: 2962.8999
+  dps: 3355.88813
+  tps: 2983.4665
   hps: 19.63113
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 7906.68433
-  tps: 8003.56368
-  hps: 20.06062
+  dps: 7933.49499
+  tps: 8041.70741
+  hps: 20.2675
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3372.47909
-  tps: 3010.60305
-  hps: 19.94214
+  dps: 3369.81753
+  tps: 3018.74311
+  hps: 19.57516
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 3271.74834
-  tps: 2913.35903
-  hps: 18.8101
+  dps: 3310.18602
+  tps: 2971.63192
+  hps: 18.37308
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 4039.08961
-  tps: 4331.56256
-  hps: 10.85867
+  dps: 4082.83541
+  tps: 4373.89361
+  hps: 10.61317
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1584.52115
-  tps: 1423.11512
-  hps: 10.48813
+  dps: 1603.8581
+  tps: 1438.17703
+  hps: 10.42009
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1585.07705
-  tps: 1396.46812
-  hps: 10.43572
+  dps: 1593.0586
+  tps: 1404.89898
+  hps: 10.66558
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 8378.71345
-  tps: 8464.55105
-  hps: 20.42848
+  dps: 8431.33189
+  tps: 8516.57039
+  hps: 20.42642
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 3583.61957
-  tps: 3211.01887
-  hps: 19.76851
+  dps: 3596.28006
+  tps: 3225.56882
+  hps: 19.53396
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 3476.16688
-  tps: 3118.19072
-  hps: 18.53052
+  dps: 3516.69246
+  tps: 3139.45364
+  hps: 18.50552
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 4056.10417
-  tps: 4338.1036
-  hps: 10.55065
+  dps: 4082.50572
+  tps: 4356.1754
+  hps: 10.81361
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 1580.13907
-  tps: 1412.45347
-  hps: 10.36124
+  dps: 1584.26407
+  tps: 1421.54424
+  hps: 10.41917
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 1560.91128
-  tps: 1383.18371
-  hps: 10.02197
+  dps: 1585.81876
+  tps: 1403.49198
+  hps: 10.15989
  }
 }
 dps_results: {
  key: "TestSV-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3109.09804
-  tps: 2808.19345
+  dps: 3129.75289
+  tps: 2828.8483
   hps: 19.23476
  }
 }

--- a/sim/hunter/aimed_shot.go
+++ b/sim/hunter/aimed_shot.go
@@ -61,10 +61,10 @@ func (hunter *Hunter) getAimedShotConfig(rank int, timer *core.Timer) core.Spell
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target)) +
+			baseDamage := hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target, false)) +
 				hunter.AmmoDamageBonus +
 				baseDamage
-				
+
 			if has2PDragonStalkerPursuit && (target.HasActiveAuraWithTag("ImmolationTrap") || hunter.HasActiveAuraWithTag("ExplosiveTrap")) {
 				baseDamage *= 1.20
 			}

--- a/sim/hunter/chimera_shot.go
+++ b/sim/hunter/chimera_shot.go
@@ -18,7 +18,7 @@ func (hunter *Hunter) registerChimeraShotSpell() {
 	}
 
 	hunter.ChimeraShot = hunter.RegisterSpell(core.SpellConfig{
-		SpellCode: 	  SpellCode_HunterChimeraShot,
+		SpellCode:    SpellCode_HunterChimeraShot,
 		ActionID:     core.ActionID{SpellID: 409433},
 		SpellSchool:  core.SpellSchoolNature,
 		DefenseType:  core.DefenseTypeRanged,
@@ -50,7 +50,7 @@ func (hunter *Hunter) registerChimeraShotSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target)) +
+			baseDamage := hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target, false)) +
 				hunter.AmmoDamageBonus
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)

--- a/sim/hunter/explosive_shot.go
+++ b/sim/hunter/explosive_shot.go
@@ -58,7 +58,7 @@ func (hunter *Hunter) registerExplosiveShotSpell() {
 			NumberOfTicks: 2,
 			TickLength:    time.Second * 1,
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
-				baseDamage := sim.Roll(baseLowDamage, baseHighDamage) + 0.039*dot.Spell.RangedAttackPower(target)
+				baseDamage := sim.Roll(baseLowDamage, baseHighDamage) + 0.039*dot.Spell.RangedAttackPower(target, false)
 				dot.Snapshot(target, baseDamage, isRollover)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
@@ -67,7 +67,7 @@ func (hunter *Hunter) registerExplosiveShotSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := sim.Roll(baseLowDamage, baseHighDamage) + 0.039*spell.RangedAttackPower(target)
+			baseDamage := sim.Roll(baseLowDamage, baseHighDamage) + 0.039*spell.RangedAttackPower(target, false)
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)
 
 			spell.WaitTravelTime(sim, func(s *core.Simulation) {
@@ -77,7 +77,7 @@ func (hunter *Hunter) registerExplosiveShotSpell() {
 					curTarget := target
 					for hitIndex := int32(0); hitIndex < numHits; hitIndex++ {
 						if curTarget != target {
-							baseDamage = sim.Roll(baseLowDamage, baseHighDamage) + 0.039*spell.RangedAttackPower(curTarget)
+							baseDamage = sim.Roll(baseLowDamage, baseHighDamage) + 0.039*spell.RangedAttackPower(curTarget, false)
 							spell.CalcAndDealDamage(sim, curTarget, baseDamage, spell.OutcomeRangedCritOnly)
 						}
 

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -317,7 +317,7 @@ func NewHunter(character *core.Character, options *proto.Player) *Hunter {
 	hunter.AutoAttacks.RangedConfig().CritDamageBonus = hunter.mortalShots()
 	hunter.AutoAttacks.RangedConfig().BonusCoefficient = 1
 	hunter.AutoAttacks.RangedConfig().ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-		baseDamage := hunter.RangedWeaponDamage(sim, spell.RangedAttackPower(target)) +
+		baseDamage := hunter.RangedWeaponDamage(sim, spell.RangedAttackPower(target, false)) +
 			hunter.AmmoDamageBonus
 		result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)
 

--- a/sim/hunter/item_sets_pve.go
+++ b/sim/hunter/item_sets_pve.go
@@ -348,6 +348,7 @@ var ItemSetPredatorArmor = core.NewItemSet(core.ItemSet{
 		2: func(agent core.Agent) {
 			c := agent.GetCharacter()
 			c.AddStat(stats.AttackPower, 20)
+			c.AddStat(stats.RangedAttackPower, 20)
 		},
 		// Increases the Attack Power your Beast pet gains from your attributes by 20%.
 		3: func(agent core.Agent) {

--- a/sim/hunter/kill_shot.go
+++ b/sim/hunter/kill_shot.go
@@ -49,7 +49,7 @@ func (hunter *Hunter) registerKillShotSpell() {
 				spell.CD.Reset()
 			}
 
-			damage := hunter.AutoAttacks.Ranged().CalculateWeaponDamage(sim, spell.RangedAttackPower(target)) + hunter.AmmoDamageBonus + baseDamage
+			damage := hunter.AutoAttacks.Ranged().CalculateWeaponDamage(sim, spell.RangedAttackPower(target, false)) + hunter.AmmoDamageBonus + baseDamage
 			result := spell.CalcDamage(sim, target, damage, spell.OutcomeRangedHitAndCrit)
 
 			spell.WaitTravelTime(sim, func(s *core.Simulation) {

--- a/sim/hunter/multi_shot.go
+++ b/sim/hunter/multi_shot.go
@@ -65,7 +65,7 @@ func (hunter *Hunter) getMultiShotConfig(rank int, timer *core.Timer) core.Spell
 
 			for hitIndex := int32(0); hitIndex < numHits; hitIndex++ {
 				baseDamage := baseDamage +
-					hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target)) +
+					hunter.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target, false)) +
 					hunter.AmmoDamageBonus
 
 				results[hitIndex] = spell.CalcDamage(sim, curTarget, baseDamage, spell.OutcomeRangedHitAndCrit)

--- a/sim/hunter/serpent_sting.go
+++ b/sim/hunter/serpent_sting.go
@@ -52,6 +52,7 @@ func (hunter *Hunter) getSerpentStingConfig(rank int) core.SpellConfig {
 			BonusCoefficient: spellCoeff,
 
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
+				// As of phase 5 the only time serpent sting scales with AP is using the Dragonstalker's Pursuit 6P - this AP scaling doesn't benefit from target AP modifiers
 				damage := baseDamage + (hunter.SerpentStingAPCoeff*dot.Spell.RangedAttackPower(target, true))/5
 				dot.Snapshot(target, damage, isRollover)
 			},
@@ -93,6 +94,7 @@ func (hunter *Hunter) chimeraShotSerpentStingSpell(rank int) *core.Spell {
 		BonusCoefficient:         0.4,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			// As of phase 5 the only time serpent sting scales with AP is using the Dragonstalker's Pursuit 6P - this AP scaling doesn't benefit from target AP modifiers
 			damage := baseDamage + (hunter.SerpentStingAPCoeff*spell.RangedAttackPower(target, true))/5
 			spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeRangedHitAndCrit)
 		},

--- a/sim/hunter/serpent_sting.go
+++ b/sim/hunter/serpent_sting.go
@@ -52,7 +52,7 @@ func (hunter *Hunter) getSerpentStingConfig(rank int) core.SpellConfig {
 			BonusCoefficient: spellCoeff,
 
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
-				damage := baseDamage + (hunter.SerpentStingAPCoeff*dot.Spell.RangedAttackPower(target))/5
+				damage := baseDamage + (hunter.SerpentStingAPCoeff*dot.Spell.RangedAttackPower(target, true))/5
 				dot.Snapshot(target, damage, isRollover)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
@@ -93,8 +93,8 @@ func (hunter *Hunter) chimeraShotSerpentStingSpell(rank int) *core.Spell {
 		BonusCoefficient:         0.4,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			damage := baseDamage + (hunter.SerpentStingAPCoeff*spell.RangedAttackPower(target))/5
-			spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeRangedCritOnly)
+			damage := baseDamage + (hunter.SerpentStingAPCoeff*spell.RangedAttackPower(target, true))/5
+			spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeRangedHitAndCrit)
 		},
 	})
 }

--- a/sim/hunter/steady_shot.go
+++ b/sim/hunter/steady_shot.go
@@ -48,7 +48,7 @@ func (hunter *Hunter) registerSteadyShotSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := hunter.AutoAttacks.Ranged().CalculateWeaponDamage(sim, spell.RangedAttackPower(target)) +
+			baseDamage := hunter.AutoAttacks.Ranged().CalculateWeaponDamage(sim, spell.RangedAttackPower(target, false)) +
 				hunter.AmmoDamageBonus
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 8044.16
-  final_stats: 770
+  final_stats: 810
   final_stats: 163
   final_stats: 13.52
   final_stats: 191.38

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -77,7 +77,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 8296.4
-  final_stats: 740
+  final_stats: 780
   final_stats: 0
   final_stats: 5
   final_stats: 62.495

--- a/sim/rogue/quick_draw.go
+++ b/sim/rogue/quick_draw.go
@@ -60,7 +60,7 @@ func (rogue *Rogue) registerQuickDrawSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.BreakStealth(sim)
-			baseDamage := rogue.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target)) +
+			baseDamage := rogue.AutoAttacks.Ranged().CalculateNormalizedWeaponDamage(sim, spell.RangedAttackPower(target, false)) +
 				normalizedAmmoBonusDamage
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeRangedHitAndCrit)

--- a/sim/shaman/warden/TestWardenShaman.results
+++ b/sim/shaman/warden/TestWardenShaman.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 5812.74
-  final_stats: 851
+  final_stats: 891
   final_stats: 34
   final_stats: 21.36
   final_stats: 45

--- a/sim/warrior/tank_warrior/TestTankWarrior.results
+++ b/sim/warrior/tank_warrior/TestTankWarrior.results
@@ -28,7 +28,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 7573.74
-  final_stats: 774
+  final_stats: 814
   final_stats: 165
   final_stats: 16.6
   final_stats: 178.185


### PR DESCRIPTION
Juju Might updated to provide 40rAP in addition to mAP. 
https://www.wowhead.com/classic/spell=16329/juju-might

Predator's Armor 2P now provides 20rAP in addition to mAP.
https://www.wowhead.com/classic/spell=9331/attack-power-20#used-by-item-set

Dragonstalker's Pursuit 6P bonus to serpent sting no longer includes hunter's mark and mob-type rAP bonuses into its calculation.
https://www.wowhead.com/classic/spell=467326/s03-item-t2-hunter-ranged-6p-bonus (not sure if wowhead describes this interaction but testing on ptr shows the benefit is calculated from player stats)

Chimera - Serpent portion of Chimera shot has to roll individually to hit as its own ranged attack, chimera shot landing does not guarantee Chimera - Serpent will hit.