### PR TITLE
Rework WS and WF

### DIFF
--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -202,6 +202,7 @@ func (apl *APLRotation) DoNextAction(sim *Simulation) {
 
 	if sim.Log != nil && i == 0 {
 		apl.unit.Log(sim, "No available actions!")
+		apl.unit.Log(sim, "GCD ready at : %f ", apl.unit.GCD.ReadyAt())
 	}
 
 	gcdReady := apl.unit.GCD.IsReady(sim)

--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -458,8 +458,21 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		BonusCoefficient: TernaryFloat64(options.MainHand.GetSpellSchool() == SpellSchoolPhysical, 1, 0),
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
-			baseDamage := spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower())
-			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWhite)
+
+			autoInProgress := *spell
+
+			baseDamage := autoInProgress.Unit.MHWeaponDamage(sim, autoInProgress.MeleeAttackPower())
+			result := autoInProgress.CalcDamage(sim, target, baseDamage, autoInProgress.OutcomeMeleeWhite)
+
+			StartDelayedAction(sim, DelayedActionOptions{
+				DoAt: sim.CurrentTime + SpellBatchWindow,
+				OnAction: func(s *Simulation) {
+					autoInProgress.DealDamage(sim, result)
+				},
+			})
+
+			//baseDamage := spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower()) */
+			//spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWhite)
 		},
 	}
 
@@ -478,6 +491,17 @@ func (unit *Unit) EnableAutoAttacks(agent Agent, options AutoAttackOptions) {
 		BonusCoefficient: TernaryFloat64(options.OffHand.GetSpellSchool() == SpellSchoolPhysical, 1, 0),
 
 		ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
+
+			/* autoInProgress := *spell
+			baseDamage := autoInProgress.Unit.OHWeaponDamage(sim, autoInProgress.MeleeAttackPower())
+			result := autoInProgress.CalcDamage(sim, target, baseDamage, autoInProgress.OutcomeMeleeWhite)
+
+			StartDelayedAction(sim, DelayedActionOptions{
+				DoAt: sim.CurrentTime + SpellBatchWindow,
+				OnAction: func(s *Simulation) {
+					autoInProgress.DealDamage(sim, result)
+				},
+			}) */
 			baseDamage := spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower())
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWhite)
 		},
@@ -728,7 +752,8 @@ func (aa *AutoAttacks) ExtraMHAttack(sim *Simulation, attacks int32, actionID Ac
 		attacksText := Ternary(attacks == 1, "attack", "attacks")
 		aa.mh.unit.Log(sim, "gained %d extra main-hand %s from %s triggered by %s", attacks, attacksText, actionID, triggerAction)
 	}
