### PR TITLE
Bug fix: Defer calculation of Block Value's strength dependency and add Shaman SBV from strength

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -165,6 +165,7 @@ enum PseudoStat {
 
 	PseudoStatMeleeSpeedMultiplier = 27;
 	PseudoStatRangedSpeedMultiplier = 28;
+	PseudoStatBlockValuePerStrength = 29;
 }
 
 message UnitStats {
@@ -320,18 +321,18 @@ enum Explosive {
 // NextIndex: 28
 enum Potions {
 	UnknownPotion = 0;
-	
+
 	// Mana Pots
 	ManaPotion = 2;
 	GreaterManaPotion = 3;
 	SuperiorManaPotion = 4;
 	MajorManaPotion = 5;
-	
+
 	// Rage Pots
 	RagePotion = 6;
 	GreatRagePotion = 7;
 	MightyRagePotion = 8;
-	
+
 	// Armor Pots
 	LesserStoneshieldPotion = 9;
 	GreaterStoneshieldPotion = 10;
@@ -751,7 +752,7 @@ message Debuffs {
 	bool occult_poison = 38;
 
 	bool winters_chill = 6;
-	
+
 	bool improved_shadow_bolt = 7;
 
 	bool improved_scorch = 8;

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -629,6 +629,7 @@ func (character *Character) GetPseudoStatsProto() []float64 {
 
 		proto.PseudoStat_PseudoStatMeleeSpeedMultiplier:  float64(character.PseudoStats.MeleeSpeedMultiplier),
 		proto.PseudoStat_PseudoStatRangedSpeedMultiplier: float64(character.PseudoStats.RangedSpeedMultiplier),
+		proto.PseudoStat_PseudoStatBlockValuePerStrength: float64(character.PseudoStats.BlockValuePerStrength),
 	}
 }
 

--- a/sim/core/stats/stats.go
+++ b/sim/core/stats/stats.go
@@ -437,6 +437,9 @@ type PseudoStats struct {
 	// Important when unit is attacker or target
 	BlockValueMultiplier float64
 
+	// BlockValue per Strength has to be calculated independently.
+	BlockValuePerStrength float64
+
 	// Only used for NPCs, governs variance in enemy auto-attack damage
 	DamageSpread float64
 
@@ -514,7 +517,8 @@ func NewPseudoStats() PseudoStats {
 		DamageDealtMultiplier:       1,
 		SchoolDamageDealtMultiplier: NewSchoolValueArray(1.0),
 
-		BlockValueMultiplier: 1,
+		BlockValueMultiplier:  1,
+		BlockValuePerStrength: 0,
 
 		DamageSpread: 0.3333,
 

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -365,7 +365,9 @@ func (unit *Unit) Armor() float64 {
 }
 
 func (unit *Unit) BlockValue() float64 {
-	return unit.PseudoStats.BlockValueMultiplier * unit.stats[stats.BlockValue]
+	// Shield block value gained from strength is offset by 1 and independent of the BlockValueMultiplier.
+	strengthComponent := max(0., (unit.stats[stats.Strength]*unit.PseudoStats.BlockValuePerStrength)-1.)
+	return strengthComponent + unit.PseudoStats.BlockValueMultiplier*unit.stats[stats.BlockValue]
 }
 
 func (unit *Unit) ArmorPenetrationPercentage(armorPenRating float64) float64 {

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -174,7 +174,7 @@ func NewPaladin(character *core.Character, options *proto.Player, paladinOptions
 	paladin.AddStatDependency(stats.Intellect, stats.SpellCrit, core.CritPerIntAtLevel[character.Class][int(paladin.Level)]*core.SpellCritRatingPerCritChance)
 
 	// Paladins get 1 block value per 20 str
-	paladin.AddStatDependency(stats.Strength, stats.BlockValue, .05)
+	paladin.PseudoStats.BlockValuePerStrength = 0.05
 
 	// Bonus Armor and Armor are treated identically for Paladins
 	paladin.AddStatDependency(stats.BonusArmor, stats.Armor, 1)

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -31,7 +31,7 @@ character_stats_results: {
   final_stats: 810
   final_stats: 163
   final_stats: 13.52
-  final_stats: 191.38
+  final_stats: 174
   final_stats: 16.6822
   final_stats: 16.52
   final_stats: 0
@@ -50,10 +50,10 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtection-Lvl60-StatWeights-Default"
  value: {
-  weights: 1.02692
-  weights: 0.50871
+  weights: 1.01824
+  weights: 0.50277
   weights: 0
-  weights: 0.0132
+  weights: 0.01246
   weights: 0
   weights: 0.20599
   weights: 0
@@ -63,14 +63,14 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.63635
-  weights: 2.2153
+  weights: 3.64524
+  weights: 2.21949
   weights: 0
   weights: 0
   weights: 0.45626
   weights: 0
-  weights: 17.33383
-  weights: 13.43394
+  weights: 17.29076
+  weights: 13.4332
   weights: 0
   weights: 0
   weights: 0
@@ -99,168 +99,168 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1449.05975
-  tps: 1702.73656
+  dps: 1447.67444
+  tps: 1701.35124
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 1818.00479
-  tps: 2095.2467
+  dps: 1814.72382
+  tps: 2091.96574
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1449.12088
-  tps: 1703.41348
+  dps: 1447.73557
+  tps: 1702.02817
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1531.46579
-  tps: 1798.72722
+  dps: 1529.78123
+  tps: 1797.04266
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 1880.89213
-  tps: 2160.81905
+  dps: 1877.59176
+  tps: 2157.51868
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1652.06632
-  tps: 1934.08068
+  dps: 1650.4389
+  tps: 1932.45325
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 1889.23354
-  tps: 2169.65251
+  dps: 1885.93068
+  tps: 2166.34964
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1154.40755
-  tps: 1184.21575
+  dps: 1152.67702
+  tps: 1182.48522
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 1567.29072
-  tps: 1794.85004
+  dps: 1564.13629
+  tps: 1791.69561
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1842.8433
-  tps: 2119.14986
+  dps: 1841.15317
+  tps: 2117.45973
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Average-Default"
  value: {
-  dps: 1864.69391
-  tps: 2142.97601
+  dps: 1861.36006
+  tps: 2139.64215
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 1194.6808
-  tps: 2113.07899
+  dps: 1192.1606
+  tps: 2110.55879
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 457.62392
-  tps: 686.68623
+  dps: 455.18495
+  tps: 684.24726
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 609.5157
-  tps: 901.48453
+  dps: 606.08901
+  tps: 898.05784
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 409.47519
-  tps: 765.91203
+  dps: 408.83317
+  tps: 765.27001
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 138.97267
-  tps: 204.40849
+  dps: 138.34823
+  tps: 203.78405
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 281.31093
-  tps: 395.08441
+  dps: 279.65152
+  tps: 393.42501
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 1198.66072
-  tps: 2120.65531
+  dps: 1196.14181
+  tps: 2118.1364
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 463.49911
-  tps: 694.25313
+  dps: 461.04397
+  tps: 691.79798
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 612.37803
-  tps: 905.99254
+  dps: 608.93253
+  tps: 902.54705
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 404.46316
-  tps: 746.67678
+  dps: 403.81269
+  tps: 746.02632
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 149.02561
-  tps: 211.11276
+  dps: 148.40566
+  tps: 210.49281
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 282.58463
-  tps: 397.02423
+  dps: 280.93287
+  tps: 395.37248
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1569.54059
-  tps: 1845.34584
+  dps: 1566.77037
+  tps: 1842.57562
  }
 }

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -31,7 +31,7 @@ character_stats_results: {
   final_stats: 810
   final_stats: 163
   final_stats: 13.52
-  final_stats: 191.38
+  final_stats: 174
   final_stats: 16.6822
   final_stats: 16.52
   final_stats: 0
@@ -50,10 +50,10 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtection-Lvl60-StatWeights-Default"
  value: {
-  weights: 1.02692
-  weights: 0.50871
+  weights: 1.01824
+  weights: 0.50277
   weights: 0
-  weights: 0.0132
+  weights: 0.01246
   weights: 0
   weights: 0.20599
   weights: 0
@@ -63,14 +63,14 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.63635
-  weights: 2.2153
+  weights: 3.64524
+  weights: 2.21949
   weights: 0
   weights: 0
   weights: 0.45626
   weights: 0
-  weights: 17.33383
-  weights: 13.43394
+  weights: 17.29076
+  weights: 13.4332
   weights: 0
   weights: 0
   weights: 0
@@ -99,168 +99,168 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1449.05975
-  tps: 2731.34101
+  dps: 1447.67444
+  tps: 2728.70891
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 1818.00479
-  tps: 3835.15827
+  dps: 1814.72382
+  tps: 3827.94014
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1449.12088
-  tps: 2732.01793
+  dps: 1447.73557
+  tps: 2729.38583
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1531.46579
-  tps: 2882.3037
+  dps: 1529.78123
+  tps: 2879.10303
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 1880.89213
-  tps: 3960.92022
+  dps: 1877.59176
+  tps: 3953.65941
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1652.06632
-  tps: 3491.09294
+  dps: 1650.4389
+  tps: 3487.5126
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 1889.23354
-  tps: 3973.15985
+  dps: 1885.93068
+  tps: 3965.89355
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1154.40755
-  tps: 1782.81781
+  dps: 1152.67702
+  tps: 1779.52981
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 1567.29072
-  tps: 3303.06084
+  dps: 1564.13629
+  tps: 3296.12109
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1842.8433
-  tps: 3885.16513
+  dps: 1841.15317
+  tps: 3881.44684
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Average-Default"
  value: {
-  dps: 1864.69391
-  tps: 3925.90289
+  dps: 1861.36006
+  tps: 3918.56842
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 1194.6808
-  tps: 3931.29347
+  dps: 1192.1606
+  tps: 3925.74903
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 457.62392
-  tps: 1481.71013
+  dps: 455.18495
+  tps: 1476.34439
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 609.5157
-  tps: 1938.74277
+  dps: 606.08901
+  tps: 1931.20406
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 409.47519
-  tps: 1283.12503
+  dps: 408.83317
+  tps: 1281.71259
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 138.97267
-  tps: 433.81686
+  dps: 138.34823
+  tps: 432.44309
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Dwarf-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 281.31093
-  tps: 839.09115
+  dps: 279.65152
+  tps: 835.44046
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 1198.66072
-  tps: 3950.54918
+  dps: 1196.14181
+  tps: 3945.00758
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 463.49911
-  tps: 1496.79729
+  dps: 461.04397
+  tps: 1491.39598
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 612.37803
-  tps: 1948.62369
+  dps: 608.93253
+  tps: 1941.04361
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 404.46316
-  tps: 1246.34729
+  dps: 403.81269
+  tps: 1244.91627
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 149.02561
-  tps: 448.28721
+  dps: 148.40566
+  tps: 446.92332
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-Settings-Human-p4prot-P4 Prot-p4prot-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 282.58463
-  tps: 843.34946
+  dps: 280.93287
+  tps: 839.7156
  }
 }
 dps_results: {
  key: "TestProtection-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1569.54059
-  tps: 3378.44378
+  dps: 1566.77037
+  tps: 3372.3493
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -31,7 +31,7 @@ character_stats_results: {
   final_stats: 98
   final_stats: 8
   final_stats: 5.32
-  final_stats: 8.8
+  final_stats: 0
   final_stats: 12.96325
   final_stats: 5.32
   final_stats: 0
@@ -80,7 +80,7 @@ character_stats_results: {
   final_stats: 294
   final_stats: 0
   final_stats: 5
-  final_stats: 13.2
+  final_stats: 0
   final_stats: 13.33405
   final_stats: 5
   final_stats: 0
@@ -129,7 +129,7 @@ character_stats_results: {
   final_stats: 489
   final_stats: 0
   final_stats: 5
-  final_stats: 22.08492
+  final_stats: 0
   final_stats: 13.51472
   final_stats: 5
   final_stats: 0

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -31,7 +31,7 @@ character_stats_results: {
   final_stats: 294
   final_stats: 0
   final_stats: 5
-  final_stats: 14.0965
+  final_stats: 0
   final_stats: 13.98613
   final_stats: 5
   final_stats: 0
@@ -80,7 +80,7 @@ character_stats_results: {
   final_stats: 780
   final_stats: 0
   final_stats: 5
-  final_stats: 62.495
+  final_stats: 51
   final_stats: 8.04712
   final_stats: 5
   final_stats: 0

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -33,6 +33,7 @@ func NewShaman(character *core.Character, talents string) *Shaman {
 	shaman.AddStatDependency(stats.Agility, stats.Dodge, core.DodgePerAgiAtLevel[character.Class][int(shaman.Level)]*core.DodgeRatingPerDodgeChance)
 	shaman.AddStatDependency(stats.Intellect, stats.SpellCrit, core.CritPerIntAtLevel[character.Class][int(shaman.Level)]*core.SpellCritRatingPerCritChance)
 	shaman.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
+	shaman.PseudoStats.BlockValuePerStrength = .05 // 20 str = 1 block
 
 	shaman.ApplyRockbiterImbue(shaman.getImbueProcMask(proto.WeaponImbue_RockbiterWeapon))
 	shaman.ApplyFlametongueImbue(shaman.getImbueProcMask(proto.WeaponImbue_FlametongueWeapon))

--- a/sim/warrior/dps_warrior/TestArms.results
+++ b/sim/warrior/dps_warrior/TestArms.results
@@ -31,7 +31,7 @@ character_stats_results: {
   final_stats: 361
   final_stats: 0
   final_stats: 5
-  final_stats: 19.01151
+  final_stats: 0
   final_stats: 19.61566
   final_stats: 5
   final_stats: 0

--- a/sim/warrior/dps_warrior/TestFury.results
+++ b/sim/warrior/dps_warrior/TestFury.results
@@ -31,7 +31,7 @@ character_stats_results: {
   final_stats: 322
   final_stats: 0
   final_stats: 5
-  final_stats: 14.6355
+  final_stats: 0
   final_stats: 14.25798
   final_stats: 5
   final_stats: 0
@@ -80,7 +80,7 @@ character_stats_results: {
   final_stats: 832
   final_stats: 0
   final_stats: 5
-  final_stats: 27.555
+  final_stats: 0
   final_stats: 16.2635
   final_stats: 5
   final_stats: 0

--- a/sim/warrior/tank_warrior/TestTankWarrior.results
+++ b/sim/warrior/tank_warrior/TestTankWarrior.results
@@ -31,7 +31,7 @@ character_stats_results: {
   final_stats: 814
   final_stats: 165
   final_stats: 16.6
-  final_stats: 178.185
+  final_stats: 158
   final_stats: 19.8935
   final_stats: 11.6
   final_stats: 0
@@ -50,7 +50,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestTankWarrior-Lvl60-StatWeights-Default"
  value: {
-  weights: 0.6984
+  weights: 0.6987
   weights: 0
   weights: 0
   weights: 0
@@ -67,7 +67,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.33722
+  weights: 0.3377
   weights: 0
   weights: 0
   weights: 0
@@ -78,7 +78,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.02281
+  weights: 1.02123
   weights: 0
   weights: 0.52203
   weights: 0
@@ -99,140 +99,140 @@ stat_weights_results: {
 dps_results: {
  key: "TestTankWarrior-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
-  dps: 1577.49233
-  tps: 3512.21781
+  dps: 1576.88694
+  tps: 3510.40769
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 900.69117
-  tps: 1847.33898
+  dps: 900.23358
+  tps: 1845.97076
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
-  dps: 902.16804
-  tps: 1885.99065
+  dps: 901.70267
+  tps: 1884.59921
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
-  dps: 892.64211
-  tps: 1866.84109
+  dps: 892.18001
+  tps: 1865.45942
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
-  dps: 902.16804
-  tps: 1885.99065
+  dps: 901.70267
+  tps: 1884.59921
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
-  dps: 1661.86413
-  tps: 3617.25424
+  dps: 1661.24692
+  tps: 3615.40879
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Average-Default"
  value: {
-  dps: 1506.88344
-  tps: 3931.76928
+  dps: 1506.35613
+  tps: 3930.03494
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Human-phase_4_tanky-Arms-phase_4-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 463.40659
-  tps: 1317.45367
+  dps: 463.34742
+  tps: 1317.25904
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Human-phase_4_tanky-Arms-phase_4-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 116.07637
-  tps: 384.08414
+  dps: 115.98893
+  tps: 383.79653
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Human-phase_4_tanky-Arms-phase_4-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 173.24657
-  tps: 553.73603
+  dps: 173.1188
+  tps: 553.31577
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Human-phase_4_tanky-Arms-phase_4-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 155.47518
-  tps: 602.19213
+  dps: 155.43415
+  tps: 602.05716
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Human-phase_4_tanky-Arms-phase_4-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 51.15732
-  tps: 205.61464
+  dps: 51.09669
+  tps: 205.41521
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Human-phase_4_tanky-Arms-phase_4-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 72.98623
-  tps: 288.85569
+  dps: 72.89892
+  tps: 288.56851
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Orc-phase_4_tanky-Arms-phase_4-FullBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 480.846
-  tps: 1349.461
+  dps: 480.78299
+  tps: 1349.25376
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Orc-phase_4_tanky-Arms-phase_4-FullBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 120.296
-  tps: 394.18969
+  dps: 120.20664
+  tps: 393.89578
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Orc-phase_4_tanky-Arms-phase_4-FullBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 181.56462
-  tps: 571.50185
+  dps: 181.43445
+  tps: 571.07371
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Orc-phase_4_tanky-Arms-phase_4-NoBuffs-Phase 4 Consumes-LongMultiTarget"
  value: {
-  dps: 155.77022
-  tps: 603.06697
+  dps: 155.72918
+  tps: 602.93201
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Orc-phase_4_tanky-Arms-phase_4-NoBuffs-Phase 4 Consumes-LongSingleTarget"
  value: {
-  dps: 51.19099
-  tps: 205.76227
+  dps: 51.13035
+  tps: 205.56283
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-Settings-Orc-phase_4_tanky-Arms-phase_4-NoBuffs-Phase 4 Consumes-ShortSingleTarget"
  value: {
-  dps: 72.74161
-  tps: 288.45213
+  dps: 72.65429
+  tps: 288.16494
  }
 }
 dps_results: {
  key: "TestTankWarrior-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1285.87652
-  tps: 3387.34636
+  dps: 1285.44903
+  tps: 3385.94034
  }
 }

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -312,7 +312,7 @@ func NewWarrior(character *core.Character, talents string, inputs WarriorInputs)
 	warrior.PseudoStats.CanParry = true
 
 	warrior.AddStatDependency(stats.Strength, stats.AttackPower, core.APPerStrength[character.Class])
-	warrior.AddStatDependency(stats.Strength, stats.BlockValue, .05) // 20 str = 1 block
+	warrior.PseudoStats.BlockValuePerStrength = .05 // 20 str = 1 block
 	warrior.AddStatDependency(stats.Agility, stats.MeleeCrit, core.CritPerAgiAtLevel[character.Class][int(warrior.Level)]*core.CritRatingPerCritChance)
 	warrior.AddStatDependency(stats.Agility, stats.Dodge, core.DodgePerAgiAtLevel[character.Class][int(warrior.Level)]*core.DodgeRatingPerDodgeChance)
 	warrior.AddStatDependency(stats.BonusArmor, stats.Armor, 1)

--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -323,6 +323,7 @@ export class CharacterStats extends Component {
 
 		if (stat === Stat.StatBlockValue) {
 			rawValue *= stats.getPseudoStat(PseudoStat.PseudoStatBlockValueMultiplier) || 1;
+			rawValue += Math.max(0, stats.getPseudoStat(PseudoStat.PseudoStatBlockValuePerStrength) * deltaStats.getStat(Stat.StatStrength) - 1);
 		}
 
 		let displayStr = String(Math.round(rawValue));


### PR DESCRIPTION
Fixes #1025 by adding `PseudoStat.BlockValuePerStrength` so that we can apply the `BlockValueMultiplier` independently to raw SBV and not SBV gained via strength.

Shield Block Value should now be correctly computed for all classes, including UI display.