-	aa.mh.swingAt = sim.CurrentTime + SpellBatchWindow
+
+	aa.mh.swingAt = sim.CurrentTime
 	aa.mh.spell.SetMetricsSplit(1)
 	sim.rescheduleWeaponAttack(aa.mh.swingAt)
 	aa.mh.extraAttacksPending += attacks

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -2175,18 +2175,16 @@ func BattleSquawkAura(character *Unit, stackcount int32) *Aura {
 // 	})
 // }
 
-func ApplyWildStrikes(character *Character) *Aura {
-	buffActionID := ActionID{SpellID: 407975}
-
+func CreateExtraAttackAuraCommon(character *Character, buffActionID ActionID, auraLabel string, rank int32, getBonusAP func(aura *Aura, rank int32) float64) *Aura {
 	var bonusAP float64
 
-	wsBuffAura := character.GetOrRegisterAura(Aura{
-		Label:     "Wild Strikes Buff",
+	apBuffAura := character.GetOrRegisterAura(Aura{
+		Label:     auraLabel + " Buff",
 		ActionID:  buffActionID,
 		Duration:  time.Millisecond * 1500,
 		MaxStacks: 2,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			bonusAP = 0.2 * aura.Unit.GetStat(stats.AttackPower)
+			bonusAP = getBonusAP(aura, rank)
 			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.AttackPower: bonusAP})
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
@@ -2199,37 +2197,48 @@ func ApplyWildStrikes(character *Character) *Aura {
 		Duration: time.Millisecond * 1500,
 	}
 
-	wsBuffAura.Icd = &icd
+	apBuffAura.Icd = &icd
 
 	MakePermanent(character.GetOrRegisterAura(Aura{
-		Label: "Wild Strikes",
+		Label: auraLabel,
 		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
+			// charges are removed by every auto or next melee, whether it lands or not
+			//  this directly contradicts https://github.com/magey/classic-warrior/wiki/Windfury-Totem#triggered-by-melee-spell-while-an-on-next-swing-attack-is-queued
+			//  but can be seen in both "vanilla" and "sod" era logs
+			if apBuffAura.IsActive() && spell.ProcMask.Matches(ProcMaskMeleeWhiteHit) {
+				apBuffAura.RemoveStack(sim)
+			}
+
 			if !result.Landed() || !spell.ProcMask.Matches(ProcMaskMeleeMH) || spell.Flags.Matches(SpellFlagSuppressEquipProcs) {
 				return
 			}
 
-			// charges are removed by every auto or next melee, whether it lands or not
-			if wsBuffAura.IsActive() && spell.ProcMask.Matches(ProcMaskMeleeWhiteHit) {
-				if wsBuffAura.GetStacks() == 2 {
-					wsBuffAura.SetStacks(sim, 1)
-					wsBuffAura.Duration = time.Millisecond * 100 // 100 ms might be generous - could anywhere from 50-150 ms potentially
-					wsBuffAura.Refresh(sim)                      // Apply New Duration
-				}
-			}
-
-			if icd.IsReady(sim) && sim.RandomFloat("Wild Strikes") < 0.2 {
+			if icd.IsReady(sim) && sim.RandomFloat(auraLabel) < 0.2 {
 				icd.Use(sim)
-				wsBuffAura.Activate(sim)
-				// aura is up _after_ the triggering swing lands, the extra attack only has 1500ms for the AP bonus but the extra attack does not expire
-				wsBuffAura.SetStacks(sim, 2)
-				wsBuffAura.Duration = time.Millisecond * 1500
-				wsBuffAura.Refresh(sim) // Apply New Duration
+				apBuffAura.Activate(sim)
+				// aura is up _before_ the triggering swing lands, so if triggered by an auto attack, the aura fades right after the extra attack lands.
+				if spell.ProcMask == ProcMaskMeleeMHAuto {
+					apBuffAura.SetStacks(sim, 1)
+				} else {
+					apBuffAura.SetStacks(sim, 2)
+				}
+
 				aura.Unit.AutoAttacks.ExtraMHAttackProc(sim, 1, buffActionID, spell)
 			}
 		},
 	}))
 
-	return wsBuffAura
+	return apBuffAura
+}
+
+func GetWildStrikesAP(aura *Aura, rank int32) float64 {
+	return 0.2 * aura.Unit.GetStat(stats.AttackPower)
+}
+
+func ApplyWildStrikes(character *Character) *Aura {
+	buffActionID := ActionID{SpellID: 407975}
+
+	return CreateExtraAttackAuraCommon(character, buffActionID, "Wild Strikes", 1, GetWildStrikesAP)
 }
 
 const WindfuryRanks = 3
@@ -2239,6 +2248,10 @@ var (
 	WindfuryBuffBonusAP = [WindfuryRanks + 1]float64{0, 122, 229, 315}
 )
 
+func GetWindfuryAP(aura *Aura, rank int32) float64 {
+	return WindfuryBuffBonusAP[rank]
+}
+
 func ApplyWindfury(character *Character) *Aura {
 	level := character.Level
 	if level < 32 {
@@ -2247,58 +2260,10 @@ func ApplyWindfury(character *Character) *Aura {
 
 	rank := LevelToBuffRank[Windfury][level]
 	spellId := WindfuryBuffSpellId[rank]
-	bonusAP := WindfuryBuffBonusAP[rank]
+	buffActionID := ActionID{SpellID: spellId}
 
-	windfuryBuffAura := character.GetOrRegisterAura(Aura{
-		Label:     "Windfury Buff",
-		ActionID:  ActionID{SpellID: spellId},
-		Duration:  time.Millisecond * 1500,
-		MaxStacks: 2,
-		OnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.AttackPower: bonusAP})
-		},
-		OnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.AddStatsDynamic(sim, stats.Stats{stats.AttackPower: -bonusAP})
-		},
-	})
+	return CreateExtraAttackAuraCommon(character, buffActionID, "Windfury", rank, GetWindfuryAP)
 
-	icd := Cooldown{
-		Timer:    character.NewTimer(),
-		Duration: time.Millisecond * 1500,
-	}
-
-	windfuryBuffAura.Icd = &icd
-
-	MakePermanent(character.GetOrRegisterAura(Aura{
-		Label: "Windfury",
-		OnSpellHitDealt: func(aura *Aura, sim *Simulation, spell *Spell, result *SpellResult) {
-			// charges are removed by every auto or next melee, whether it lands or not
-			//  this directly contradicts https://github.com/magey/classic-warrior/wiki/Windfury-Totem#triggered-by-melee-spell-while-an-on-next-swing-attack-is-queued
-			//  but can be seen in both "vanilla" and "sod" era logs
-			if windfuryBuffAura.IsActive() && spell.ProcMask.Matches(ProcMaskMeleeWhiteHit) {
-				windfuryBuffAura.RemoveStack(sim)
-			}
-
-			if !result.Landed() || !spell.ProcMask.Matches(ProcMaskMeleeMH) || spell.Flags.Matches(SpellFlagSuppressEquipProcs) {
-				return
-			}
-
-			if icd.IsReady(sim) && sim.RandomFloat("Windfury") < 0.2 {
-				icd.Use(sim)
-				windfuryBuffAura.Activate(sim)
-				// aura is up _before_ the triggering swing lands, so if triggered by an auto attack, the aura fades right after the extra attack lands.
-				if spell.ProcMask == ProcMaskMeleeMHAuto {
-					windfuryBuffAura.SetStacks(sim, 1)
-				} else {
-					windfuryBuffAura.SetStacks(sim, 2)
-				}
-
-				aura.Unit.AutoAttacks.ExtraMHAttackProc(sim, 1, ActionID{SpellID: spellId}, spell)
-			}
-		},
-	}))
-
-	return windfuryBuffAura
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -398,7 +398,7 @@ stat_weights_results: {
   weights: 0
   weights: 1.10524
   weights: 0
-  weights: 2.25477
+  weights: 2.25465
   weights: 0
   weights: 0
   weights: 0
@@ -407,7 +407,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 25.3384
+  weights: 25.20328
   weights: 0
   weights: 0
   weights: 0
@@ -445,18 +445,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.92936
+  weights: -0.9318
   weights: 0
-  weights: 2.8038
-  weights: 0
-  weights: 0
+  weights: 2.80172
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 31.87271
+  weights: 0
+  weights: 0
+  weights: 32.8774
   weights: 0
   weights: 0
   weights: 0
@@ -491,8 +491,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestBalance-Phase1-Lvl25-AllItems-FeralheartRaiment"
  value: {
-  dps: 129.05782
-  tps: 132.75738
+  dps: 128.99265
+  tps: 132.69221
  }
 }
 dps_results: {
@@ -596,15 +596,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase2-Lvl40-AllItems-FeralheartRaiment"
  value: {
-  dps: 229.02538
-  tps: 237.64656
+  dps: 228.80605
+  tps: 237.41348
  }
 }
 dps_results: {
  key: "TestBalance-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 796.90159
-  tps: 807.49703
+  dps: 796.9008
+  tps: 807.49563
  }
 }
 dps_results: {
@@ -701,8 +701,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase3-Lvl50-AllItems-FeralheartRaiment"
  value: {
-  dps: 516.29889
-  tps: 530.99873
+  dps: 513.05217
+  tps: 527.73084
  }
 }
 dps_results: {
@@ -806,99 +806,99 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1165.60644
-  tps: 1183.59817
+  dps: 1165.11917
+  tps: 1183.22777
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1098.5406
-  tps: 1116.8667
+  dps: 1098.12446
+  tps: 1116.52313
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1064.35076
-  tps: 1082.07195
+  dps: 1060.54319
+  tps: 1078.29287
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 1477.49591
-  tps: 1496.37398
+  dps: 1479.45239
+  tps: 1498.36239
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1067.49526
-  tps: 1085.24595
+  dps: 1061.76008
+  tps: 1079.52942
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1097.69992
-  tps: 1116.02602
+  dps: 1097.27798
+  tps: 1115.67665
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1124.23985
-  tps: 1141.97581
+  dps: 1123.80127
+  tps: 1141.5657
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 1496.92788
-  tps: 1515.60804
+  dps: 1493.98014
+  tps: 1512.65415
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1064.60722
-  tps: 1083.64351
+  dps: 1067.18806
+  tps: 1086.30727
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1165.60644
-  tps: 1183.59817
+  dps: 1165.11917
+  tps: 1183.22777
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1098.5406
-  tps: 1116.8667
+  dps: 1098.12446
+  tps: 1116.52313
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1064.35076
-  tps: 1082.07195
+  dps: 1060.54319
+  tps: 1078.29287
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 1582.83825
-  tps: 1601.75565
+  dps: 1584.24982
+  tps: 1603.19425
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3247.31308
-  tps: 3267.37442
+  dps: 3247.34948
+  tps: 3267.41645
  }
 }
 dps_results: {
@@ -988,127 +988,127 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3232.22269
-  tps: 3252.53152
+  dps: 3232.20963
+  tps: 3252.52236
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1455.56308
-  tps: 1473.86342
+  dps: 1458.56635
+  tps: 1476.92569
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1358.26671
-  tps: 1376.56213
+  dps: 1356.31886
+  tps: 1374.65362
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1343.59594
-  tps: 1361.7537
+  dps: 1336.39897
+  tps: 1354.57148
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 1985.95491
-  tps: 1909.73142
+  dps: 1986.97173
+  tps: 1911.79031
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1337.21196
-  tps: 1355.35989
+  dps: 1341.96291
+  tps: 1360.16
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1357.25936
-  tps: 1375.55478
+  dps: 1355.30376
+  tps: 1373.63852
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1409.48676
-  tps: 1427.61502
+  dps: 1405.97594
+  tps: 1424.1337
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 2006.51813
-  tps: 1932.86682
+  dps: 2020.54896
+  tps: 1944.32665
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1233.94838
-  tps: 1252.21505
+  dps: 1232.66017
+  tps: 1250.94651
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1455.56308
-  tps: 1473.86342
+  dps: 1458.56635
+  tps: 1476.92569
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1358.26671
-  tps: 1376.56213
+  dps: 1356.31886
+  tps: 1374.65362
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1343.59594
-  tps: 1361.7537
+  dps: 1336.39897
+  tps: 1354.57148
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 2115.31368
-  tps: 2046.6765
+  dps: 2108.77655
+  tps: 2042.51355
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4446.85589
-  tps: 4313.6568
+  dps: 4447.03401
+  tps: 4313.98692
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-NightElf-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 6292.06844
-  tps: 6580.45494
+  dps: 6296.28259
+  tps: 6584.47242
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-NightElf-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 4379.56936
-  tps: 4235.84152
+  dps: 4385.38379
+  tps: 4242.37957
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-NightElf-phase_5-Default-phase_5-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
   dps: 4222.63132
-  tps: 4117.93599
+  tps: 4117.91141
  }
 }
 dps_results: {
@@ -1135,22 +1135,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-Tauren-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 6203.10095
-  tps: 6489.94194
+  dps: 6201.30625
+  tps: 6487.45891
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-Tauren-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 4372.06913
-  tps: 4229.57036
+  dps: 4381.59552
+  tps: 4238.80736
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-Tauren-phase_5-Default-phase_5-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
   dps: 4231.66386
-  tps: 4127.59461
+  tps: 4127.57003
  }
 }
 dps_results: {
@@ -1177,7 +1177,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4406.98674
-  tps: 4263.39961
+  dps: 4412.50121
+  tps: 4268.70275
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -246,8 +246,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestFeral-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.57599
-  weights: 0.51714
+  weights: 0.57675
+  weights: 0.52797
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.26181
-  weights: 2.01408
-  weights: 2.19334
+  weights: 0.26216
+  weights: 2.3139
+  weights: 2.24627
   weights: 0
   weights: 0
   weights: 0
@@ -295,8 +295,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.94603
-  weights: 0.83019
+  weights: 0.94445
+  weights: 1.02691
   weights: 0
   weights: 0
   weights: 0
@@ -312,9 +312,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.4135
-  weights: 3.97162
-  weights: 5.41439
+  weights: 0.41281
+  weights: 4.83242
+  weights: 5.45266
   weights: 0
   weights: 0
   weights: 0
@@ -344,8 +344,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.51843
-  weights: 1.61996
+  weights: 1.51638
+  weights: 1.61816
   weights: 0
   weights: 0
   weights: 0
@@ -361,9 +361,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.63907
-  weights: 18.42436
-  weights: 11.77852
+  weights: 0.63821
+  weights: 16.71662
+  weights: 11.8052
   weights: 0
   weights: 0
   weights: 0
@@ -393,8 +393,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.10484
-  weights: 2.54993
+  weights: 2.10198
+  weights: 2.29903
   weights: 0
   weights: 0
   weights: 0
@@ -410,9 +410,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.79729
+  weights: 0.79621
   weights: 0
-  weights: 25.01944
+  weights: 24.06366
   weights: 0
   weights: 0
   weights: 0
@@ -442,8 +442,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.79044
-  weights: 2.44667
+  weights: 2.78722
+  weights: 2.42429
   weights: 0
   weights: 0
   weights: 0
@@ -459,9 +459,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.91912
+  weights: 0.91806
   weights: 0
-  weights: 22.35809
+  weights: 22.26447
   weights: 0
   weights: 0
   weights: 0
@@ -491,15 +491,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestFeral-Phase1-Lvl25-AllItems-FeralheartRaiment"
  value: {
-  dps: 261.46339
-  tps: 188.16902
+  dps: 261.04499
+  tps: 187.87395
  }
 }
 dps_results: {
  key: "TestFeral-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 264.6443
-  tps: 191.91162
+  dps: 265.05073
+  tps: 192.2046
  }
 }
 dps_results: {
@@ -757,22 +757,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 190.09472
-  tps: 138.06188
+  dps: 189.00238
+  tps: 137.07387
  }
 }
 dps_results: {
  key: "TestFeral-Phase2-Lvl40-AllItems-FeralheartRaiment"
  value: {
-  dps: 525.27048
-  tps: 383.60682
+  dps: 523.94947
+  tps: 382.53083
  }
 }
 dps_results: {
  key: "TestFeral-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 803.97821
-  tps: 586.43536
+  dps: 803.37838
+  tps: 586.00606
  }
 }
 dps_results: {
@@ -1030,24 +1030,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 464.27842
-  tps: 332.51271
+  dps: 462.78275
+  tps: 331.45192
  }
 }
 dps_results: {
  key: "TestFeral-Phase3-Lvl50-AllItems-FeralheartRaiment"
  value: {
-  dps: 904.82231
-  tps: 656.5816
-  hps: 9.17246
+  dps: 903.59128
+  tps: 655.80994
+  hps: 9.05555
  }
 }
 dps_results: {
  key: "TestFeral-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1885.20208
-  tps: 1348.90915
-  hps: 10.23716
+  dps: 1883.19205
+  tps: 1347.46916
+  hps: 10.23573
  }
 }
 dps_results: {
@@ -1341,107 +1341,107 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1243.51501
-  tps: 886.61256
-  hps: 9.39953
+  dps: 1241.5312
+  tps: 885.22962
+  hps: 9.35676
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1315.64511
-  tps: 960.85808
+  dps: 1314.6924
+  tps: 960.21936
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1363.07144
-  tps: 994.46331
+  dps: 1363.69219
+  tps: 994.99603
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1285.05513
-  tps: 939.25444
+  dps: 1285.22161
+  tps: 939.32495
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 2038.06723
-  tps: 1464.61022
+  dps: 2039.40306
+  tps: 1465.68663
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1291.45587
-  tps: 943.49176
+  dps: 1289.30737
+  tps: 942.03505
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1355.7175
-  tps: 989.23257
+  dps: 1356.32766
+  tps: 989.75726
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1297.25727
-  tps: 947.67165
+  dps: 1295.93285
+  tps: 946.77113
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 1900.92339
-  tps: 1375.55357
+  dps: 1900.20315
+  tps: 1375.01524
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1392.18876
-  tps: 1015.0521
+  dps: 1394.39894
+  tps: 1016.7611
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1315.64511
-  tps: 960.85808
+  dps: 1314.6924
+  tps: 960.21936
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1363.07144
-  tps: 994.46331
+  dps: 1363.69219
+  tps: 994.99603
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1285.05513
-  tps: 939.25444
+  dps: 1285.22161
+  tps: 939.32495
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 1955.59533
-  tps: 1415.37833
+  dps: 1954.88611
+  tps: 1415.12921
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3675.28392
-  tps: 2633.04063
+  dps: 3673.23248
+  tps: 2631.56809
  }
 }
 dps_results: {
@@ -1699,106 +1699,106 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2735.24031
-  tps: 1953.65377
+  dps: 2734.27196
+  tps: 1953.02028
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1379.92231
-  tps: 1005.73383
+  dps: 1377.59081
+  tps: 1004.04158
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1435.97847
-  tps: 1045.9299
+  dps: 1431.66558
+  tps: 1042.87063
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1349.44556
-  tps: 984.04391
+  dps: 1348.96712
+  tps: 983.6285
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 2313.02777
-  tps: 1659.71551
+  dps: 2312.61299
+  tps: 1659.4112
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1355.93621
-  tps: 988.90556
+  dps: 1354.75271
+  tps: 987.97939
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1428.61663
-  tps: 1040.69367
+  dps: 1424.3206
+  tps: 1037.64572
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1362.63793
-  tps: 993.53914
+  dps: 1361.09757
+  tps: 992.41287
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 2158.32555
-  tps: 1557.41457
+  dps: 2157.17379
+  tps: 1556.59203
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1456.88246
-  tps: 1059.21193
+  dps: 1456.27775
+  tps: 1058.74733
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1379.92231
-  tps: 1005.73383
+  dps: 1377.59081
+  tps: 1004.04158
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1435.97847
-  tps: 1045.9299
+  dps: 1431.66558
+  tps: 1042.87063
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1349.44556
-  tps: 984.04391
+  dps: 1348.96712
+  tps: 983.6285
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 2201.49418
-  tps: 1588.89126
+  dps: 2200.18992
+  tps: 1587.84763
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4570.12222
-  tps: 3267.57527
+  dps: 4563.57393
+  tps: 3262.9485
  }
 }
 dps_results: {
@@ -2056,7 +2056,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3310.28646
-  tps: 2360.69579
+  dps: 3304.53819
+  tps: 2356.45457
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -51,7 +51,11 @@ stat_weights_results: {
  key: "TestBM-Phase2-Lvl40-StatWeights-Default"
  value: {
   weights: 0
+<<<<<<< HEAD
   weights: 0.809
+=======
+  weights: 0.83565
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +71,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.34068
   weights: 8.89983
   weights: 8.05951
+=======
+  weights: 0.34104
+  weights: 9.45983
+  weights: 7.94954
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -77,7 +87,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0692
+  weights: 0.06911
   weights: 0
   weights: 0
   weights: 0
@@ -99,392 +109,487 @@ stat_weights_results: {
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 489.49252
-  tps: 223.69363
+  dps: 489.40624
+  tps: 225.55594
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-Maelstrom'sWrath-231320"
  value: {
+<<<<<<< HEAD
   dps: 863.87223
   tps: 368.32103
+=======
+  dps: 865.71599
+  tps: 371.77172
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
+<<<<<<< HEAD
   dps: 837.18553
   tps: 359.18137
+=======
+  dps: 838.18688
+  tps: 362.31574
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-ZandalarPredator'sBelt-231322"
  value: {
+<<<<<<< HEAD
   dps: 712.08945
   tps: 377.38085
+=======
+  dps: 714.60873
+  tps: 379.56943
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-ZandalarPredator'sBracers-231323"
  value: {
+<<<<<<< HEAD
   dps: 846.46742
   tps: 363.92432
+=======
+  dps: 847.83967
+  tps: 367.40139
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-ZandalarPredator'sMantle-231321"
  value: {
+<<<<<<< HEAD
   dps: 854.24764
   tps: 363.54709
+=======
+  dps: 856.15762
+  tps: 366.96183
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 845.37731
   tps: 361.81313
+=======
+  dps: 847.5829
+  tps: 364.88878
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 2188.94103
   tps: 1993.16161
+=======
+  dps: 2219.25036
+  tps: 2025.37816
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 858.0993
   tps: 375.82361
+=======
+  dps: 860.62007
+  tps: 380.0063
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 907.55203
   tps: 387.53346
+=======
+  dps: 904.18495
+  tps: 389.39851
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 1255.76148
   tps: 1270.21415
+=======
+  dps: 1259.34335
+  tps: 1266.08346
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 456.05378
   tps: 201.15821
+=======
+  dps: 450.893
+  tps: 196.97605
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 495.70633
   tps: 202.99497
+=======
+  dps: 494.9958
+  tps: 205.29815
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 566.34042
-  tps: 555.14085
+  dps: 566.13278
+  tps: 554.08885
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 506.89174
-  tps: 253.926
+  dps: 507.56516
+  tps: 254.52732
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 557.54198
-  tps: 271.78973
+  dps: 555.70107
+  tps: 271.98261
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 317.20542
-  tps: 443.95234
+  dps: 316.62459
+  tps: 443.45974
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 273.98885
-  tps: 150.76744
+  dps: 273.97217
+  tps: 150.68734
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 303.41224
-  tps: 158.27319
+  dps: 302.68358
+  tps: 158.15506
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 589.59629
-  tps: 660.03094
+  dps: 592.46004
+  tps: 666.43652
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 484.46955
-  tps: 229.2988
+  dps: 487.40146
+  tps: 233.75098
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 517.04451
-  tps: 244.63477
+  dps: 517.96608
+  tps: 246.29183
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 303.16115
-  tps: 501.71538
+  dps: 299.95058
+  tps: 494.48573
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 249.36716
-  tps: 123.47978
+  dps: 246.88225
+  tps: 121.0919
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 272.73691
-  tps: 127.79887
+  dps: 271.29487
+  tps: 123.74818
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 765.77392
-  tps: 872.19738
+  dps: 764.77859
+  tps: 871.48694
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 688.45576
-  tps: 437.09722
+  dps: 687.51263
+  tps: 437.26689
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 751.03593
-  tps: 478.30952
+  dps: 750.23777
+  tps: 481.10985
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 444.84489
-  tps: 675.67241
+  dps: 444.1887
+  tps: 674.76614
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 394.15455
-  tps: 271.29941
+  dps: 394.32004
+  tps: 271.50277
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 424.88508
-  tps: 290.3124
+  dps: 424.02661
+  tps: 290.27079
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 2122.8471
   tps: 1926.41759
+=======
+  dps: 2153.40984
+  tps: 1958.61111
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 850.32616
   tps: 364.17741
+=======
+  dps: 849.41484
+  tps: 365.84663
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 886.02247
   tps: 366.36871
+=======
+  dps: 884.26504
+  tps: 364.68474
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 1245.94538
   tps: 1250.02717
+=======
+  dps: 1234.79345
+  tps: 1229.49721
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 461.3247
   tps: 201.02419
+=======
+  dps: 456.37578
+  tps: 197.94378
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 495.3003
   tps: 200.11137
+=======
+  dps: 497.63616
+  tps: 202.54151
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 570.61742
-  tps: 552.01776
+  dps: 570.15106
+  tps: 552.31469
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 514.26618
-  tps: 251.65459
+  dps: 514.9936
+  tps: 251.97392
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 563.06058
-  tps: 268.5649
+  dps: 561.15231
+  tps: 268.75651
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 320.2091
-  tps: 442.22134
+  dps: 319.68528
+  tps: 440.89267
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 276.15004
-  tps: 149.09057
+  dps: 277.19063
+  tps: 149.19322
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 307.94113
-  tps: 156.50184
+  dps: 307.18933
+  tps: 156.38602
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 593.22773
-  tps: 654.95086
+  dps: 590.46279
+  tps: 656.9349
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 488.62947
-  tps: 223.0159
+  dps: 485.8082
+  tps: 223.48479
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 521.02403
-  tps: 235.4337
+  dps: 522.83561
+  tps: 237.56823
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 311.25123
-  tps: 500.12165
+  dps: 304.77357
+  tps: 485.17754
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 256.74252
-  tps: 124.05072
+  dps: 252.56426
+  tps: 119.46006
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 286.39469
-  tps: 128.28919
+  dps: 286.23398
+  tps: 124.65513
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 762.34993
-  tps: 870.07555
+  dps: 762.32999
+  tps: 868.37384
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 687.1767
-  tps: 430.25594
+  dps: 687.33049
+  tps: 430.57903
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 754.60568
-  tps: 472.63074
+  dps: 753.27645
+  tps: 475.0199
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 446.99121
-  tps: 669.84028
+  dps: 446.72113
+  tps: 670.58118
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 395.51874
-  tps: 267.92199
+  dps: 395.22567
+  tps: 267.8743
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 427.44873
-  tps: 286.88341
+  dps: 426.65691
+  tps: 286.8418
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 808.15075
   tps: 335.70353
+=======
+  dps: 807.4985
+  tps: 337.71811
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -100,7 +100,11 @@ stat_weights_results: {
  key: "TestMM-Phase2-Lvl40-StatWeights-Default"
  value: {
   weights: 0
+<<<<<<< HEAD
   weights: 0.39744
+=======
+  weights: 0.39743
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +120,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.1237
   weights: 3.94601
   weights: 3.81935
+=======
+  weights: 0.12341
+  weights: 3.95628
+  weights: 3.82702
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +159,7 @@ stat_weights_results: {
  key: "TestMM-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.51922
+  weights: 0.51925
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +185,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.04141
+  weights: 0.04142
   weights: 0
   weights: 0
   weights: 0
@@ -197,50 +207,85 @@ stat_weights_results: {
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-BeastmasterArmor"
  value: {
+<<<<<<< HEAD
   dps: 331.80276
   tps: 170.12798
+=======
+  dps: 333.24811
+  tps: 169.80885
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-Maelstrom'sWrath-231320"
  value: {
+<<<<<<< HEAD
   dps: 348.90493
   tps: 185.52832
+=======
+  dps: 350.43771
+  tps: 185.2709
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
+<<<<<<< HEAD
   dps: 340.61841
   tps: 181.47826
+=======
+  dps: 342.14062
+  tps: 181.2309
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-ZandalarPredator'sBelt-231322"
  value: {
+<<<<<<< HEAD
   dps: 333.54743
   tps: 172.98276
+=======
+  dps: 335.09143
+  tps: 172.73206
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-ZandalarPredator'sBracers-231323"
  value: {
+<<<<<<< HEAD
   dps: 342.71916
   tps: 183.11753
+=======
+  dps: 344.23562
+  tps: 182.8662
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-ZandalarPredator'sMantle-231321"
  value: {
+<<<<<<< HEAD
   dps: 349.41471
   tps: 184.74389
+=======
+  dps: 350.98035
+  tps: 184.49167
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 344.17691
   tps: 184.63261
+=======
+  dps: 345.66669
+  tps: 184.3634
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -330,120 +375,125 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 329.8315
   tps: 171.16244
+=======
+  dps: 331.30061
+  tps: 170.87977
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 512.21178
-  tps: 512.32249
-  hps: 10.12473
+  dps: 512.39454
+  tps: 512.50526
+  hps: 10.11647
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 728.12015
-  tps: 728.2306
-  hps: 10.03567
+  dps: 728.1028
+  tps: 728.21325
+  hps: 10.03854
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 861.05857
-  tps: 861.16902
-  hps: 12.98882
+  dps: 861.28322
+  tps: 861.39367
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 860.07955
-  tps: 860.19
-  hps: 12.98882
+  dps: 860.30533
+  tps: 860.41578
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 853.14314
-  tps: 853.25359
-  hps: 12.98882
+  dps: 853.36892
+  tps: 853.47937
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 634.05791
-  tps: 634.17781
-  hps: 9.5885
+  dps: 634.06656
+  tps: 634.18488
+  hps: 9.5936
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 862.54251
-  tps: 862.65296
-  hps: 12.98882
+  dps: 862.76716
+  tps: 862.87761
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 728.12015
-  tps: 728.2306
-  hps: 10.03567
+  dps: 728.1028
+  tps: 728.21325
+  hps: 10.03854
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 861.55776
-  tps: 861.66821
-  hps: 12.81888
+  dps: 861.7851
+  tps: 861.89555
+  hps: 12.81677
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 848.97089
-  tps: 849.08134
-  hps: 12.98882
+  dps: 849.19428
+  tps: 849.30473
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 809.71002
-  tps: 809.82047
-  hps: 12.98882
+  dps: 809.91783
+  tps: 810.02828
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 733.77728
-  tps: 733.88773
-  hps: 12.98882
+  dps: 733.80443
+  tps: 733.91488
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 846.09139
-  tps: 846.20184
-  hps: 12.98882
+  dps: 846.31308
+  tps: 846.42353
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 865.04746
-  tps: 865.15344
-  hps: 13.04623
+  dps: 865.06031
+  tps: 865.16619
+  hps: 13.05262
  }
 }
 dps_results: {
@@ -545,8 +595,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 718.54495
-  tps: 718.65514
-  hps: 11.10274
+  dps: 718.43386
+  tps: 718.54405
+  hps: 11.10659
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestSV-Phase2-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.89401
+  weights: 0.88765
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.37221
   weights: 6.28754
   weights: 7.24514
+=======
+  weights: 0.37295
+  weights: 6.36885
+  weights: 7.2888
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -126,7 +132,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0392
+  weights: 0.03919
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +155,11 @@ stat_weights_results: {
  key: "TestSV-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
+<<<<<<< HEAD
   weights: 2.92574
+=======
+  weights: 3.00295
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +175,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.41596
   weights: 0
   weights: 20.53801
+=======
+  weights: 0.45891
+  weights: 0
+  weights: 19.3171
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +191,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50491
+  weights: 0.49905
   weights: 0
   weights: 0
   weights: 0
@@ -197,157 +213,252 @@ stat_weights_results: {
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 404.36276
-  tps: 254.25908
+  dps: 404.5068
+  tps: 254.19652
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-Maelstrom'sWrath-231320"
  value: {
+<<<<<<< HEAD
   dps: 803.94129
   tps: 397.64831
+=======
+  dps: 809.80243
+  tps: 403.86958
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
+<<<<<<< HEAD
   dps: 781.54476
   tps: 386.7768
+=======
+  dps: 787.42134
+  tps: 392.90226
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-ZandalarPredator'sBelt-231322"
  value: {
+<<<<<<< HEAD
   dps: 613.63696
   tps: 408.26528
+=======
+  dps: 617.05408
+  tps: 411.33901
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-ZandalarPredator'sBracers-231323"
  value: {
+<<<<<<< HEAD
   dps: 791.52331
   tps: 392.40356
+=======
+  dps: 797.2092
+  tps: 398.45986
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-ZandalarPredator'sMantle-231321"
  value: {
+<<<<<<< HEAD
   dps: 797.76948
   tps: 392.86992
+=======
+  dps: 803.55283
+  tps: 399.01849
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 795.613
   tps: 396.89574
+=======
+  dps: 797.98077
+  tps: 399.84702
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 2256.50968
   tps: 2138.04009
+=======
+  dps: 2281.60972
+  tps: 2163.66762
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 806.434
   tps: 408.3337
+=======
+  dps: 809.80795
+  tps: 412.68554
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 847.6918
   tps: 427.82441
+=======
+  dps: 848.80041
+  tps: 428.71083
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 1310.33496
   tps: 1351.60921
+=======
+  dps: 1305.90236
+  tps: 1343.59862
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 436.50411
   tps: 220.3363
+=======
+  dps: 429.9506
+  tps: 216.13913
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 464.2304
   tps: 221.39225
+=======
+  dps: 465.73333
+  tps: 223.19865
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 2208.68013
   tps: 2092.08383
+=======
+  dps: 2234.26757
+  tps: 2117.17376
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 797.00347
   tps: 397.12059
+=======
+  dps: 799.2033
+  tps: 399.57633
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 834.27572
   tps: 412.75993
+=======
+  dps: 835.72894
+  tps: 414.74519
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 1303.96481
   tps: 1345.47868
+=======
+  dps: 1318.78974
+  tps: 1346.74022
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 441.58959
   tps: 219.89795
+=======
+  dps: 438.71359
+  tps: 220.56101
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 473.35914
   tps: 229.28006
+=======
+  dps: 475.27369
+  tps: 231.43472
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 751.62124
   tps: 372.08004
+=======
+  dps: 754.67877
+  tps: 374.99206
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 1125.0274
-  tps: 905.28074
-  hps: 14.3972
+  dps: 1100.81471
+  tps: 878.24338
+  hps: 14.00309
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 1394.86526
-  tps: 1150.65857
-  hps: 14.3972
+  dps: 1368.87904
+  tps: 1122.63325
+  hps: 14.00309
  }
 }
 dps_results: {
@@ -361,25 +472,37 @@ dps_results: {
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
+<<<<<<< HEAD
   dps: 3525.30767
   tps: 3145.28344
   hps: 19.9832
+=======
+  dps: 3573.38559
+  tps: 3193.74769
+  hps: 20.36399
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
+<<<<<<< HEAD
   dps: 3495.90796
   tps: 3119.03146
   hps: 19.9832
+=======
+  dps: 3543.09748
+  tps: 3166.75874
+  hps: 20.36399
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 2089.2021
-  tps: 1823.61287
-  hps: 14.99414
+  dps: 2043.59587
+  tps: 1778.9464
+  hps: 15.36682
  }
 }
 dps_results: {
@@ -393,160 +516,273 @@ dps_results: {
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 1394.86526
-  tps: 1150.65857
-  hps: 14.3972
+  dps: 1368.87904
+  tps: 1122.63325
+  hps: 14.00309
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
+<<<<<<< HEAD
   dps: 3543.57511
   tps: 3167.0201
   hps: 19.82352
+=======
+  dps: 3593.17681
+  tps: 3217.16491
+  hps: 20.23194
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
+<<<<<<< HEAD
   dps: 3460.12995
   tps: 3091.26853
   hps: 20.40391
+=======
+  dps: 3501.94261
+  tps: 3132.75336
+  hps: 20.2995
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
+<<<<<<< HEAD
   dps: 3163.77905
   tps: 2829.48332
   hps: 19.40117
+=======
+  dps: 3197.68057
+  tps: 2863.5392
+  hps: 19.77086
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
+<<<<<<< HEAD
   dps: 3143.72955
   tps: 2781.651
   hps: 19.40117
+=======
+  dps: 3188.65372
+  tps: 2827.06886
+  hps: 19.77086
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
+<<<<<<< HEAD
   dps: 3417.42519
   tps: 3055.78416
   hps: 19.40117
+=======
+  dps: 3460.44394
+  tps: 3098.95611
+  hps: 19.77086
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 3528.43883
   tps: 3151.72512
   hps: 20.24192
+=======
+  dps: 3591.08997
+  tps: 3216.19161
+  hps: 19.9338
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 8211.75666
   tps: 8273.52171
   hps: 20.54717
+=======
+  dps: 8206.64337
+  tps: 8261.96199
+  hps: 19.92686
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3558.68282
   tps: 3200.23451
   hps: 20.08257
+=======
+  dps: 3643.45388
+  tps: 3288.9785
+  hps: 20.15627
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3463.91615
   tps: 3129.7374
   hps: 18.37475
+=======
+  dps: 3504.98087
+  tps: 3180.53058
+  hps: 18.98892
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 4167.19824
   tps: 4457.17192
   hps: 10.61777
+=======
+  dps: 4172.51617
+  tps: 4437.7876
+  hps: 10.52491
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 1691.1062
   tps: 1524.39687
   hps: 10.35941
+=======
+  dps: 1724.76021
+  tps: 1561.26725
+  hps: 10.3355
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 1681.72637
   tps: 1493.56675
   hps: 10.66558
+=======
+  dps: 1727.2058
+  tps: 1542.89897
+  hps: 10.25183
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 8666.9536
   tps: 8729.05814
   hps: 20.78363
+=======
+  dps: 8589.4876
+  tps: 8620.65635
+  hps: 20.43662
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3802.77585
   tps: 3431.90791
   hps: 20.51249
+=======
+  dps: 3855.53567
+  tps: 3486.23408
+  hps: 19.97202
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3727.93481
   tps: 3345.2507
   hps: 19.83341
+=======
+  dps: 3732.10611
+  tps: 3377.78944
+  hps: 19.18852
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 4163.77793
   tps: 4430.4855
   hps: 10.82557
+=======
+  dps: 4169.87481
+  tps: 4414.64097
+  hps: 10.51111
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 1672.1814
   tps: 1508.15261
   hps: 10.4302
+=======
+  dps: 1719.74819
+  tps: 1550.09546
+  hps: 10.23436
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 1669.19549
   tps: 1486.86871
+=======
+  dps: 1722.19434
+  tps: 1530.33626
+>>>>>>> 4b5b2b329... WIP
   hps: 10.15989
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3287.05955
   tps: 2976.26938
   hps: 19.83795
+=======
+  dps: 3330.22864
+  tps: 3036.00596
+  hps: 19.45496
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/paladin/crusader_strike.go
+++ b/sim/paladin/crusader_strike.go
@@ -40,7 +40,14 @@ func (paladin *Paladin) registerCrusaderStrike() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
-			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+
+			core.StartDelayedAction(sim, core.DelayedActionOptions{
+				DoAt: sim.CurrentTime + core.SpellBatchWindow,
+				OnAction: func(s *core.Simulation) {
+					spell.DealDamage(sim, result)
+				},
+			})
 
 			paladin.AddMana(sim, 0.05*paladin.MaxMana(), manaMetrics)
 

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -50,6 +50,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtection-Phase4-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 0.87874
   weights: 0.58656
   weights: 0
@@ -71,6 +72,29 @@ stat_weights_results: {
   weights: 0
   weights: 14.02298
   weights: 10.87034
+=======
+  weights: 0.88948
+  weights: 0.48839
+  weights: 0
+  weights: 0.08242
+  weights: 0
+  weights: 0.18358
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.10031
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 3.32006
+  weights: 1.17168
+  weights: 0
+  weights: 0
+  weights: 0.39912
+  weights: 0
+  weights: 14.42879
+  weights: 11.77684
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -78,9 +102,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 1.94046
   weights: 0
   weights: 0.33418
+=======
+  weights: 1.96365
+  weights: 0
+  weights: 0.33205
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -99,78 +129,128 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
+<<<<<<< HEAD
   dps: 1243.66272
   tps: 2230.10878
+=======
+  dps: 1258.10046
+  tps: 2270.03362
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
+<<<<<<< HEAD
   dps: 1559.84154
   tps: 3122.89213
+=======
+  dps: 1568.95436
+  tps: 3163.60188
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
+<<<<<<< HEAD
   dps: 1243.74236
   tps: 2230.82631
+=======
+  dps: 1258.18091
+  tps: 2270.7399
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
+<<<<<<< HEAD
   dps: 1315.26834
   tps: 2354.18958
+=======
+  dps: 1330.45706
+  tps: 2396.25151
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
+<<<<<<< HEAD
   dps: 1612.93081
   tps: 3243.62488
+=======
+  dps: 1622.41555
+  tps: 3267.4327
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 1419.83321
   tps: 2836.90155
+=======
+  dps: 1435.39581
+  tps: 2891.16032
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
+<<<<<<< HEAD
   dps: 1616.59626
   tps: 3250.47239
+=======
+  dps: 1632.54136
+  tps: 3282.03639
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1017.76917
-  tps: 1521.25783
+  dps: 1017.57567
+  tps: 1514.37215
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
+<<<<<<< HEAD
   dps: 1332.36957
   tps: 2682.6786
+=======
+  dps: 1349.90929
+  tps: 2719.83732
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
+<<<<<<< HEAD
   dps: 1571.19591
   tps: 3157.02583
+=======
+  dps: 1594.40222
+  tps: 3205.39488
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 1593.90701
   tps: 3190.42093
+=======
+  dps: 1609.53771
+  tps: 3240.39494
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -260,7 +340,12 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 1301.74746
   tps: 2594.6402
+=======
+  dps: 1349.35002
+  tps: 2769.82356
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/paladin/retribution/TestExodin.results
+++ b/sim/paladin/retribution/TestExodin.results
@@ -99,12 +99,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestExodin-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.12336
-  weights: 1.90913
+  weights: 2.08924
+  weights: 1.2992
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.71587
+  weights: 0.71332
   weights: 0
   weights: 0
   weights: 0
@@ -112,13 +112,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.70988
-  weights: 2.09556
+  weights: 9.56191
+  weights: 1.72503
   weights: 0
   weights: 0
-  weights: 0.87742
+  weights: 0.86332
   weights: 0
-  weights: 21.96742
+  weights: 20.13232
   weights: 0
   weights: 0
   weights: 0
@@ -148,12 +148,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestExodin-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.92288
-  weights: 0.78292
+  weights: 2.89807
+  weights: 1.5723
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.92752
+  weights: 0.92552
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 16.66754
-  weights: -0.30886
+  weights: 12.44335
+  weights: 2.19718
   weights: 0
   weights: 0
-  weights: 1.05026
+  weights: 1.04135
   weights: 0
-  weights: 29.3121
+  weights: 24.43412
   weights: 0
   weights: 0
   weights: 0
@@ -197,336 +197,336 @@ stat_weights_results: {
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1336.87262
-  tps: 1372.06571
+  dps: 1326.97626
+  tps: 1362.10537
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 3224.58066
-  tps: 3256.91886
+  dps: 3188.40394
+  tps: 3220.93814
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1337.01263
-  tps: 1373.08855
+  dps: 1327.13852
+  tps: 1363.12992
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1436.83232
-  tps: 1474.21743
+  dps: 1426.18879
+  tps: 1463.50638
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 3262.10077
-  tps: 3294.31845
+  dps: 3233.07962
+  tps: 3265.13453
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1572.71774
-  tps: 1610.38093
+  dps: 1566.45342
+  tps: 1604.1539
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 3139.97411
-  tps: 3172.3625
+  dps: 3107.02574
+  tps: 3139.15918
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1215.57282
-  tps: 1252.07982
+  dps: 1209.71744
+  tps: 1246.16036
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 1416.72379
-  tps: 1454.47473
+  dps: 1409.35011
+  tps: 1447.17098
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1665.71711
-  tps: 1703.4567
+  dps: 1648.6742
+  tps: 1686.48545
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3249.30607
-  tps: 3281.32038
+  dps: 3216.53368
+  tps: 3248.51459
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1480.97125
-  tps: 2028.59703
+  dps: 1474.38445
+  tps: 2015.82502
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 626.38901
-  tps: 653.68525
+  dps: 626.1395
+  tps: 653.43082
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 707.29814
-  tps: 738.24101
+  dps: 706.03971
+  tps: 736.98258
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 601.24799
-  tps: 971.69115
+  dps: 600.37781
+  tps: 970.82097
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 269.10808
-  tps: 287.61979
+  dps: 269.33743
+  tps: 287.84914
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 369.73145
-  tps: 393.06296
+  dps: 369.76825
+  tps: 393.09976
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1488.4063
-  tps: 2038.87613
+  dps: 1504.78619
+  tps: 2053.40101
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 639.15333
-  tps: 666.65001
+  dps: 639.12482
+  tps: 666.61657
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 710.21146
-  tps: 741.19592
+  dps: 708.82308
+  tps: 739.80755
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 603.01841
-  tps: 974.80674
+  dps: 604.13882
+  tps: 975.50681
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 275.7187
-  tps: 294.29761
+  dps: 275.30928
+  tps: 293.88819
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 374.1251
-  tps: 397.5579
+  dps: 372.66311
+  tps: 396.09591
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2685.2624
-  tps: 2719.96003
+  dps: 2662.72373
+  tps: 2697.50557
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1637.13445
-  tps: 1672.77418
+  dps: 1631.8046
+  tps: 1667.5122
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 4454.49855
-  tps: 4493.78987
+  dps: 4436.85308
+  tps: 4475.99826
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1637.14331
-  tps: 1673.59764
+  dps: 1631.8142
+  tps: 1668.3467
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1757.15569
-  tps: 1794.84193
+  dps: 1751.9744
+  tps: 1789.731
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 4523.15933
-  tps: 4562.10913
+  dps: 4521.32587
+  tps: 4560.34282
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1925.99329
-  tps: 1963.84421
+  dps: 1911.54879
+  tps: 1949.39025
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 4414.00967
-  tps: 4453.14549
+  dps: 4390.70912
+  tps: 4429.29231
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1486.46953
-  tps: 1523.40668
+  dps: 1479.27228
+  tps: 1516.18864
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 1773.11978
-  tps: 1811.19954
+  dps: 1770.92987
+  tps: 1808.95763
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 2043.75592
-  tps: 2081.82898
+  dps: 2033.82508
+  tps: 2071.84463
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4536.61207
-  tps: 4575.0366
+  dps: 4517.20428
+  tps: 4555.60529
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2516.92893
-  tps: 3160.23147
+  dps: 2439.9349
+  tps: 3053.87117
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1040.68892
-  tps: 1072.92922
+  dps: 1043.96541
+  tps: 1076.20571
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1136.28585
-  tps: 1175.17614
+  dps: 1134.81856
+  tps: 1173.65968
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 792.82924
-  tps: 1161.59935
+  dps: 795.79339
+  tps: 1163.78783
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 354.49564
-  tps: 372.93668
+  dps: 354.68656
+  tps: 373.1276
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 505.55152
-  tps: 529.79457
+  dps: 504.49182
+  tps: 528.73487
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2538.13849
-  tps: 3182.87465
+  dps: 2482.2297
+  tps: 3101.33197
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1054.40896
-  tps: 1086.87081
+  dps: 1056.28692
+  tps: 1088.74877
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1140.56323
-  tps: 1179.65445
+  dps: 1140.17543
+  tps: 1179.24207
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 807.34412
-  tps: 1176.53732
+  dps: 806.9172
+  tps: 1175.72006
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 362.99614
-  tps: 381.40979
+  dps: 363.80331
+  tps: 382.21696
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 502.54074
-  tps: 526.7925
+  dps: 502.004
+  tps: 526.25576
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3753.52709
-  tps: 3795.82454
+  dps: 3714.87995
+  tps: 3757.03593
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -246,12 +246,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.45725
-  weights: 0.24202
+  weights: 0.45448
+  weights: 0.27056
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13749
+  weights: 0.13776
   weights: 0
   weights: 0
   weights: 0
@@ -259,13 +259,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.41897
+  weights: 0.21068
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.20784
-  weights: 1.26759
-  weights: 2.17683
+  weights: 0.20658
+  weights: 1.69537
+  weights: 2.19509
   weights: 0
   weights: 0
   weights: 0
@@ -295,12 +295,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.66354
-  weights: 0.40743
+  weights: 0.66066
+  weights: 0.3795
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22175
+  weights: 0.2217
   weights: 0
   weights: 0
   weights: 0
@@ -308,13 +308,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.68951
-  weights: 0.07977
+  weights: 1.74055
+  weights: 0.08283
   weights: 0
   weights: 0
-  weights: 0.30161
-  weights: 5.17831
-  weights: 5.24761
+  weights: 0.3003
+  weights: 5.10188
+  weights: 5.19765
   weights: 0
   weights: 0
   weights: 0
@@ -344,12 +344,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.06725
-  weights: 1.01742
+  weights: 1.07177
+  weights: 1.58648
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.28111
+  weights: 0.28005
   weights: 0
   weights: 0
   weights: 0
@@ -357,13 +357,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.53149
-  weights: 0.46126
+  weights: 2.56734
+  weights: 0.46665
   weights: 0
   weights: 0
-  weights: 0.40626
-  weights: 12.73206
-  weights: 9.79176
+  weights: 0.40607
+  weights: 13.08333
+  weights: 9.80118
   weights: 0
   weights: 0
   weights: 0
@@ -393,12 +393,21 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase4-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 2.61392
   weights: 1.81223
   weights: 0
   weights: 0
   weights: 0
   weights: 0.40771
+=======
+  weights: 2.60976
+  weights: 2.25613
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.40929
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -406,6 +415,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 5.68818
   weights: 0.7883
   weights: 0
@@ -413,6 +423,15 @@ stat_weights_results: {
   weights: 0.93925
   weights: 2.46521
   weights: 28.70978
+=======
+  weights: 5.9112
+  weights: 0.75595
+  weights: 0
+  weights: 0
+  weights: 0.93775
+  weights: 0
+  weights: 29.98837
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -442,12 +461,21 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase5-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 3.00377
   weights: 1.74636
   weights: 0
   weights: 0
   weights: 0
   weights: 0.50638
+=======
+  weights: 2.85066
+  weights: 2.59597
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.50941
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -455,6 +483,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 12.2032
   weights: 0.65393
   weights: 0
@@ -462,6 +491,15 @@ stat_weights_results: {
   weights: 1.03578
   weights: 1.42587
   weights: 35.20843
+=======
+  weights: 10.18517
+  weights: 0.70371
+  weights: 0
+  weights: 0
+  weights: 0.77023
+  weights: 2.87171
+  weights: 35.59156
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -491,456 +529,506 @@ stat_weights_results: {
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 249.94345
-  tps: 256.93929
+  dps: 249.28749
+  tps: 256.28333
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-SoulforgeArmor"
  value: {
-  dps: 197.00824
-  tps: 198.74774
+  dps: 196.34485
+  tps: 198.08435
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 250.54499
-  tps: 258.00694
+  dps: 248.78216
+  tps: 256.24411
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 217.68029
-  tps: 223.15121
+  dps: 217.60473
+  tps: 223.07685
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 249.37754
-  tps: 256.19108
+  dps: 250.06189
+  tps: 256.87542
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 176.07997
-  tps: 315.26495
+  dps: 167.50332
+  tps: 306.6883
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 94.11011
-  tps: 101.06936
+  dps: 93.30431
+  tps: 100.26355
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 106.90803
-  tps: 115.96341
+  dps: 107.1902
+  tps: 116.24559
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 99.38531
-  tps: 204.5716
+  dps: 101.60732
+  tps: 206.79361
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 52.61365
-  tps: 57.87296
+  dps: 52.72011
+  tps: 57.97942
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 65.40836
-  tps: 73.39714
+  dps: 65.53939
+  tps: 73.52817
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 177.48277
-  tps: 317.74085
+  dps: 169.62065
+  tps: 309.87873
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 94.93101
-  tps: 101.94391
+  dps: 94.08671
+  tps: 101.09961
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 107.48996
-  tps: 116.60004
+  dps: 107.77021
+  tps: 116.88029
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 100.43322
-  tps: 206.7217
+  dps: 100.04509
+  tps: 206.33357
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 52.97193
-  tps: 58.28636
+  dps: 53.07122
+  tps: 58.38564
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 65.56642
-  tps: 73.60891
+  dps: 65.6961
+  tps: 73.7386
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 233.86841
-  tps: 240.88132
+  dps: 233.26457
+  tps: 240.27747
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 546.46321
-  tps: 560.19666
+  dps: 544.62229
+  tps: 558.37377
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-SoulforgeArmor"
  value: {
-  dps: 327.52646
-  tps: 335.36102
+  dps: 325.60669
+  tps: 333.41375
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 470.96511
-  tps: 484.88019
+  dps: 468.93625
+  tps: 482.80272
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 486.02225
-  tps: 496.44432
+  dps: 483.29966
+  tps: 493.70004
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 548.4983
-  tps: 562.00552
+  dps: 548.61548
+  tps: 562.12304
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 429.91227
-  tps: 674.9001
+  dps: 419.18903
+  tps: 658.81985
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 205.35988
-  tps: 217.22901
+  dps: 204.79834
+  tps: 216.65936
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 227.60289
-  tps: 239.32088
+  dps: 227.66526
+  tps: 239.38324
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 238.54461
-  tps: 400.36395
+  dps: 234.29971
+  tps: 393.64451
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 107.99244
-  tps: 116.00768
+  dps: 107.82373
+  tps: 115.83897
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 132.10906
-  tps: 142.83317
+  dps: 132.14217
+  tps: 142.86628
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 429.52991
-  tps: 674.45611
+  dps: 417.04106
+  tps: 653.55207
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 205.29952
-  tps: 217.11827
+  dps: 204.8499
+  tps: 216.6593
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 228.38983
-  tps: 240.10812
+  dps: 228.45203
+  tps: 240.17033
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 238.81254
-  tps: 400.2672
+  dps: 236.71967
+  tps: 397.45738
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 108.35624
-  tps: 116.41357
+  dps: 108.2034
+  tps: 116.26073
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 132.38776
-  tps: 143.16816
+  dps: 132.42077
+  tps: 143.20117
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 516.61655
-  tps: 529.97864
+  dps: 514.43962
+  tps: 527.77771
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 1126.13527
-  tps: 1164.54067
+  dps: 1125.85858
+  tps: 1164.31199
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-SoulforgeArmor"
  value: {
-  dps: 733.69783
-  tps: 768.12046
+  dps: 733.93401
+  tps: 768.38962
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 977.90371
-  tps: 1016.35238
+  dps: 979.22521
+  tps: 1017.72037
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1115.05641
-  tps: 1153.4549
+  dps: 1111.97788
+  tps: 1150.30924
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1136.71557
-  tps: 1175.09789
+  dps: 1136.05918
+  tps: 1174.45671
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1443.20567
-  tps: 1984.88419
+  dps: 1443.31925
+  tps: 1984.92111
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 338.88685
-  tps: 366.00403
+  dps: 338.44428
+  tps: 365.55762
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 400.41198
-  tps: 428.02316
+  dps: 400.52869
+  tps: 428.13987
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 511.87633
-  tps: 785.75421
+  dps: 511.7067
+  tps: 785.58458
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 138.52917
-  tps: 152.22306
+  dps: 138.35953
+  tps: 152.05343
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 195.13245
-  tps: 212.93379
+  dps: 194.61283
+  tps: 212.41416
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1451.4421
-  tps: 1996.41021
+  dps: 1450.5652
+  tps: 1995.45665
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 342.37064
-  tps: 369.59921
+  dps: 342.19786
+  tps: 369.42643
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 402.94345
-  tps: 430.57606
+  dps: 403.14615
+  tps: 430.77876
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 501.673
-  tps: 776.71621
+  dps: 500.45425
+  tps: 775.49746
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 142.16671
-  tps: 155.91887
+  dps: 141.79319
+  tps: 155.54535
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 196.13679
-  tps: 214.02606
+  dps: 195.88752
+  tps: 213.7768
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1076.46553
-  tps: 1114.32392
+  dps: 1073.30308
+  tps: 1111.25164
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
+<<<<<<< HEAD
   dps: 1693.16566
   tps: 1732.15523
+=======
+  dps: 1663.73616
+  tps: 1702.04416
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
+<<<<<<< HEAD
   dps: 3625.9255
   tps: 3675.66346
+=======
+  dps: 3635.03364
+  tps: 3684.14054
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
+<<<<<<< HEAD
   dps: 1693.77262
   tps: 1732.91515
+=======
+  dps: 1659.48023
+  tps: 1697.74919
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
+<<<<<<< HEAD
   dps: 1779.4781
   tps: 1818.94027
+=======
+  dps: 1763.91769
+  tps: 1803.10747
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
+<<<<<<< HEAD
   dps: 3673.57979
   tps: 3723.1539
+=======
+  dps: 3694.34839
+  tps: 3743.37578
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 2229.02519
   tps: 2280.02876
+=======
+  dps: 2263.0786
+  tps: 2314.03004
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
+<<<<<<< HEAD
   dps: 3592.72811
   tps: 3642.12383
+=======
+  dps: 3589.02817
+  tps: 3638.13851
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1575.48636
-  tps: 1614.65441
+  dps: 1537.54125
+  tps: 1576.05204
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
+<<<<<<< HEAD
   dps: 3204.34088
   tps: 3254.20814
+=======
+  dps: 3205.72812
+  tps: 3254.84654
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
+<<<<<<< HEAD
   dps: 2359.70664
   tps: 2403.16601
+=======
+  dps: 2368.9726
+  tps: 2411.76739
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 3686.03323
   tps: 3735.41389
+=======
+  dps: 3683.11133
+  tps: 3732.47685
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -988,43 +1076,58 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 2195.8767
   tps: 2774.45657
+=======
+  dps: 2113.98571
+  tps: 2677.92132
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 995.10871
   tps: 1024.18428
+=======
+  dps: 998.0215
+  tps: 1027.10399
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 1125.47156
   tps: 1158.83116
+=======
+  dps: 1138.5693
+  tps: 1171.8697
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 688.62076
-  tps: 1059.91252
+  dps: 698.63396
+  tps: 1070.13464
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 355.86899
-  tps: 374.42313
+  dps: 357.22025
+  tps: 375.77439
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 479.33709
-  tps: 502.77629
+  dps: 481.03563
+  tps: 504.47483
  }
 }
 dps_results: {
@@ -1072,15 +1175,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 334.40108
-  tps: 763.89963
+  dps: 334.58215
+  tps: 764.0807
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 290.97268
-  tps: 312.44761
+  dps: 291.09185
+  tps: 312.56677
  }
 }
 dps_results: {
@@ -1092,22 +1195,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 237.59581
-  tps: 572.88822
+  dps: 240.11438
+  tps: 575.40679
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 182.54271
-  tps: 199.30733
+  dps: 183.16826
+  tps: 199.93288
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 70.81871
-  tps: 89.17372
+  dps: 66.18046
+  tps: 84.53547
  }
 }
 dps_results: {
@@ -1155,43 +1258,68 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 2218.95488
   tps: 2800.42313
+=======
+  dps: 2163.84642
+  tps: 2730.01297
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 994.44097
   tps: 1023.43869
+=======
+  dps: 999.65189
+  tps: 1028.64962
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 1124.65321
   tps: 1158.08522
+=======
+  dps: 1137.52956
+  tps: 1170.90198
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 685.56197
   tps: 1057.98498
+=======
+  dps: 692.76837
+  tps: 1065.19138
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 354.44349
   tps: 373.09616
+=======
+  dps: 356.15157
+  tps: 374.80425
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 484.80105
-  tps: 508.28743
+  dps: 486.28353
+  tps: 509.76991
  }
 }
 dps_results: {
@@ -1239,15 +1367,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 346.57546
-  tps: 778.35543
+  dps: 345.31015
+  tps: 777.09012
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 298.00447
-  tps: 319.61313
+  dps: 297.94508
+  tps: 319.55374
  }
 }
 dps_results: {
@@ -1259,106 +1387,166 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 239.69954
-  tps: 575.48037
+  dps: 239.36515
+  tps: 575.14597
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 185.4878
-  tps: 202.26621
+  dps: 185.94433
+  tps: 202.72274
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 72.04642
-  tps: 90.42018
+  dps: 67.55519
+  tps: 85.92895
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3012.2552
   tps: 3061.36391
+=======
+  dps: 2979.48908
+  tps: 3028.32129
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
+<<<<<<< HEAD
   dps: 2386.24984
   tps: 2443.45374
+=======
+  dps: 2386.9491
+  tps: 2443.95968
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
+<<<<<<< HEAD
   dps: 4412.95168
   tps: 4469.04932
+=======
+  dps: 4435.41027
+  tps: 4491.92998
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
+<<<<<<< HEAD
   dps: 2391.32022
   tps: 2449.17673
+=======
+  dps: 2387.25395
+  tps: 2444.89329
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
+<<<<<<< HEAD
   dps: 2545.75412
   tps: 2605.25683
+=======
+  dps: 2540.89494
+  tps: 2600.17184
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
+<<<<<<< HEAD
   dps: 4493.15532
   tps: 4549.17076
+=======
+  dps: 4519.70416
+  tps: 4576.05069
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 3862.20421
   tps: 3924.96069
+=======
+  dps: 3875.62187
+  tps: 3938.93536
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
+<<<<<<< HEAD
   dps: 4368.28952
   tps: 4423.81719
+=======
+  dps: 4388.63898
+  tps: 4444.62202
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
+<<<<<<< HEAD
   dps: 1911.78587
   tps: 1963.72745
+=======
+  dps: 1823.53562
+  tps: 1873.19629
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
+<<<<<<< HEAD
   dps: 3733.61373
   tps: 3789.61545
+=======
+  dps: 3797.60248
+  tps: 3854.04685
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
+<<<<<<< HEAD
   dps: 4100.8718
   tps: 4159.21536
+=======
+  dps: 4095.99602
+  tps: 4153.99194
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 4472.48287
   tps: 4528.71496
+=======
+  dps: 4479.54993
+  tps: 4536.01653
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -1530,7 +1718,12 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3646.18801
   tps: 3700.99744
+=======
+  dps: 3651.06084
+  tps: 3706.42855
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -99,12 +99,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestShockadin-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.71754
-  weights: 0.11352
+  weights: 0.71804
+  weights: 0.1204
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.1802
+  weights: 0.18035
   weights: 0
   weights: 0
   weights: 0
@@ -112,13 +112,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.74531
-  weights: 0.18066
+  weights: 1.77931
+  weights: 0.17672
   weights: 0
   weights: 0
-  weights: 0.2965
-  weights: 5.08587
-  weights: 4.63411
+  weights: 0.29671
+  weights: 5.15293
+  weights: 4.57561
   weights: 0
   weights: 0
   weights: 0
@@ -148,12 +148,21 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestShockadin-Phase5-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 0.50922
   weights: 2.65125
   weights: 0
   weights: 0
   weights: 0
   weights: 1.43197
+=======
+  weights: 0.42318
+  weights: 2.13835
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 1.07435
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -161,6 +170,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.49947
   weights: 10.74859
   weights: 0
@@ -168,6 +178,15 @@ stat_weights_results: {
   weights: 0.18297
   weights: 9.38231
   weights: 23.2999
+=======
+  weights: 13.17152
+  weights: 14.15263
+  weights: 0
+  weights: 0
+  weights: 0.17487
+  weights: 15.47147
+  weights: 21.94916
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -197,50 +216,50 @@ stat_weights_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 504.45966
-  tps: 528.84909
+  dps: 504.59014
+  tps: 528.94766
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-SoulforgeArmor"
  value: {
-  dps: 384.12299
-  tps: 403.81257
+  dps: 384.17911
+  tps: 403.88708
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 446.50042
-  tps: 470.88997
+  dps: 446.61088
+  tps: 471.00163
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 500.67931
-  tps: 525.12289
+  dps: 500.20797
+  tps: 524.62794
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 512.07483
-  tps: 536.41457
+  dps: 512.17379
+  tps: 536.51048
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 545.35166
-  tps: 824.0562
+  dps: 545.35844
+  tps: 824.06297
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 147.14497
-  tps: 161.04846
+  dps: 147.15029
+  tps: 161.05377
  }
 }
 dps_results: {
@@ -253,15 +272,15 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 257.61091
-  tps: 442.55719
+  dps: 257.61526
+  tps: 442.56154
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 77.77845
-  tps: 87.02577
+  dps: 77.75211
+  tps: 86.99943
  }
 }
 dps_results: {
@@ -274,15 +293,15 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 557.92089
-  tps: 837.05075
+  dps: 557.35472
+  tps: 836.37459
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 146.95012
-  tps: 160.91294
+  dps: 146.71806
+  tps: 160.67813
  }
 }
 dps_results: {
@@ -295,15 +314,15 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 263.83922
-  tps: 450.1165
+  dps: 263.72985
+  tps: 450.00713
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 78.07802
-  tps: 87.39188
+  dps: 77.95938
+  tps: 87.27325
  }
 }
 dps_results: {
@@ -316,64 +335,104 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 480.61019
-  tps: 504.7873
+  dps: 480.57571
+  tps: 504.7627
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
+<<<<<<< HEAD
   dps: 1936.08848
   tps: 1991.03207
+=======
+  dps: 1349.95106
+  tps: 1395.63708
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
+<<<<<<< HEAD
   dps: 1960.90498
   tps: 2015.28819
+=======
+  dps: 1339.55725
+  tps: 1384.33682
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
+<<<<<<< HEAD
   dps: 1961.28827
   tps: 2014.69678
+=======
+  dps: 1368.65752
+  tps: 1413.35154
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
+<<<<<<< HEAD
   dps: 3853.7958
   tps: 3941.40278
+=======
+  dps: 2752.28291
+  tps: 2830.8899
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 2834.42939
   tps: 2920.5475
+=======
+  dps: 2369.63131
+  tps: 2452.22903
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
+<<<<<<< HEAD
   dps: 3574.94518
   tps: 3661.03017
+=======
+  dps: 2993.92478
+  tps: 3078.15317
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
+<<<<<<< HEAD
   dps: 1567.42737
   tps: 1607.41021
+=======
+  dps: 1229.36583
+  tps: 1264.45167
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 3926.74987
   tps: 4011.71845
+=======
+  dps: 3118.40928
+  tps: 3204.00087
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -463,7 +522,12 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3702.74471
   tps: 3787.20674
+=======
+  dps: 2942.11923
+  tps: 3026.46021
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/paladin/soc.go
+++ b/sim/paladin/soc.go
@@ -116,7 +116,6 @@ func (paladin *Paladin) registerSealOfCommand() {
 						spell.DealDamage(sim, result)
 					},
 				})
-
 			},
 		})
 

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.10086
+  weights: 0.10247
   weights: 0
-  weights: 0.28841
-  weights: 0
-  weights: 0
+  weights: 0.28779
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22232
   weights: 0
   weights: 0
-  weights: 0.37114
+  weights: 0.22206
+  weights: 0
+  weights: 0
+  weights: 0.36995
   weights: 0
   weights: 0
   weights: 0
@@ -298,18 +298,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.23153
+  weights: 0.01233
   weights: 0
-  weights: 0.80259
-  weights: 0
-  weights: 0
+  weights: 0.80115
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.80259
   weights: 0
   weights: 0
-  weights: 1.82422
+  weights: 0.80115
+  weights: 0
+  weights: 0
+  weights: 1.78676
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.55838
+  weights: 0.34297
   weights: 0
-  weights: 1.11177
-  weights: 0
-  weights: 0
+  weights: 1.11123
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.11177
   weights: 0
   weights: 0
-  weights: 8.24006
+  weights: 1.11123
+  weights: 0
+  weights: 0
+  weights: 8.2918
   weights: 0
   weights: 0
   weights: 0
@@ -398,16 +398,16 @@ stat_weights_results: {
   weights: 0
   weights: 0.34437
   weights: 0
-  weights: 1.9798
+  weights: 1.97984
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.9798
+  weights: 1.97984
   weights: 0
   weights: 0
-  weights: 23.35755
+  weights: 23.35429
   weights: 0
   weights: 0
   weights: 0
@@ -447,16 +447,27 @@ stat_weights_results: {
   weights: 0
   weights: 0.42382
   weights: 0
+<<<<<<< HEAD
   weights: 1.94097
+=======
+  weights: 1.96496
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 1.94097
   weights: 0
   weights: 0
   weights: 30.234
+=======
+  weights: 1.96496
+  weights: 0
+  weights: 0
+  weights: 27.83851
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -491,106 +502,106 @@ stat_weights_results: {
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-AllItems-VestmentsoftheVirtuous"
  value: {
-  dps: 54.36306
-  tps: 57.47404
+  dps: 54.36378
+  tps: 57.48017
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 96.08593
-  tps: 80.74056
+  dps: 96.12764
+  tps: 80.78292
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 102.91958
-  tps: 177.14688
+  dps: 102.83634
+  tps: 177.16043
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 102.91958
-  tps: 87.65574
+  dps: 102.83634
+  tps: 87.66928
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 115.02908
+  dps: 114.61423
   tps: 104.90497
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 67.86099
-  tps: 142.30149
+  dps: 67.79886
+  tps: 142.29871
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 67.86099
-  tps: 59.23709
+  dps: 67.79886
+  tps: 59.23431
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 87.79327
-  tps: 79.72751
+  dps: 86.65417
+  tps: 79.36138
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 96.42072
-  tps: 169.16059
+  dps: 96.40348
+  tps: 169.24013
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 96.42072
-  tps: 80.81894
+  dps: 96.40348
+  tps: 80.89848
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 112.87632
+  dps: 112.4646
   tps: 101.30099
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 66.15934
-  tps: 139.41962
+  dps: 66.16485
+  tps: 139.48447
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 66.15934
-  tps: 57.40022
+  dps: 66.16485
+  tps: 57.46507
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 84.48138
-  tps: 76.36982
+  dps: 84.13832
+  tps: 76.26142
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 96.42072
-  tps: 80.81894
+  dps: 96.40348
+  tps: 80.89848
  }
 }
 dps_results: {
@@ -603,145 +614,145 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 616.49393
-  tps: 491.92817
+  dps: 616.36966
+  tps: 491.91368
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 615.01434
-  tps: 778.46208
+  dps: 614.07089
+  tps: 777.97399
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 615.01434
-  tps: 490.45125
+  dps: 614.07089
+  tps: 489.91091
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 589.29676
+  dps: 588.09828
   tps: 476.17304
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 418.54616
+  dps: 418.40522
   tps: 536.81367
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 418.54616
+  dps: 418.40522
   tps: 332.12354
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 457.99676
+  dps: 457.29279
   tps: 369.58089
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 615.47117
-  tps: 776.37738
+  dps: 615.76983
+  tps: 776.9357
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 615.47117
-  tps: 490.44925
+  dps: 615.76983
+  tps: 490.95531
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 588.13719
+  dps: 586.93871
   tps: 475.20992
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 412.36962
+  dps: 412.32511
   tps: 529.29259
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 412.36962
+  dps: 412.32511
   tps: 327.01546
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 458.42658
-  tps: 369.45174
+  dps: 456.71813
+  tps: 369.12507
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 618.41339
-  tps: 492.85567
+  dps: 618.26167
+  tps: 493.04169
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-AllItems-VestmentsoftheVirtuous"
  value: {
   dps: 298.82108
-  tps: 238.63274
+  tps: 238.56474
   hps: 4.65023
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1281.32454
-  tps: 1028.97747
-  hps: 11.81188
+  dps: 1281.42357
+  tps: 1029.17891
+  hps: 11.8172
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1742.95137
-  tps: 1780.49978
-  hps: 11.40421
+  dps: 1732.82807
+  tps: 1772.61738
+  hps: 11.40193
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 1282.34742
-  tps: 1027.35516
-  hps: 12.27402
+  dps: 1282.66557
+  tps: 1028.2553
+  hps: 12.31728
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 1302.93738
-  tps: 978.63613
+  dps: 1300.70233
+  tps: 979.992
   hps: 13.25709
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 846.9925
+  dps: 846.70858
   tps: 920.27959
   hps: 6.611
  }
@@ -749,7 +760,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 722.76441
+  dps: 722.48049
   tps: 573.28679
   hps: 7.98433
  }
@@ -757,39 +768,39 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 874.7396
-  tps: 662.43288
+  dps: 873.56163
+  tps: 663.44907
   hps: 10.59667
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1710.0167
-  tps: 1748.83591
-  hps: 10.97158
+  dps: 1704.92405
+  tps: 1744.54468
+  hps: 10.98296
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 1270.77231
-  tps: 1020.652
-  hps: 12.06226
+  dps: 1268.61862
+  tps: 1019.35976
+  hps: 12.01216
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 1305.11635
-  tps: 981.88624
+  dps: 1302.96122
+  tps: 983.21613
   hps: 12.88138
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 833.14527
+  dps: 832.86134
   tps: 906.45084
   hps: 6.382
  }
@@ -797,7 +808,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 708.24001
+  dps: 707.95608
   tps: 559.99959
   hps: 7.84917
  }
@@ -805,115 +816,115 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 871.84474
-  tps: 660.59867
+  dps: 870.66677
+  tps: 661.06158
   hps: 10.31042
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1272.37092
-  tps: 1021.98242
-  hps: 12.05543
+  dps: 1272.78351
+  tps: 1022.84238
+  hps: 12.05315
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-BenevolentProphet'sVestments"
  value: {
-  dps: 2126.29383
-  tps: 2033.16304
+  dps: 2126.49565
+  tps: 2033.42716
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1688.98217
-  tps: 1611.68948
+  dps: 1689.64903
+  tps: 1612.46481
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-BloodGuard'sSatin"
  value: {
-  dps: 1558.71791
-  tps: 1488.94578
+  dps: 1559.34915
+  tps: 1489.70529
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1679.73166
-  tps: 1602.89623
+  dps: 1680.39558
+  tps: 1603.67164
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-EmeraldWovenGarb"
  value: {
-  dps: 1557.4136
-  tps: 1487.69049
+  dps: 1558.04483
+  tps: 1488.45221
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 648.20512
-  tps: 593.36248
+  dps: 648.42626
+  tps: 593.6857
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1688.98217
-  tps: 1611.68948
+  dps: 1689.64903
+  tps: 1612.46481
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-KnightLieutenant'sSatin"
  value: {
-  dps: 1558.71791
-  tps: 1488.94578
+  dps: 1559.34915
+  tps: 1489.70529
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 2254.26355
-  tps: 2154.03071
+  dps: 2254.67408
+  tps: 2154.47919
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-VestmentsoftheVirtuous"
  value: {
-  dps: 644.45295
-  tps: 590.44256
+  dps: 644.67171
+  tps: 590.783
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3510.82658
-  tps: 3265.85244
+  dps: 3510.88314
+  tps: 3265.97672
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3995.98038
-  tps: 4279.00851
+  dps: 3996.6475
+  tps: 4279.64612
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3476.141
-  tps: 3223.75763
+  dps: 3476.28302
+  tps: 3224.05184
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3387.95166
-  tps: 2998.6868
+  dps: 3389.89741
+  tps: 3001.01242
  }
 }
 dps_results: {
@@ -927,35 +938,35 @@ dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 1902.24623
-  tps: 1756.9813
+  tps: 1757.04003
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 1873.77846
-  tps: 1646.58506
+  tps: 1646.93962
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4007.86357
-  tps: 4299.88601
+  dps: 4008.20427
+  tps: 4301.0732
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3476.4059
-  tps: 3224.70284
+  dps: 3476.54792
+  tps: 3224.98899
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3404.81164
-  tps: 3015.31425
+  dps: 3405.57243
+  tps: 3016.50038
  }
 }
 dps_results: {
@@ -969,119 +980,149 @@ dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 1891.30226
-  tps: 1747.00843
+  tps: 1747.07064
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 1873.40315
-  tps: 1647.02887
+  tps: 1647.42805
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3485.41477
-  tps: 3236.61612
+  dps: 3485.55679
+  tps: 3236.88414
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-BenevolentProphet'sVestments"
  value: {
+<<<<<<< HEAD
   dps: 2335.91271
   tps: 2227.53962
+=======
+  dps: 2339.77063
+  tps: 2230.72208
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1825.07351
-  tps: 1738.31782
+  dps: 1825.43916
+  tps: 1738.9453
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-BloodGuard'sSatin"
  value: {
-  dps: 1689.21752
-  tps: 1610.39791
+  dps: 1689.5632
+  tps: 1611.0355
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1815.68343
-  tps: 1729.35988
+  dps: 1816.04743
+  tps: 1729.99143
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-EmeraldWovenGarb"
  value: {
-  dps: 1688.60046
-  tps: 1609.5553
+  dps: 1688.94615
+  tps: 1610.20634
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
   dps: 679.84452
-  tps: 622.33219
+  tps: 622.2118
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1825.07351
-  tps: 1738.31782
+  dps: 1825.43916
+  tps: 1738.9453
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-KnightLieutenant'sSatin"
  value: {
-  dps: 1689.21752
-  tps: 1610.39791
+  dps: 1689.5632
+  tps: 1611.0355
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
+<<<<<<< HEAD
   dps: 2465.39193
   tps: 2350.2287
+=======
+  dps: 2468.35838
+  tps: 2352.51326
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-VestmentsoftheVirtuous"
  value: {
   dps: 676.30735
-  tps: 619.25154
+  tps: 619.10013
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 3914.62348
   tps: 3626.24544
+=======
+  dps: 3918.64643
+  tps: 3629.71538
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 4189.06643
   tps: 4435.68704
+=======
+  dps: 4434.1366
+  tps: 4683.94824
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3874.55468
   tps: 3582.47598
+=======
+  dps: 3857.45891
+  tps: 3563.55356
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3703.2354
   tps: 3241.19119
+=======
+  dps: 3632.42887
+  tps: 3174.76823
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -1094,78 +1135,133 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2081.87622
   tps: 1910.90014
+=======
+  dps: 2062.85401
+  tps: 1893.57013
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2029.10804
   tps: 1765.71297
+=======
+  dps: 1982.89008
+  tps: 1721.6348
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 5034.2917
   tps: 5119.52352
+=======
+  dps: 5216.21889
+  tps: 5306.38561
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3965.34789
   tps: 3667.69722
+=======
+  dps: 3912.72208
+  tps: 3617.62322
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3779.5716
   tps: 3316.71282
+=======
+  dps: 3717.42105
+  tps: 3262.48295
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 2652.40787
   tps: 2902.74447
+=======
+  dps: 2763.2097
+  tps: 3015.39144
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2222.39335
   tps: 2045.77252
+=======
+  dps: 2195.91095
+  tps: 2021.6617
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2144.49094
   tps: 1872.27435
+=======
+  dps: 2107.78318
+  tps: 1841.95274
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 4168.95251
   tps: 4430.15716
+=======
+  dps: 4425.27449
+  tps: 4691.33686
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3867.68545
   tps: 3576.98332
+=======
+  dps: 3856.25706
+  tps: 3563.1549
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3696.20063
   tps: 3237.40171
+=======
+  dps: 3634.1335
+  tps: 3179.50921
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -1178,36 +1274,61 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2077.36901
   tps: 1906.72999
+=======
+  dps: 2063.15235
+  tps: 1894.04955
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2025.49982
   tps: 1763.01039
+=======
+  dps: 1981.01144
+  tps: 1720.65405
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
+<<<<<<< HEAD
   dps: 5016.68517
   tps: 5110.17357
+=======
+  dps: 5210.02207
+  tps: 5315.8219
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3959.50541
   tps: 3662.536
+=======
+  dps: 3909.2988
+  tps: 3614.62377
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 3776.21259
   tps: 3317.03148
+=======
+  dps: 3721.3485
+  tps: 3265.83753
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -1220,21 +1341,36 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2218.56131
   tps: 2042.26223
+=======
+  dps: 2194.3593
+  tps: 2020.24743
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
+<<<<<<< HEAD
   dps: 2140.00882
   tps: 1870.06062
+=======
+  dps: 2108.08504
+  tps: 1842.21169
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3888.09149
   tps: 3599.02151
+=======
+  dps: 3870.74747
+  tps: 3581.50946
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -99,8 +99,13 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestAssassination-Phase1-Lvl25-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 0.30636
   weights: 0.51894
+=======
+  weights: 0.30671
+  weights: 0.51635
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +121,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.27851
   weights: 2.52031
   weights: 2.19659
+=======
+  weights: 0.27882
+  weights: 2.44347
+  weights: 2.20513
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +159,13 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestAssassination-Phase2-Lvl40-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 0.37853
   weights: 0.62929
+=======
+  weights: 0.37642
+  weights: 0.63155
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +181,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.34412
   weights: 5.18188
   weights: 4.2533
+=======
+  weights: 0.3422
+  weights: 5.13646
+  weights: 4.25831
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -197,15 +219,20 @@ stat_weights_results: {
 dps_results: {
  key: "TestAssassination-Phase1-Lvl25-AllItems-DarkmantleArmor"
  value: {
-  dps: 145.02684
-  tps: 102.96905
+  dps: 144.79724
+  tps: 102.80604
  }
 }
 dps_results: {
  key: "TestAssassination-Phase1-Lvl25-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 273.75018
   tps: 194.36263
+=======
+  dps: 273.93883
+  tps: 194.49657
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -295,22 +322,32 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 261.66137
   tps: 185.77957
+=======
+  dps: 262.42642
+  tps: 186.32276
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestAssassination-Phase2-Lvl40-AllItems-DarkmantleArmor"
  value: {
-  dps: 207.55559
-  tps: 147.36447
+  dps: 207.17383
+  tps: 147.09342
  }
 }
 dps_results: {
  key: "TestAssassination-Phase2-Lvl40-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 570.02535
   tps: 404.718
+=======
+  dps: 568.22362
+  tps: 403.43877
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -400,7 +437,7 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 548.88284
-  tps: 389.70681
+  dps: 548.13568
+  tps: 389.17633
  }
 }

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestCombat-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.24298
-  weights: 0.45889
+  weights: 0.24272
+  weights: 0.45075
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22089
-  weights: 1.66493
-  weights: 1.81572
+  weights: 0.22065
+  weights: 1.85171
+  weights: 1.82161
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,13 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestCombat-Phase2-Lvl40-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 0.36319
   weights: 0.58576
+=======
+  weights: 0.36203
+  weights: 0.58861
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +170,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.33018
   weights: 3.66536
   weights: 3.68081
+=======
+  weights: 0.32912
+  weights: 3.77625
+  weights: 3.66549
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -197,15 +208,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestCombat-Phase1-Lvl25-AllItems-DarkmantleArmor"
  value: {
-  dps: 259.43493
-  tps: 184.1988
+  dps: 258.17768
+  tps: 183.30616
  }
 }
 dps_results: {
  key: "TestCombat-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 214.7804
-  tps: 152.49408
+  dps: 214.72666
+  tps: 152.45593
  }
 }
 dps_results: {
@@ -295,22 +306,27 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 202.00453
-  tps: 143.42322
+  dps: 202.00594
+  tps: 143.42422
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-AllItems-DarkmantleArmor"
  value: {
-  dps: 265.13611
-  tps: 188.24664
+  dps: 264.57647
+  tps: 187.8493
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 522.66673
   tps: 371.09338
+=======
+  dps: 521.93013
+  tps: 370.57039
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -400,7 +416,12 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 500.5303
   tps: 355.37652
+=======
+  dps: 498.30008
+  tps: 353.79306
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -298,18 +298,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.98263
+  weights: 1.0974
   weights: 0
-  weights: 0.83676
+  weights: 0.837
   weights: 0
-  weights: 0.25479
-  weights: 0
-  weights: 0
-  weights: 0.58198
+  weights: 0.25475
   weights: 0
   weights: 0
-  weights: 6.81858
-  weights: 3.26972
+  weights: 0.58225
+  weights: 0
+  weights: 0
+  weights: 6.95667
+  weights: 3.28275
   weights: 0
   weights: 0
   weights: 0
@@ -396,9 +396,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.19735
+  weights: 2.19734
   weights: 0
-  weights: 1.73101
+  weights: 1.731
   weights: 0
   weights: 0.54471
   weights: 0
@@ -407,7 +407,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 30.70618
-  weights: 16.11833
+  weights: 16.1169
   weights: 0
   weights: 0
   weights: 0
@@ -491,8 +491,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 197.03751
-  tps: 157.08273
+  dps: 197.0368
+  tps: 157.08202
  }
 }
 dps_results: {
@@ -589,8 +589,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 601.44136
-  tps: 505.87897
+  dps: 601.437
+  tps: 505.88737
  }
 }
 dps_results: {
@@ -680,15 +680,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 596.84955
-  tps: 504.58152
+  dps: 596.75114
+  tps: 504.33358
  }
 }
 dps_results: {
  key: "TestElemental-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1515.21219
-  tps: 1315.48896
+  dps: 1515.21218
+  tps: 1315.48894
  }
 }
 dps_results: {
@@ -848,8 +848,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3226.24543
-  tps: 1972.8315
+  dps: 3226.24581
+  tps: 1972.83162
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -246,8 +246,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.34792
-  weights: 0.24153
+  weights: 0.34791
+  weights: 0.24781
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.15815
-  weights: 1.33554
-  weights: 1.66171
+  weights: 0.15814
+  weights: 1.33335
+  weights: 1.68198
   weights: 0
   weights: 0
   weights: 0
@@ -295,16 +295,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 1.01354
-  weights: 0.85346
+  weights: 1.01243
+  weights: 0.40709
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37164
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.3719
   weights: 0
   weights: 0
   weights: 0
@@ -312,9 +308,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.4607
-  weights: 3.73667
-  weights: 7.28111
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.46019
+  weights: 3.14901
+  weights: 6.81633
   weights: 0
   weights: 0
   weights: 0
@@ -344,16 +344,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.60272
-  weights: 0.76683
+  weights: 1.60127
+  weights: 0.61636
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43084
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.43188
   weights: 0
   weights: 0
   weights: 0
@@ -361,9 +357,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.67455
-  weights: 6.62175
-  weights: 10.15468
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.67393
+  weights: 5.63375
+  weights: 10.11767
   weights: 0
   weights: 0
   weights: 0
@@ -393,16 +393,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.07498
-  weights: 0.50573
+  weights: 2.07157
+  weights: 0.20361
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.76241
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.75973
   weights: 0
   weights: 0
   weights: 0
@@ -410,9 +406,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.94317
-  weights: 29.15617
-  weights: 10.97165
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.94162
+  weights: 26.60824
+  weights: 9.6735
   weights: 0
   weights: 0
   weights: 0
@@ -442,12 +442,21 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase5-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 2.51507
   weights: 0.78946
   weights: 0
   weights: 0
   weights: 0
   weights: 0.83835
+=======
+  weights: 2.54596
+  weights: 1.56118
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.84282
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -459,9 +468,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.9941
   weights: 28.18901
   weights: 14.0186
+=======
+  weights: 1.00631
+  weights: 22.80671
+  weights: 19.75151
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -491,8 +506,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestEnhancement-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 163.89109
-  tps: 163.05328
+  dps: 163.88671
+  tps: 163.0489
  }
 }
 dps_results: {
@@ -666,15 +681,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 154.97819
-  tps: 154.08401
+  dps: 154.9952
+  tps: 154.10102
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 814.75955
-  tps: 865.86165
+  dps: 814.69254
+  tps: 865.80412
  }
 }
 dps_results: {
@@ -848,15 +863,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 751.67928
-  tps: 798.92317
+  dps: 753.13724
+  tps: 800.85362
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1719.73143
-  tps: 1259.19952
+  dps: 1719.34681
+  tps: 1258.78226
  }
 }
 dps_results: {
@@ -1030,78 +1045,78 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1602.98804
-  tps: 1170.47499
+  dps: 1599.282
+  tps: 1170.67529
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-BloodGuard'sInscribedMail"
  value: {
-  dps: 1851.65307
-  tps: 1876.06964
+  dps: 1849.47794
+  tps: 1875.79395
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 1920.47366
-  tps: 1943.59256
+  dps: 1918.07366
+  tps: 1943.13934
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-BloodGuard'sPulsingMail"
  value: {
-  dps: 1976.34323
-  tps: 2004.6623
+  dps: 1956.08072
+  tps: 1982.90661
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-EmeraldChainmail"
  value: {
-  dps: 1897.14554
-  tps: 1921.44245
+  dps: 1894.62572
+  tps: 1921.1968
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-EmeraldLadenChain"
  value: {
-  dps: 1851.17435
-  tps: 1875.55821
+  dps: 1848.4291
+  tps: 1875.01903
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 1898.2085
-  tps: 1921.67734
+  dps: 1895.23608
+  tps: 1920.91075
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-OstracizedBerserker'sBattlemail"
  value: {
-  dps: 2798.9139
-  tps: 2856.00767
+  dps: 2810.13676
+  tps: 2870.68055
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-ShunnedDevotee'sChainmail"
  value: {
-  dps: 2740.59115
-  tps: 2798.17715
+  dps: 2755.81179
+  tps: 2818.85444
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-TheFiveThunders"
  value: {
-  dps: 1515.63934
-  tps: 1548.20316
+  dps: 1521.68227
+  tps: 1555.65418
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3723.99979
-  tps: 2658.73994
+  dps: 3721.81576
+  tps: 2657.21696
  }
 }
 dps_results: {
@@ -1443,78 +1458,128 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3007.68156
-  tps: 2149.26574
+  dps: 3014.34786
+  tps: 2149.12888
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-BloodGuard'sInscribedMail"
  value: {
+<<<<<<< HEAD
   dps: 1950.337
   tps: 1968.3169
+=======
+  dps: 1979.27863
+  tps: 1992.81211
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-BloodGuard'sMail"
  value: {
+<<<<<<< HEAD
   dps: 2026.11203
   tps: 2042.72108
+=======
+  dps: 2057.53218
+  tps: 2069.50876
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-BloodGuard'sPulsingMail"
  value: {
+<<<<<<< HEAD
   dps: 2070.91439
   tps: 2087.74756
+=======
+  dps: 2088.99242
+  tps: 2109.42823
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-EmeraldChainmail"
  value: {
+<<<<<<< HEAD
   dps: 1999.11383
   tps: 2016.73964
+=======
+  dps: 2029.82842
+  tps: 2042.70373
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-EmeraldLadenChain"
  value: {
+<<<<<<< HEAD
   dps: 1949.461
   tps: 1967.5402
+=======
+  dps: 1979.02704
+  tps: 1992.53095
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-EmeraldScalemail"
  value: {
+<<<<<<< HEAD
   dps: 1995.7668
   tps: 2012.9365
+=======
+  dps: 2026.58387
+  tps: 2039.15131
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-OstracizedBerserker'sBattlemail"
  value: {
+<<<<<<< HEAD
   dps: 3199.57164
   tps: 3250.77537
+=======
+  dps: 3207.20469
+  tps: 3267.6081
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-ShunnedDevotee'sChainmail"
  value: {
+<<<<<<< HEAD
   dps: 3136.17647
   tps: 3190.58288
+=======
+  dps: 3139.7437
+  tps: 3202.24386
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-TheFiveThunders"
  value: {
+<<<<<<< HEAD
   dps: 1590.68827
   tps: 1620.33677
+=======
+  dps: 1598.66403
+  tps: 1632.41588
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 4350.04005
   tps: 3099.42381
+=======
+  dps: 4339.34794
+  tps: 3091.62434
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -1856,7 +1921,12 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3589.80429
   tps: 2552.58564
+=======
+  dps: 3599.40249
+  tps: 2558.78152
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/shaman/warden/TestWardenShaman.results
+++ b/sim/shaman/warden/TestWardenShaman.results
@@ -50,24 +50,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestWardenShaman-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 1.10709
+  weights: 1.10733
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.48758
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0.50322
+  weights: 0.48821
   weights: 0
   weights: 0
   weights: 0
@@ -78,7 +66,19 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.94812
+  weights: 0
+  weights: 0.50333
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.95019
   weights: 0
   weights: 0
   weights: 0
@@ -99,64 +99,64 @@ stat_weights_results: {
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-BloodGuard'sInscribedMail"
  value: {
-  dps: 1129.45538
-  tps: 1170.54804
+  dps: 1130.37677
+  tps: 1171.93995
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 1177.31269
-  tps: 1216.89486
+  dps: 1178.21861
+  tps: 1218.20431
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-BloodGuard'sPulsingMail"
  value: {
-  dps: 1170.38676
-  tps: 1213.41062
+  dps: 1169.52495
+  tps: 1212.63273
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-EmeraldChainmail"
  value: {
-  dps: 1156.94948
-  tps: 1197.98387
+  dps: 1157.93481
+  tps: 1199.37725
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-EmeraldLadenChain"
  value: {
-  dps: 1129.28813
-  tps: 1170.02297
+  dps: 1130.20952
+  tps: 1171.32503
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 1162.03191
-  tps: 1201.90605
+  dps: 1162.94275
+  tps: 1203.1976
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-OstracizedBerserker'sBattlemail"
  value: {
-  dps: 1733.09486
-  tps: 1923.79469
+  dps: 1734.01986
+  tps: 1924.86118
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-TheFiveThunders"
  value: {
-  dps: 1031.91261
-  tps: 1064.15773
+  dps: 1032.16452
+  tps: 1064.34119
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 1945.48666
-  tps: 1558.48667
+  dps: 1945.40033
+  tps: 1558.35717
  }
 }
 dps_results: {
@@ -246,7 +246,7 @@ dps_results: {
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1676.85039
-  tps: 1363.68216
+  dps: 1678.84637
+  tps: 1366.52146
  }
 }

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.35323
+  weights: -2.23037
   weights: 0
-  weights: 1.21386
-  weights: 0
-  weights: 0
+  weights: 0.82749
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 13.02962
-  weights: 10.2224
+  weights: 0
+  weights: 0
+  weights: 12.68882
+  weights: 10.58563
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Phase1-Lvl25-AllItems-DeathmistRaiment"
  value: {
-  dps: 127.14306
-  tps: 104.02001
+  dps: 127.14277
+  tps: 104.02084
  }
 }
 dps_results: {
@@ -267,78 +267,78 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1466.14183
-  tps: 1700.27973
+  dps: 1468.46347
+  tps: 1704.48836
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 1290.64359
-  tps: 1466.41987
+  dps: 1287.45869
+  tps: 1463.26225
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1455.19224
-  tps: 1685.58911
+  dps: 1452.05859
+  tps: 1677.9522
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 1994.08044
-  tps: 3968.83875
+  dps: 1995.79641
+  tps: 3961.39606
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 1238.32529
-  tps: 1393.08421
+  dps: 1237.50858
+  tps: 1395.06028
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 1976.71094
-  tps: 3940.1778
+  dps: 1976.7724
+  tps: 3928.99779
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1466.14183
-  tps: 1700.27973
+  dps: 1468.46347
+  tps: 1704.48836
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1638.79406
-  tps: 3278.1879
+  dps: 1643.14514
+  tps: 3290.60963
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1616.44151
-  tps: 3225.40016
+  dps: 1619.30817
+  tps: 3229.97996
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 1992.14926
-  tps: 3968.83875
+  dps: 1993.91348
+  tps: 3961.39606
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2016.49578
-  tps: 4011.9689
+  dps: 2016.3894
+  tps: 4011.14971
  }
 }
 dps_results: {
@@ -386,7 +386,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1967.58015
-  tps: 3905.17213
+  dps: 1973.05036
+  tps: 3918.19344
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.55984
+  weights: 3.21349
   weights: 0
-  weights: 1.85685
-  weights: 0
-  weights: 0
+  weights: 1.45493
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 17.01172
-  weights: 8.8908
+  weights: 0
+  weights: 0
+  weights: 19.36688
+  weights: 13.04155
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Phase2-Lvl40-AllItems-DeathmistRaiment"
  value: {
-  dps: 129.81835
-  tps: 144.88996
+  dps: 129.81135
+  tps: 144.88213
  }
 }
 dps_results: {
@@ -211,8 +211,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 361.90423
-  tps: 1085.03784
+  dps: 361.90365
+  tps: 1085.03655
  }
 }
 dps_results: {
@@ -267,8 +267,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1138.59531
-  tps: 433.34571
+  dps: 1143.57956
+  tps: 439.59268
  }
 }
 dps_results: {
@@ -281,15 +281,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1139.40543
-  tps: 440.10116
+  dps: 1132.87223
+  tps: 435.90495
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2212.39829
-  tps: 4552.88934
+  dps: 2212.53865
+  tps: 4570.46869
  }
 }
 dps_results: {
@@ -302,91 +302,91 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 2283.44355
-  tps: 4508.60797
+  dps: 2281.57517
+  tps: 4515.28522
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1138.59531
-  tps: 433.34571
+  dps: 1143.57956
+  tps: 439.59268
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1226.7776
-  tps: 1392.15732
+  dps: 1224.9529
+  tps: 1384.03985
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1208.39807
-  tps: 1371.11636
+  dps: 1213.09309
+  tps: 1380.32209
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2212.39829
-  tps: 4552.88934
+  dps: 2212.53865
+  tps: 4570.46869
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2224.59628
-  tps: 4592.99086
+  dps: 2223.38054
+  tps: 4591.0074
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2802.7323
-  tps: 8636.29423
+  dps: 2803.28523
+  tps: 8643.52803
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2161.97755
-  tps: 4421.3263
+  dps: 2164.89277
+  tps: 4420.34769
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 2138.59165
-  tps: 4401.05935
+  dps: 2138.17889
+  tps: 4402.18279
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1197.32184
+  dps: 1196.00105
   tps: 5398.49904
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 901.78358
+  dps: 900.49345
   tps: 2060.23075
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 902.53661
+  dps: 896.86728
   tps: 2093.08757
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2182.67939
-  tps: 4495.98194
+  dps: 2181.43303
+  tps: 4483.11976
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.16679
+  weights: -0.12449
   weights: 0
-  weights: 0.70239
-  weights: 0
-  weights: 0
+  weights: 0.70121
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.47005
-  weights: 3.33947
+  weights: 0
+  weights: 0
+  weights: 5.63167
+  weights: 3.35675
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.94295
+  weights: 1.27754
   weights: 0
-  weights: 2.03278
-  weights: 0
-  weights: 0
+  weights: 1.66816
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 15.27461
-  weights: 11.90709
+  weights: 0
+  weights: 0
+  weights: 16.5242
+  weights: 12.45582
   weights: 0
   weights: 0
   weights: 0
@@ -393,8 +393,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Phase1-Lvl25-AllItems-DeathmistRaiment"
  value: {
-  dps: 105.2716
-  tps: 68.20073
+  dps: 105.32162
+  tps: 68.66172
  }
 }
 dps_results: {
@@ -463,22 +463,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-AllItems-DeathmistRaiment"
  value: {
-  dps: 143.72003
-  tps: 90.88508
+  dps: 143.71864
+  tps: 90.89054
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 471.12143
-  tps: 1324.67265
+  dps: 471.63877
+  tps: 1325.84737
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 467.45396
-  tps: 1313.67479
+  dps: 467.37423
+  tps: 1313.37879
  }
 }
 dps_results: {
@@ -526,32 +526,32 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 461.20141
-  tps: 1300.21692
+  dps: 461.58637
+  tps: 1301.56464
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-AllItems-DeathmistRaiment"
  value: {
-  dps: 344.46525
-  tps: 228.28192
-  hps: 7.27404
+  dps: 344.27526
+  tps: 228.46012
+  hps: 7.3256
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 1317.32864
-  tps: 2684.22587
-  hps: 11.94084
+  dps: 1317.32886
+  tps: 2684.22626
+  hps: 11.94107
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1316.26654
-  tps: 2680.22524
-  hps: 11.54273
+  dps: 1316.26539
+  tps: 2680.22266
+  hps: 11.54306
  }
 }
 dps_results: {
@@ -605,86 +605,86 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1299.42006
-  tps: 2643.93201
-  hps: 11.69731
+  dps: 1299.42028
+  tps: 2643.9324
+  hps: 11.69753
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1520.02024
-  tps: 1854.53454
+  dps: 1522.46659
+  tps: 1858.58549
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 1332.17163
-  tps: 1598.29642
+  dps: 1337.8832
+  tps: 1610.90965
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1515.92318
-  tps: 1853.45874
+  dps: 1525.6606
+  tps: 1867.8479
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2018.07197
-  tps: 4173.52306
+  dps: 2021.84495
+  tps: 4190.19379
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 1283.14264
-  tps: 1532.59682
+  dps: 1275.02635
+  tps: 1518.05902
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 2011.36919
-  tps: 4168.8194
+  dps: 2010.87578
+  tps: 4171.98596
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1520.02024
-  tps: 1854.53454
+  dps: 1522.46659
+  tps: 1858.58549
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1666.90939
-  tps: 3494.41565
+  dps: 1664.17472
+  tps: 3483.86113
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1659.5448
-  tps: 3480.04968
+  dps: 1664.71966
+  tps: 3490.06343
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2016.19416
-  tps: 4173.52306
+  dps: 2019.88093
+  tps: 4190.19379
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2034.59444
-  tps: 4219.18374
+  dps: 2035.04597
+  tps: 4219.62322
  }
 }
 dps_results: {
@@ -732,7 +732,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1987.31149
-  tps: 4143.74094
+  dps: 1984.5261
+  tps: 4131.05885
  }
 }

--- a/sim/warrior/dps_warrior/TestDualWieldWarrior.results
+++ b/sim/warrior/dps_warrior/TestDualWieldWarrior.results
@@ -148,8 +148,13 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 0.94302
   weights: 1.01776
+=======
+  weights: 0.15476
+  weights: 0.06728
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +170,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.58982
   weights: 7.17749
   weights: 8.54288
+=======
+  weights: 0.70856
+  weights: 8.3972
+  weights: 8.34618
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +208,13 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 2.08894
   weights: 1.0931
+=======
+  weights: 2.05688
+  weights: 1.49111
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +230,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.88147
   weights: 2.81365
   weights: 24.54815
+=======
+  weights: 1.17064
+  weights: 5.56509
+  weights: 24.77705
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -246,8 +268,13 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 1.70501
   weights: 1.00876
+=======
+  weights: 2.43679
+  weights: 2.2539
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +290,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.29549
   weights: 36.03048
   weights: 24.87437
+=======
+  weights: 0.4511
+  weights: 37.40617
+  weights: 24.87821
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -295,15 +328,25 @@ stat_weights_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-AllItems-BattlegearofHeroism"
  value: {
+<<<<<<< HEAD
   dps: 548.19856
   tps: 487.19115
+=======
+  dps: 544.61232
+  tps: 483.391
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 608.16526
   tps: 537.4594
+=======
+  dps: 602.40461
+  tps: 531.86654
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -393,57 +436,97 @@ dps_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 569.57811
   tps: 504.09767
+=======
+  dps: 558.38316
+  tps: 494.13943
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
+<<<<<<< HEAD
   dps: 2639.76655
   tps: 2287.1778
+=======
+  dps: 2624.33508
+  tps: 2269.33451
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-BattlegearofHeroism"
  value: {
+<<<<<<< HEAD
   dps: 1989.92848
   tps: 1756.64517
+=======
+  dps: 1991.27499
+  tps: 1756.92381
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 2383.14096
   tps: 2063.07283
+=======
+  dps: 2365.26854
+  tps: 2047.10204
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
+<<<<<<< HEAD
   dps: 2336.87499
   tps: 2025.53882
+=======
+  dps: 2328.62047
+  tps: 2015.95303
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 2383.14096
   tps: 2063.07283
+=======
+  dps: 2365.26854
+  tps: 2047.10204
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
+<<<<<<< HEAD
   dps: 2797.62709
   tps: 2413.38735
+=======
+  dps: 2792.91699
+  tps: 2408.36246
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 3617.97964
   tps: 2841.24899
+=======
+  dps: 3632.31645
+  tps: 2848.32439
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -533,57 +616,97 @@ dps_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 2840.1998
   tps: 2237.93399
+=======
+  dps: 2845.9041
+  tps: 2238.06542
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
+<<<<<<< HEAD
   dps: 2983.8361
   tps: 2565.68699
+=======
+  dps: 3020.09161
+  tps: 2592.54544
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-BattlegearofHeroism"
  value: {
+<<<<<<< HEAD
   dps: 2065.16729
   tps: 1812.30237
+=======
+  dps: 2062.09291
+  tps: 1805.20125
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 2525.35944
   tps: 2175.23509
+=======
+  dps: 2507.62061
+  tps: 2155.50585
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
+<<<<<<< HEAD
   dps: 2491.20194
   tps: 2147.10994
+=======
+  dps: 2476.65852
+  tps: 2130.17247
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 2525.35944
   tps: 2175.23509
+=======
+  dps: 2507.62061
+  tps: 2155.50585
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
+<<<<<<< HEAD
   dps: 3198.42156
   tps: 2744.70651
+=======
+  dps: 3230.57991
+  tps: 2765.78983
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 4210.88702
   tps: 3277.22592
+=======
+  dps: 4249.54733
+  tps: 3307.20152
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -757,7 +880,12 @@ dps_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3349.17822
   tps: 2599.69152
+=======
+  dps: 3347.93726
+  tps: 2598.48102
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/warrior/dps_warrior/TestTwoHandedWarrior.results
+++ b/sim/warrior/dps_warrior/TestTwoHandedWarrior.results
@@ -99,8 +99,13 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 1.25244
   weights: 0.77304
+=======
+  weights: 1.28559
+  weights: 0.95648
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +121,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.56223
   weights: 16.38978
   weights: 10.07868
+=======
+  weights: 0.50977
+  weights: 15.70656
+  weights: 10.32434
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +159,13 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 3.34876
   weights: 1.0076
+=======
+  weights: 2.49296
+  weights: 1.71557
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +181,15 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 1.03342
   weights: 0
   weights: 22.78528
+=======
+  weights: 1.21324
+  weights: 0
+  weights: 21.79684
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -197,15 +219,25 @@ stat_weights_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-AllItems-BattlegearofHeroism"
  value: {
+<<<<<<< HEAD
   dps: 800.40886
   tps: 693.884
+=======
+  dps: 800.16392
+  tps: 689.24796
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 1166.94161
   tps: 996.96535
+=======
+  dps: 1167.46232
+  tps: 997.40695
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -295,57 +327,92 @@ dps_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 1089.05509
   tps: 930.74883
+=======
+  dps: 1088.03126
+  tps: 933.84753
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
+<<<<<<< HEAD
   dps: 2504.77138
   tps: 2083.76618
+=======
+  dps: 2545.76935
+  tps: 2118.65424
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 1565.42218
-  tps: 1327.72205
+  dps: 1564.08877
+  tps: 1326.46969
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 1873.49327
   tps: 1579.06599
+=======
+  dps: 1875.5336
+  tps: 1581.30015
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
+<<<<<<< HEAD
   dps: 1850.97693
   tps: 1559.77514
+=======
+  dps: 1856.98219
+  tps: 1565.04801
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 1873.49327
   tps: 1579.06599
+=======
+  dps: 1875.5336
+  tps: 1581.30015
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
+<<<<<<< HEAD
   dps: 2726.18727
   tps: 2268.80937
+=======
+  dps: 2748.8116
+  tps: 2286.64528
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 4225.43592
   tps: 3208.61384
+=======
+  dps: 4272.08136
+  tps: 3242.0156
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -519,7 +586,12 @@ dps_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 3474.08653
   tps: 2619.60305
+=======
+  dps: 3517.87953
+  tps: 2649.6422
+>>>>>>> 4b5b2b329... WIP
  }
 }

--- a/sim/warrior/tank_warrior/TestTankWarrior.results
+++ b/sim/warrior/tank_warrior/TestTankWarrior.results
@@ -50,7 +50,11 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestTankWarrior-Phase4-Lvl60-StatWeights-Default"
  value: {
+<<<<<<< HEAD
   weights: 0.67457
+=======
+  weights: 0.85377
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -67,7 +71,11 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.33114
+=======
+  weights: 0.82621
+>>>>>>> 4b5b2b329... WIP
   weights: 0
   weights: 0
   weights: 0
@@ -78,9 +86,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
+<<<<<<< HEAD
   weights: 0.98529
+=======
+  weights: 1.13171
+>>>>>>> 4b5b2b329... WIP
   weights: 0
-  weights: 0.52203
+  weights: 0.52154
   weights: 0
   weights: 0
   weights: 0
@@ -99,50 +111,85 @@ stat_weights_results: {
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
+<<<<<<< HEAD
   dps: 1569.66853
   tps: 3500.40882
+=======
+  dps: 1586.07904
+  tps: 3525.15935
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-BattlegearofHeroism"
  value: {
+<<<<<<< HEAD
   dps: 892.14386
   tps: 1833.87664
+=======
+  dps: 902.35455
+  tps: 1845.64
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 894.06096
   tps: 1873.17485
+=======
+  dps: 904.44731
+  tps: 1890.60573
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
+<<<<<<< HEAD
   dps: 885.04529
   tps: 1854.793
+=======
+  dps: 894.47463
+  tps: 1870.5812
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
+<<<<<<< HEAD
   dps: 894.06096
   tps: 1873.17485
+=======
+  dps: 904.44731
+  tps: 1890.60573
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
+<<<<<<< HEAD
   dps: 1653.52702
   tps: 3604.66287
+=======
+  dps: 1668.33762
+  tps: 3628.69782
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-Average-Default"
  value: {
+<<<<<<< HEAD
   dps: 1489.19615
   tps: 3861.70571
+=======
+  dps: 1511.07433
+  tps: 3944.29896
+>>>>>>> 4b5b2b329... WIP
  }
 }
 dps_results: {
@@ -232,7 +279,12 @@ dps_results: {
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
+<<<<<<< HEAD
   dps: 1268.18215
   tps: 3318.34203
+=======
+  dps: 1287.29087
+  tps: 3394.30304
+>>>>>>> 4b5b2b329... WIP
  }
 }


### PR DESCRIPTION
Rework WS to work like https://github.com/magey/classic-warrior/wiki/Windfury-Totem#triggered-by-melee-spell
Autos have a cast batch where damage and result are calculated, and a damage batch where autos are applied.

This should allow two Instant stike GCD's in a row to proc WS with the second ability benefiting from the AP of the first proc.
(Same for autos but harder to time / align)

Refactored WS/ WF totem to share the same helper function code.

Still need to prevent WS/WF AP from turning off in the middle of a batch though.