### PR TITLE
ws wf rework

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -2208,6 +2208,16 @@ func CreateExtraAttackAuraCommon(character *Character, buffActionID ActionID, au
 		},
 	})
 
+	MakePermanent(character.GetOrRegisterAura(Aura{
+		Label:     "Extra Attacks  (Main Hand)", // Tracks Stored Extra Attacks from all sources
+		ActionID:  ActionID{SpellID: 21919},     // Thrash ID
+		Duration:  NeverExpires,
+		MaxStacks: 4, // Max is 4 extra attacks stored - more can proc after
+		OnInit: func(aura *Aura, sim *Simulation) {
+			aura.Unit.AutoAttacks.mh.extraAttacksAura = aura
+		},
+	}))
+
 	icd := Cooldown{
 		Timer:    character.NewTimer(),
 		Duration: time.Millisecond * 1500,

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -398,7 +398,7 @@ stat_weights_results: {
   weights: 0
   weights: 1.10524
   weights: 0
-  weights: 2.25477
+  weights: 2.25465
   weights: 0
   weights: 0
   weights: 0
@@ -407,7 +407,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 25.3384
+  weights: 25.20328
   weights: 0
   weights: 0
   weights: 0
@@ -445,18 +445,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 3.92936
+  weights: -0.9318
   weights: 0
-  weights: 2.8038
-  weights: 0
-  weights: 0
+  weights: 2.80172
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 31.87271
+  weights: 0
+  weights: 0
+  weights: 32.8774
   weights: 0
   weights: 0
   weights: 0
@@ -491,8 +491,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestBalance-Phase1-Lvl25-AllItems-FeralheartRaiment"
  value: {
-  dps: 129.05782
-  tps: 132.75738
+  dps: 128.99265
+  tps: 132.69221
  }
 }
 dps_results: {
@@ -596,15 +596,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase2-Lvl40-AllItems-FeralheartRaiment"
  value: {
-  dps: 229.02538
-  tps: 237.64656
+  dps: 228.80605
+  tps: 237.41348
  }
 }
 dps_results: {
  key: "TestBalance-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 796.90159
-  tps: 807.49703
+  dps: 796.9008
+  tps: 807.49563
  }
 }
 dps_results: {
@@ -701,8 +701,8 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase3-Lvl50-AllItems-FeralheartRaiment"
  value: {
-  dps: 516.29889
-  tps: 530.99873
+  dps: 513.05217
+  tps: 527.73084
  }
 }
 dps_results: {
@@ -806,99 +806,99 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1165.60644
-  tps: 1183.59817
+  dps: 1165.11917
+  tps: 1183.22777
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1098.5406
-  tps: 1116.8667
+  dps: 1098.12446
+  tps: 1116.52313
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1064.35076
-  tps: 1082.07195
+  dps: 1060.54319
+  tps: 1078.29287
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 1477.49591
-  tps: 1496.37398
+  dps: 1479.45239
+  tps: 1498.36239
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1067.49526
-  tps: 1085.24595
+  dps: 1061.76008
+  tps: 1079.52942
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1097.69992
-  tps: 1116.02602
+  dps: 1097.27798
+  tps: 1115.67665
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1124.23985
-  tps: 1141.97581
+  dps: 1123.80127
+  tps: 1141.5657
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 1496.92788
-  tps: 1515.60804
+  dps: 1493.98014
+  tps: 1512.65415
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1064.60722
-  tps: 1083.64351
+  dps: 1067.18806
+  tps: 1086.30727
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1165.60644
-  tps: 1183.59817
+  dps: 1165.11917
+  tps: 1183.22777
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1098.5406
-  tps: 1116.8667
+  dps: 1098.12446
+  tps: 1116.52313
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1064.35076
-  tps: 1082.07195
+  dps: 1060.54319
+  tps: 1078.29287
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 1582.83825
-  tps: 1601.75565
+  dps: 1584.24982
+  tps: 1603.19425
  }
 }
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3247.31308
-  tps: 3267.37442
+  dps: 3247.34948
+  tps: 3267.41645
  }
 }
 dps_results: {
@@ -988,127 +988,127 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3232.22269
-  tps: 3252.53152
+  dps: 3232.20963
+  tps: 3252.52236
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1455.56308
-  tps: 1473.86342
+  dps: 1458.56635
+  tps: 1476.92569
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1358.26671
-  tps: 1376.56213
+  dps: 1356.31886
+  tps: 1374.65362
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1343.59594
-  tps: 1361.7537
+  dps: 1336.39897
+  tps: 1354.57148
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 1985.95491
-  tps: 1909.73142
+  dps: 1986.97173
+  tps: 1911.79031
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1337.21196
-  tps: 1355.35989
+  dps: 1341.96291
+  tps: 1360.16
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1357.25936
-  tps: 1375.55478
+  dps: 1355.30376
+  tps: 1373.63852
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1409.48676
-  tps: 1427.61502
+  dps: 1405.97594
+  tps: 1424.1337
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 2006.51813
-  tps: 1932.86682
+  dps: 2020.54896
+  tps: 1944.32665
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1233.94838
-  tps: 1252.21505
+  dps: 1232.66017
+  tps: 1250.94651
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1455.56308
-  tps: 1473.86342
+  dps: 1458.56635
+  tps: 1476.92569
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1358.26671
-  tps: 1376.56213
+  dps: 1356.31886
+  tps: 1374.65362
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1343.59594
-  tps: 1361.7537
+  dps: 1336.39897
+  tps: 1354.57148
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 2115.31368
-  tps: 2046.6765
+  dps: 2108.77655
+  tps: 2042.51355
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4446.85589
-  tps: 4313.6568
+  dps: 4447.03401
+  tps: 4313.98692
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-NightElf-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 6292.06844
-  tps: 6580.45494
+  dps: 6296.28259
+  tps: 6584.47242
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-NightElf-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 4379.56936
-  tps: 4235.84152
+  dps: 4385.38379
+  tps: 4242.37957
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-NightElf-phase_5-Default-phase_5-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
   dps: 4222.63132
-  tps: 4117.93599
+  tps: 4117.91141
  }
 }
 dps_results: {
@@ -1135,22 +1135,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-Tauren-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 6203.10095
-  tps: 6489.94194
+  dps: 6201.30625
+  tps: 6487.45891
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-Tauren-phase_5-Default-phase_5-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 4372.06913
-  tps: 4229.57036
+  dps: 4381.59552
+  tps: 4238.80736
  }
 }
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-Settings-Tauren-phase_5-Default-phase_5-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
   dps: 4231.66386
-  tps: 4127.59461
+  tps: 4127.57003
  }
 }
 dps_results: {
@@ -1177,7 +1177,7 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4406.98674
-  tps: 4263.39961
+  dps: 4412.50121
+  tps: 4268.70275
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -246,8 +246,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestFeral-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.57599
-  weights: 0.51714
+  weights: 0.57675
+  weights: 0.52797
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.26181
-  weights: 2.01408
-  weights: 2.19334
+  weights: 0.26216
+  weights: 2.3139
+  weights: 2.24627
   weights: 0
   weights: 0
   weights: 0
@@ -295,8 +295,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.94603
-  weights: 0.83019
+  weights: 0.94445
+  weights: 1.02691
   weights: 0
   weights: 0
   weights: 0
@@ -312,9 +312,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.4135
-  weights: 3.97162
-  weights: 5.41439
+  weights: 0.41281
+  weights: 4.83242
+  weights: 5.45266
   weights: 0
   weights: 0
   weights: 0
@@ -344,8 +344,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.51843
-  weights: 1.61996
+  weights: 1.51638
+  weights: 1.61816
   weights: 0
   weights: 0
   weights: 0
@@ -361,9 +361,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.63907
-  weights: 18.42436
-  weights: 11.77852
+  weights: 0.63821
+  weights: 16.71662
+  weights: 11.8052
   weights: 0
   weights: 0
   weights: 0
@@ -393,8 +393,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.10484
-  weights: 2.54993
+  weights: 2.10198
+  weights: 2.29903
   weights: 0
   weights: 0
   weights: 0
@@ -410,9 +410,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.79729
+  weights: 0.79621
   weights: 0
-  weights: 25.01944
+  weights: 24.06366
   weights: 0
   weights: 0
   weights: 0
@@ -442,8 +442,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestFeral-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.79044
-  weights: 2.44667
+  weights: 2.78722
+  weights: 2.42429
   weights: 0
   weights: 0
   weights: 0
@@ -459,9 +459,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.91912
+  weights: 0.91806
   weights: 0
-  weights: 22.35809
+  weights: 22.26447
   weights: 0
   weights: 0
   weights: 0
@@ -491,15 +491,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestFeral-Phase1-Lvl25-AllItems-FeralheartRaiment"
  value: {
-  dps: 261.46339
-  tps: 188.16902
+  dps: 261.04499
+  tps: 187.87395
  }
 }
 dps_results: {
  key: "TestFeral-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 264.6443
-  tps: 191.91162
+  dps: 265.05073
+  tps: 192.2046
  }
 }
 dps_results: {
@@ -757,22 +757,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 190.09472
-  tps: 138.06188
+  dps: 189.00238
+  tps: 137.07387
  }
 }
 dps_results: {
  key: "TestFeral-Phase2-Lvl40-AllItems-FeralheartRaiment"
  value: {
-  dps: 525.27048
-  tps: 383.60682
+  dps: 523.94947
+  tps: 382.53083
  }
 }
 dps_results: {
  key: "TestFeral-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 803.97821
-  tps: 586.43536
+  dps: 803.37838
+  tps: 586.00606
  }
 }
 dps_results: {
@@ -1030,24 +1030,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 464.27842
-  tps: 332.51271
+  dps: 462.78275
+  tps: 331.45192
  }
 }
 dps_results: {
  key: "TestFeral-Phase3-Lvl50-AllItems-FeralheartRaiment"
  value: {
-  dps: 904.82231
-  tps: 656.5816
-  hps: 9.17246
+  dps: 903.59128
+  tps: 655.80994
+  hps: 9.05555
  }
 }
 dps_results: {
  key: "TestFeral-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1885.20208
-  tps: 1348.90915
-  hps: 10.23716
+  dps: 1883.19205
+  tps: 1347.46916
+  hps: 10.23573
  }
 }
 dps_results: {
@@ -1341,107 +1341,107 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1243.51501
-  tps: 886.61256
-  hps: 9.39953
+  dps: 1241.5312
+  tps: 885.22962
+  hps: 9.35676
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1315.64511
-  tps: 960.85808
+  dps: 1314.6924
+  tps: 960.21936
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1363.07144
-  tps: 994.46331
+  dps: 1363.69219
+  tps: 994.99603
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1285.05513
-  tps: 939.25444
+  dps: 1285.22161
+  tps: 939.32495
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 2038.06723
-  tps: 1464.61022
+  dps: 2039.40306
+  tps: 1465.68663
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1291.45587
-  tps: 943.49176
+  dps: 1289.30737
+  tps: 942.03505
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1355.7175
-  tps: 989.23257
+  dps: 1356.32766
+  tps: 989.75726
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1297.25727
-  tps: 947.67165
+  dps: 1295.93285
+  tps: 946.77113
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 1900.92339
-  tps: 1375.55357
+  dps: 1900.20315
+  tps: 1375.01524
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1392.18876
-  tps: 1015.0521
+  dps: 1394.39894
+  tps: 1016.7611
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1315.64511
-  tps: 960.85808
+  dps: 1314.6924
+  tps: 960.21936
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1363.07144
-  tps: 994.46331
+  dps: 1363.69219
+  tps: 994.99603
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1285.05513
-  tps: 939.25444
+  dps: 1285.22161
+  tps: 939.32495
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 1955.59533
-  tps: 1415.37833
+  dps: 1954.88611
+  tps: 1415.12921
  }
 }
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3675.28392
-  tps: 2633.04063
+  dps: 3673.23248
+  tps: 2631.56809
  }
 }
 dps_results: {
@@ -1699,106 +1699,106 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2735.24031
-  tps: 1953.65377
+  dps: 2734.27196
+  tps: 1953.02028
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-BloodGuard'sCracklingLeather"
  value: {
-  dps: 1379.92231
-  tps: 1005.73383
+  dps: 1377.59081
+  tps: 1004.04158
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-BloodGuard'sLeather"
  value: {
-  dps: 1435.97847
-  tps: 1045.9299
+  dps: 1431.66558
+  tps: 1042.87063
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-BloodGuard'sRestoredLeather"
  value: {
-  dps: 1349.44556
-  tps: 984.04391
+  dps: 1348.96712
+  tps: 983.6285
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-CoagulateBloodguard'sLeathers"
  value: {
-  dps: 2313.02777
-  tps: 1659.71551
+  dps: 2312.61299
+  tps: 1659.4112
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-EmeraldDreamkeeperGarb"
  value: {
-  dps: 1355.93621
-  tps: 988.90556
+  dps: 1354.75271
+  tps: 987.97939
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-EmeraldLeathers"
  value: {
-  dps: 1428.61663
-  tps: 1040.69367
+  dps: 1424.3206
+  tps: 1037.64572
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-EmeraldWatcherVestments"
  value: {
-  dps: 1362.63793
-  tps: 993.53914
+  dps: 1361.09757
+  tps: 992.41287
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-ExiledProphet'sRaiment"
  value: {
-  dps: 2158.32555
-  tps: 1557.41457
+  dps: 2157.17379
+  tps: 1556.59203
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-FeralheartRaiment"
  value: {
-  dps: 1456.88246
-  tps: 1059.21193
+  dps: 1456.27775
+  tps: 1058.74733
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-Knight-Lieutenant'sCracklingLeather"
  value: {
-  dps: 1379.92231
-  tps: 1005.73383
+  dps: 1377.59081
+  tps: 1004.04158
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLeather"
  value: {
-  dps: 1435.97847
-  tps: 1045.9299
+  dps: 1431.66558
+  tps: 1042.87063
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-Knight-Lieutenant'sRestoredLeather"
  value: {
-  dps: 1349.44556
-  tps: 984.04391
+  dps: 1348.96712
+  tps: 983.6285
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-AllItems-LostWorshipper'sArmor"
  value: {
-  dps: 2201.49418
-  tps: 1588.89126
+  dps: 2200.18992
+  tps: 1587.84763
  }
 }
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4570.12222
-  tps: 3267.57527
+  dps: 4563.57393
+  tps: 3262.9485
  }
 }
 dps_results: {
@@ -2056,7 +2056,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3310.28646
-  tps: 2360.69579
+  dps: 3304.53819
+  tps: 2356.45457
  }
 }

--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -51,7 +51,7 @@ stat_weights_results: {
  key: "TestBM-Phase2-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.809
+  weights: 0.83452
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.34068
-  weights: 8.89983
-  weights: 8.05951
+  weights: 0.34104
+  weights: 9.4423
+  weights: 7.94389
   weights: 0
   weights: 0
   weights: 0
@@ -77,7 +77,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0692
+  weights: 0.06911
   weights: 0
   weights: 0
   weights: 0
@@ -99,392 +99,392 @@ stat_weights_results: {
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 489.49252
-  tps: 223.69363
+  dps: 489.40624
+  tps: 225.55594
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 863.87223
-  tps: 368.32103
+  dps: 863.72535
+  tps: 369.78108
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 837.18553
-  tps: 359.18137
+  dps: 836.20958
+  tps: 360.33844
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 712.08945
-  tps: 377.38085
+  dps: 712.49252
+  tps: 377.45323
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 846.46742
-  tps: 363.92432
+  dps: 845.86001
+  tps: 365.42173
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 854.24764
-  tps: 363.54709
+  dps: 854.16565
+  tps: 364.96986
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 845.37731
-  tps: 361.81313
+  dps: 845.49811
+  tps: 362.804
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 2188.94103
-  tps: 1993.16161
+  dps: 2187.08736
+  tps: 1993.21516
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 858.0993
-  tps: 375.82361
+  dps: 858.52069
+  tps: 377.90691
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 907.55203
-  tps: 387.53346
+  dps: 901.85394
+  tps: 387.06749
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 1255.76148
-  tps: 1270.21415
+  dps: 1241.57256
+  tps: 1248.31267
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 456.05378
-  tps: 201.15821
+  dps: 449.63627
+  tps: 195.71932
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 495.70633
-  tps: 202.99497
+  dps: 493.48772
+  tps: 203.79007
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 566.34042
-  tps: 555.14085
+  dps: 566.13278
+  tps: 554.08885
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 506.89174
-  tps: 253.926
+  dps: 507.56516
+  tps: 254.52732
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 557.54198
-  tps: 271.78973
+  dps: 555.70107
+  tps: 271.98261
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 317.20542
-  tps: 443.95234
+  dps: 316.62459
+  tps: 443.45974
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 273.98885
-  tps: 150.76744
+  dps: 273.97217
+  tps: 150.68734
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 303.41224
-  tps: 158.27319
+  dps: 302.68358
+  tps: 158.15506
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 589.59629
-  tps: 660.03094
+  dps: 592.46004
+  tps: 666.43652
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 484.46955
-  tps: 229.2988
+  dps: 487.40146
+  tps: 233.75098
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 517.04451
-  tps: 244.63477
+  dps: 517.96608
+  tps: 246.29183
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 303.16115
-  tps: 501.71538
+  dps: 299.95058
+  tps: 494.48573
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 249.36716
-  tps: 123.47978
+  dps: 246.88225
+  tps: 121.0919
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 272.73691
-  tps: 127.79887
+  dps: 271.29487
+  tps: 123.74818
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 765.77392
-  tps: 872.19738
+  dps: 764.77859
+  tps: 871.48694
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 688.45576
-  tps: 437.09722
+  dps: 687.51263
+  tps: 437.26689
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 751.03593
-  tps: 478.30952
+  dps: 750.23777
+  tps: 481.10985
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 444.84489
-  tps: 675.67241
+  dps: 444.1887
+  tps: 674.76614
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 394.15455
-  tps: 271.29941
+  dps: 394.32004
+  tps: 271.50277
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 424.88508
-  tps: 290.3124
+  dps: 424.02661
+  tps: 290.27079
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 2122.8471
-  tps: 1926.41759
+  dps: 2122.40016
+  tps: 1927.60142
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 850.32616
-  tps: 364.17741
+  dps: 847.40774
+  tps: 363.83953
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 886.02247
-  tps: 366.36871
+  dps: 882.16673
+  tps: 362.58643
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 1245.94538
-  tps: 1250.02717
+  dps: 1217.6275
+  tps: 1212.33125
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 461.3247
-  tps: 201.02419
+  dps: 455.1058
+  tps: 196.67379
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 495.3003
-  tps: 200.11137
+  dps: 496.24421
+  tps: 201.14956
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 570.61742
-  tps: 552.01776
+  dps: 570.15106
+  tps: 552.31469
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 514.26618
-  tps: 251.65459
+  dps: 514.9936
+  tps: 251.97392
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 563.06058
-  tps: 268.5649
+  dps: 561.15231
+  tps: 268.75651
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 320.2091
-  tps: 442.22134
+  dps: 319.68528
+  tps: 440.89267
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 276.15004
-  tps: 149.09057
+  dps: 277.19063
+  tps: 149.19322
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 307.94113
-  tps: 156.50184
+  dps: 307.18933
+  tps: 156.38602
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 593.22773
-  tps: 654.95086
+  dps: 590.46279
+  tps: 656.9349
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 488.62947
-  tps: 223.0159
+  dps: 485.8082
+  tps: 223.48479
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 521.02403
-  tps: 235.4337
+  dps: 522.83561
+  tps: 237.56823
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 311.25123
-  tps: 500.12165
+  dps: 304.77357
+  tps: 485.17754
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 256.74252
-  tps: 124.05072
+  dps: 252.56426
+  tps: 119.46006
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 286.39469
-  tps: 128.28919
+  dps: 286.23398
+  tps: 124.65513
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 762.34993
-  tps: 870.07555
+  dps: 762.32999
+  tps: 868.37384
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 687.1767
-  tps: 430.25594
+  dps: 687.33049
+  tps: 430.57903
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 754.60568
-  tps: 472.63074
+  dps: 753.27645
+  tps: 475.0199
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 446.99121
-  tps: 669.84028
+  dps: 446.72113
+  tps: 670.58118
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 395.51874
-  tps: 267.92199
+  dps: 395.22567
+  tps: 267.8743
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_ranged_bm-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 427.44873
-  tps: 286.88341
+  dps: 426.65691
+  tps: 286.8418
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 808.15075
-  tps: 335.70353
+  dps: 805.57489
+  tps: 335.79449
  }
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestMM-Phase2-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.39744
+  weights: 0.39707
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.1237
-  weights: 3.94601
-  weights: 3.81935
+  weights: 0.12341
+  weights: 3.94084
+  weights: 3.81292
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestMM-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.51922
+  weights: 0.51925
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +175,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.04141
+  weights: 0.04142
   weights: 0
   weights: 0
   weights: 0
@@ -197,50 +197,50 @@ stat_weights_results: {
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 331.80276
-  tps: 170.12798
+  dps: 331.4785
+  tps: 169.80885
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 348.90493
-  tps: 185.52832
+  dps: 348.64686
+  tps: 185.2709
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 340.61841
-  tps: 181.47826
+  dps: 340.37021
+  tps: 181.2309
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 333.54743
-  tps: 172.98276
+  dps: 333.29501
+  tps: 172.73206
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 342.71916
-  tps: 183.11753
+  dps: 342.46704
+  tps: 182.8662
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 349.41471
-  tps: 184.74389
+  dps: 349.16306
+  tps: 184.49167
  }
 }
 dps_results: {
  key: "TestMM-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 344.17691
-  tps: 184.63261
+  dps: 343.90209
+  tps: 184.3634
  }
 }
 dps_results: {
@@ -330,120 +330,120 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 329.8315
-  tps: 171.16244
+  dps: 329.54864
+  tps: 170.87977
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 512.21178
-  tps: 512.32249
-  hps: 10.12473
+  dps: 512.39454
+  tps: 512.50526
+  hps: 10.11647
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 728.12015
-  tps: 728.2306
-  hps: 10.03567
+  dps: 728.1028
+  tps: 728.21325
+  hps: 10.03854
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 861.05857
-  tps: 861.16902
-  hps: 12.98882
+  dps: 861.28322
+  tps: 861.39367
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 860.07955
-  tps: 860.19
-  hps: 12.98882
+  dps: 860.30533
+  tps: 860.41578
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 853.14314
-  tps: 853.25359
-  hps: 12.98882
+  dps: 853.36892
+  tps: 853.47937
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 634.05791
-  tps: 634.17781
-  hps: 9.5885
+  dps: 634.06656
+  tps: 634.18488
+  hps: 9.5936
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 862.54251
-  tps: 862.65296
-  hps: 12.98882
+  dps: 862.76716
+  tps: 862.87761
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 728.12015
-  tps: 728.2306
-  hps: 10.03567
+  dps: 728.1028
+  tps: 728.21325
+  hps: 10.03854
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 861.55776
-  tps: 861.66821
-  hps: 12.81888
+  dps: 861.7851
+  tps: 861.89555
+  hps: 12.81677
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 848.97089
-  tps: 849.08134
-  hps: 12.98882
+  dps: 849.19428
+  tps: 849.30473
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 809.71002
-  tps: 809.82047
-  hps: 12.98882
+  dps: 809.91783
+  tps: 810.02828
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 733.77728
-  tps: 733.88773
-  hps: 12.98882
+  dps: 733.80443
+  tps: 733.91488
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 846.09139
-  tps: 846.20184
-  hps: 12.98882
+  dps: 846.31308
+  tps: 846.42353
+  hps: 12.98671
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 865.04746
-  tps: 865.15344
-  hps: 13.04623
+  dps: 865.06031
+  tps: 865.16619
+  hps: 13.05262
  }
 }
 dps_results: {
@@ -545,8 +545,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 718.54495
-  tps: 718.65514
-  hps: 11.10274
+  dps: 718.43386
+  tps: 718.54405
+  hps: 11.10659
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestSV-Phase2-Lvl40-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.89401
+  weights: 0.88765
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37221
-  weights: 6.28754
-  weights: 7.24514
+  weights: 0.37295
+  weights: 6.34857
+  weights: 7.2888
   weights: 0
   weights: 0
   weights: 0
@@ -126,7 +126,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.0392
+  weights: 0.03919
   weights: 0
   weights: 0
   weights: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestSV-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 2.92574
+  weights: 2.8862
   weights: 0
   weights: 0
   weights: 0
@@ -165,17 +165,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.41596
+  weights: 0.39881
   weights: 0
-  weights: 20.53801
-  weights: 0
-  weights: 0
+  weights: 19.29311
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50491
+  weights: 0
+  weights: 0
+  weights: 0.49905
   weights: 0
   weights: 0
   weights: 0
@@ -197,157 +197,157 @@ stat_weights_results: {
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-BeastmasterArmor"
  value: {
-  dps: 404.36276
-  tps: 254.25908
+  dps: 404.5068
+  tps: 254.19652
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 803.94129
-  tps: 397.64831
+  dps: 808.03256
+  tps: 402.09971
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 781.54476
-  tps: 386.7768
+  dps: 785.65147
+  tps: 391.13239
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 613.63696
-  tps: 408.26528
+  dps: 615.32764
+  tps: 409.61257
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 791.52331
-  tps: 392.40356
+  dps: 795.43844
+  tps: 396.6891
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 797.76948
-  tps: 392.86992
+  dps: 801.78245
+  tps: 397.24811
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 795.613
-  tps: 396.89574
+  dps: 796.1679
+  tps: 398.03414
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 2256.50968
-  tps: 2138.04009
+  dps: 2253.39635
+  tps: 2135.45425
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 806.434
-  tps: 408.3337
+  dps: 807.93517
+  tps: 410.81276
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 847.6918
-  tps: 427.82441
+  dps: 846.71187
+  tps: 426.6223
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 1310.33496
-  tps: 1351.60921
+  dps: 1290.14178
+  tps: 1327.83804
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 436.50411
-  tps: 220.3363
+  dps: 428.82485
+  tps: 215.01339
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Dwarf-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 464.2304
-  tps: 221.39225
+  dps: 464.40101
+  tps: 221.86634
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 2208.68013
-  tps: 2092.08383
+  dps: 2206.36854
+  tps: 2089.27473
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 797.00347
-  tps: 397.12059
+  dps: 797.44052
+  tps: 397.81355
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 834.27572
-  tps: 412.75993
+  dps: 833.76536
+  tps: 412.78161
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 1303.96481
-  tps: 1345.47868
+  dps: 1302.91166
+  tps: 1330.86214
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 441.58959
-  tps: 219.89795
+  dps: 437.59357
+  tps: 219.44099
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_melee-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 473.35914
-  tps: 229.28006
+  dps: 474.01818
+  tps: 230.17921
  }
 }
 dps_results: {
  key: "TestSV-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 751.62124
-  tps: 372.08004
+  dps: 752.96758
+  tps: 373.28087
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 1125.0274
-  tps: 905.28074
-  hps: 14.3972
+  dps: 1100.81471
+  tps: 878.24338
+  hps: 14.00309
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 1394.86526
-  tps: 1150.65857
-  hps: 14.3972
+  dps: 1368.87904
+  tps: 1122.63325
+  hps: 14.00309
  }
 }
 dps_results: {
@@ -361,25 +361,25 @@ dps_results: {
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 3525.30767
-  tps: 3145.28344
-  hps: 19.9832
+  dps: 3424.35781
+  tps: 3044.71991
+  hps: 20.36399
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 3495.90796
-  tps: 3119.03146
-  hps: 19.9832
+  dps: 3395.96303
+  tps: 3019.62429
+  hps: 20.36399
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 2089.2021
-  tps: 1823.61287
-  hps: 14.99414
+  dps: 2043.59587
+  tps: 1778.9464
+  hps: 15.36682
  }
 }
 dps_results: {
@@ -393,160 +393,160 @@ dps_results: {
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 1394.86526
-  tps: 1150.65857
-  hps: 14.3972
+  dps: 1368.87904
+  tps: 1122.63325
+  hps: 14.00309
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 3543.57511
-  tps: 3167.0201
-  hps: 19.82352
+  dps: 3445.09977
+  tps: 3069.08788
+  hps: 20.23194
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 3460.12995
-  tps: 3091.26853
-  hps: 20.40391
+  dps: 3357.38165
+  tps: 2988.19239
+  hps: 20.2995
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 3163.77905
-  tps: 2829.48332
-  hps: 19.40117
+  dps: 3072.43358
+  tps: 2738.29221
+  hps: 19.77086
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 3143.72955
-  tps: 2781.651
-  hps: 19.40117
+  dps: 3046.98046
+  tps: 2685.3956
+  hps: 19.77086
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 3417.42519
-  tps: 3055.78416
-  hps: 19.40117
+  dps: 3318.25142
+  tps: 2956.76359
+  hps: 19.77086
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3528.43883
-  tps: 3151.72512
-  hps: 20.24192
+  dps: 3445.18386
+  tps: 3070.28549
+  hps: 19.9338
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 8211.75666
-  tps: 8273.52171
-  hps: 20.54717
+  dps: 8068.15196
+  tps: 8123.47057
+  hps: 19.92686
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3558.68282
-  tps: 3200.23451
-  hps: 20.08257
+  dps: 3503.90038
+  tps: 3149.425
+  hps: 20.15627
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3463.91615
-  tps: 3129.7374
-  hps: 18.37475
+  dps: 3379.76458
+  tps: 3055.31428
+  hps: 18.98892
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4167.19824
-  tps: 4457.17192
-  hps: 10.61777
+  dps: 4101.39339
+  tps: 4366.66482
+  hps: 10.52491
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1691.1062
-  tps: 1524.39687
-  hps: 10.35941
+  dps: 1652.66206
+  tps: 1489.1691
+  hps: 10.3355
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1681.72637
-  tps: 1493.56675
-  hps: 10.66558
+  dps: 1659.60419
+  tps: 1475.29736
+  hps: 10.25183
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 8666.9536
-  tps: 8729.05814
-  hps: 20.78363
+  dps: 8444.61243
+  tps: 8475.78118
+  hps: 20.43662
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3802.77585
-  tps: 3431.90791
-  hps: 20.51249
+  dps: 3712.11383
+  tps: 3342.81224
+  hps: 19.97202
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3727.93481
-  tps: 3345.2507
-  hps: 19.83341
+  dps: 3604.55873
+  tps: 3250.24205
+  hps: 19.18852
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4163.77793
-  tps: 4430.4855
-  hps: 10.82557
+  dps: 4099.76979
+  tps: 4344.53595
+  hps: 10.51111
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1672.1814
-  tps: 1508.15261
-  hps: 10.4302
+  dps: 1649.46555
+  tps: 1479.81282
+  hps: 10.23436
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1669.19549
-  tps: 1486.86871
+  dps: 1657.63931
+  tps: 1465.78123
   hps: 10.15989
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3287.05955
-  tps: 2976.26938
-  hps: 19.83795
+  dps: 3204.99287
+  tps: 2910.77019
+  hps: 19.45496
  }
 }

--- a/sim/paladin/crusader_strike.go
+++ b/sim/paladin/crusader_strike.go
@@ -40,7 +40,14 @@ func (paladin *Paladin) registerCrusaderStrike() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
-			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
+
+			core.StartDelayedAction(sim, core.DelayedActionOptions{
+				DoAt: sim.CurrentTime + core.SpellBatchWindow,
+				OnAction: func(s *core.Simulation) {
+					spell.DealDamage(sim, result)
+				},
+			})
 
 			paladin.AddMana(sim, 0.05*paladin.MaxMana(), manaMetrics)
 

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -50,37 +50,37 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestProtection-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 0.89252
-  weights: 0.62257
+  weights: 0.89585
+  weights: 0.82124
   weights: 0
-  weights: 0.06713
+  weights: 0.17843
   weights: 0
-  weights: 0.18182
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0.10013
+  weights: 0.18238
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.73392
-  weights: 2.20341
+  weights: 0.10038
   weights: 0
   weights: 0
-  weights: 0.39421
   weights: 0
-  weights: 14.65841
-  weights: 11.6138
+  weights: 2.03945
+  weights: 0.70241
   weights: 0
   weights: 0
+  weights: 0.39576
+  weights: 0
+  weights: 14.59032
+  weights: 10.44954
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.94046
   weights: 0
-  weights: 0.73519
+  weights: 0
+  weights: 1.94782
+  weights: 0
+  weights: 0.73221
   weights: 0
   weights: 0
   weights: 0
@@ -99,78 +99,78 @@ stat_weights_results: {
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1291.10358
-  tps: 2320.24642
+  dps: 1293.2581
+  tps: 2321.05645
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 1640.00105
-  tps: 3299.24306
+  dps: 1646.42476
+  tps: 3303.37419
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1291.18323
-  tps: 2320.96396
+  dps: 1293.33781
+  tps: 2321.7822
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1363.67769
-  tps: 2446.16735
+  dps: 1365.9742
+  tps: 2447.00181
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 1692.17075
-  tps: 3417.95275
+  dps: 1681.7127
+  tps: 3383.66288
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1481.97522
-  tps: 2973.61396
+  dps: 1482.10265
+  tps: 2971.33009
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 1696.986
-  tps: 3427.32983
+  dps: 1690.86196
+  tps: 3397.83278
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1050.24147
-  tps: 1582.95519
+  dps: 1049.98715
+  tps: 1575.95396
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 1407.15495
-  tps: 2847.20644
+  dps: 1402.09168
+  tps: 2825.91897
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1636.48364
-  tps: 3300.65883
+  dps: 1634.11852
+  tps: 3284.10847
  }
 }
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 1672.8074
-  tps: 3364.0018
+  dps: 1676.11789
+  tps: 3362.30779
  }
 }
 dps_results: {
@@ -260,7 +260,7 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1368.26875
-  tps: 2740.98705
+  dps: 1364.6969
+  tps: 2724.91558
  }
 }

--- a/sim/paladin/retribution/TestExodin.results
+++ b/sim/paladin/retribution/TestExodin.results
@@ -99,12 +99,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestExodin-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.12336
-  weights: 1.90913
+  weights: 2.08924
+  weights: 1.2992
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.71587
+  weights: 0.71332
   weights: 0
   weights: 0
   weights: 0
@@ -112,13 +112,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.70988
-  weights: 2.09556
+  weights: 9.56191
+  weights: 1.72503
   weights: 0
   weights: 0
-  weights: 0.87742
+  weights: 0.86332
   weights: 0
-  weights: 21.96742
+  weights: 20.13232
   weights: 0
   weights: 0
   weights: 0
@@ -148,12 +148,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestExodin-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.9203
-  weights: 1.17184
+  weights: 2.89757
+  weights: 1.80065
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.92905
+  weights: 0.92672
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 14.0693
-  weights: 0.09909
+  weights: 13.18999
+  weights: 2.37427
   weights: 0
   weights: 0
-  weights: 1.04934
+  weights: 1.04117
   weights: 0
-  weights: 29.07955
+  weights: 26.57433
   weights: 0
   weights: 0
   weights: 0
@@ -197,336 +197,336 @@ stat_weights_results: {
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1336.87262
-  tps: 1372.06571
+  dps: 1326.97626
+  tps: 1362.10537
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 3224.58066
-  tps: 3256.91886
+  dps: 3188.40394
+  tps: 3220.93814
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1337.01263
-  tps: 1373.08855
+  dps: 1327.13852
+  tps: 1363.12992
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1436.83232
-  tps: 1474.21743
+  dps: 1426.18879
+  tps: 1463.50638
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 3262.10077
-  tps: 3294.31845
+  dps: 3233.07962
+  tps: 3265.13453
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1572.71774
-  tps: 1610.38093
+  dps: 1566.45342
+  tps: 1604.1539
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 3139.97411
-  tps: 3172.3625
+  dps: 3107.02574
+  tps: 3139.15918
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1215.57282
-  tps: 1252.07982
+  dps: 1209.71744
+  tps: 1246.16036
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 1416.72379
-  tps: 1454.47473
+  dps: 1409.35011
+  tps: 1447.17098
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1665.71711
-  tps: 1703.4567
+  dps: 1648.6742
+  tps: 1686.48545
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3249.30607
-  tps: 3281.32038
+  dps: 3216.53368
+  tps: 3248.51459
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1480.97125
-  tps: 2028.59703
+  dps: 1474.38445
+  tps: 2015.82502
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 626.38901
-  tps: 653.68525
+  dps: 626.1395
+  tps: 653.43082
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 707.29814
-  tps: 738.24101
+  dps: 706.03971
+  tps: 736.98258
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 601.24799
-  tps: 971.69115
+  dps: 600.37781
+  tps: 970.82097
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 269.10808
-  tps: 287.61979
+  dps: 269.33743
+  tps: 287.84914
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 369.73145
-  tps: 393.06296
+  dps: 369.76825
+  tps: 393.09976
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1488.4063
-  tps: 2038.87613
+  dps: 1504.78619
+  tps: 2053.40101
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 639.15333
-  tps: 666.65001
+  dps: 639.12482
+  tps: 666.61657
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 710.21146
-  tps: 741.19592
+  dps: 708.82308
+  tps: 739.80755
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 603.01841
-  tps: 974.80674
+  dps: 604.13882
+  tps: 975.50681
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 275.7187
-  tps: 294.29761
+  dps: 275.30928
+  tps: 293.88819
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 374.1251
-  tps: 397.5579
+  dps: 372.66311
+  tps: 396.09591
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2685.2624
-  tps: 2719.96003
+  dps: 2662.72373
+  tps: 2697.50557
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1640.4938
-  tps: 1676.13354
+  dps: 1635.12662
+  tps: 1670.83421
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 4466.04045
-  tps: 4504.93683
+  dps: 4451.12139
+  tps: 4490.20573
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1640.83083
-  tps: 1677.28516
+  dps: 1635.40225
+  tps: 1671.93475
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1760.53693
-  tps: 1798.22317
+  dps: 1755.29641
+  tps: 1793.05302
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 4540.4958
-  tps: 4579.44836
+  dps: 4526.47168
+  tps: 4565.38643
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1929.85078
-  tps: 1967.70169
+  dps: 1915.35128
+  tps: 1953.19275
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 4428.49344
-  tps: 4467.58945
+  dps: 4408.02755
+  tps: 4446.77391
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1489.79958
-  tps: 1526.73673
+  dps: 1482.70818
+  tps: 1519.62455
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 1776.65502
-  tps: 1814.73478
+  dps: 1774.55179
+  tps: 1812.57956
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 2047.21171
-  tps: 2085.28477
+  dps: 2037.68477
+  tps: 2075.70432
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4551.45075
-  tps: 4589.82266
+  dps: 4531.02171
+  tps: 4569.32676
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 2540.68526
-  tps: 3183.98781
+  dps: 2462.07499
+  tps: 3076.01126
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1045.46284
-  tps: 1077.70314
+  dps: 1048.71986
+  tps: 1080.96017
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1141.60281
-  tps: 1180.4931
+  dps: 1140.11815
+  tps: 1178.95927
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 802.54235
-  tps: 1171.31246
+  dps: 805.55478
+  tps: 1173.54922
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 356.64012
-  tps: 375.08116
+  dps: 357.36301
+  tps: 375.80405
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 510.7909
-  tps: 535.03395
+  dps: 509.70939
+  tps: 533.95244
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 2562.55709
-  tps: 3207.29325
+  dps: 2505.42248
+  tps: 3124.52475
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1059.12795
-  tps: 1091.5898
+  dps: 1060.9195
+  tps: 1093.38136
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1145.37561
-  tps: 1184.46684
+  dps: 1144.97051
+  tps: 1184.03715
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 816.97286
-  tps: 1186.16605
+  dps: 816.83445
+  tps: 1185.63731
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 365.40759
-  tps: 383.82124
+  dps: 366.13194
+  tps: 384.54559
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 507.60253
-  tps: 531.85429
+  dps: 507.05313
+  tps: 531.30489
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3767.53364
-  tps: 3809.93208
+  dps: 3725.2684
+  tps: 3767.30543
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -246,12 +246,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.45725
-  weights: 0.24202
+  weights: 0.45448
+  weights: 0.27056
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.13749
+  weights: 0.13776
   weights: 0
   weights: 0
   weights: 0
@@ -259,13 +259,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.41897
+  weights: 0.21068
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.20784
-  weights: 1.26759
-  weights: 2.17683
+  weights: 0.20658
+  weights: 1.69537
+  weights: 2.19509
   weights: 0
   weights: 0
   weights: 0
@@ -295,12 +295,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.66354
-  weights: 0.40743
+  weights: 0.66066
+  weights: 0.3795
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22175
+  weights: 0.2217
   weights: 0
   weights: 0
   weights: 0
@@ -308,13 +308,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.68951
-  weights: 0.07977
+  weights: 1.74055
+  weights: 0.08283
   weights: 0
   weights: 0
-  weights: 0.30161
-  weights: 5.17831
-  weights: 5.24761
+  weights: 0.3003
+  weights: 5.10188
+  weights: 5.19765
   weights: 0
   weights: 0
   weights: 0
@@ -344,12 +344,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.06725
-  weights: 1.01742
+  weights: 1.07177
+  weights: 1.58648
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.28111
+  weights: 0.28005
   weights: 0
   weights: 0
   weights: 0
@@ -357,13 +357,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.53149
-  weights: 0.46126
+  weights: 2.56734
+  weights: 0.46665
   weights: 0
   weights: 0
-  weights: 0.40626
-  weights: 12.73206
-  weights: 9.79176
+  weights: 0.40607
+  weights: 13.08333
+  weights: 9.80118
   weights: 0
   weights: 0
   weights: 0
@@ -393,12 +393,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.61392
-  weights: 1.81223
+  weights: 2.61133
+  weights: 2.19895
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.40771
+  weights: 0.40662
   weights: 0
   weights: 0
   weights: 0
@@ -406,13 +406,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.68818
-  weights: 0.7883
+  weights: 5.71473
+  weights: 0.75595
   weights: 0
   weights: 0
-  weights: 0.93925
-  weights: 2.46521
-  weights: 28.70978
+  weights: 0.93832
+  weights: 1.00422
+  weights: 30.1095
   weights: 0
   weights: 0
   weights: 0
@@ -442,12 +442,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 3.004
-  weights: 1.73906
+  weights: 2.97887
+  weights: 2.64655
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50681
+  weights: 0.50617
   weights: 0
   weights: 0
   weights: 0
@@ -455,13 +455,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 12.26527
-  weights: 0.79071
+  weights: 10.54596
+  weights: 0.7012
   weights: 0
   weights: 0
-  weights: 1.03594
-  weights: 1.43215
-  weights: 35.21294
+  weights: 0.90698
+  weights: 1.22682
+  weights: 35.56262
   weights: 0
   weights: 0
   weights: 0
@@ -491,456 +491,456 @@ stat_weights_results: {
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 249.94345
-  tps: 256.93929
+  dps: 249.28749
+  tps: 256.28333
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-SoulforgeArmor"
  value: {
-  dps: 197.00824
-  tps: 198.74774
+  dps: 196.34485
+  tps: 198.08435
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 250.54499
-  tps: 258.00694
+  dps: 248.78216
+  tps: 256.24411
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 217.68029
-  tps: 223.15121
+  dps: 217.60473
+  tps: 223.07685
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 249.37754
-  tps: 256.19108
+  dps: 250.06189
+  tps: 256.87542
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 176.07997
-  tps: 315.26495
+  dps: 167.50332
+  tps: 306.6883
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 94.11011
-  tps: 101.06936
+  dps: 93.30431
+  tps: 100.26355
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 106.90803
-  tps: 115.96341
+  dps: 107.1902
+  tps: 116.24559
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 99.38531
-  tps: 204.5716
+  dps: 101.60732
+  tps: 206.79361
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 52.61365
-  tps: 57.87296
+  dps: 52.72011
+  tps: 57.97942
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Dwarf-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 65.40836
-  tps: 73.39714
+  dps: 65.53939
+  tps: 73.52817
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 177.48277
-  tps: 317.74085
+  dps: 169.62065
+  tps: 309.87873
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 94.93101
-  tps: 101.94391
+  dps: 94.08671
+  tps: 101.09961
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 107.48996
-  tps: 116.60004
+  dps: 107.77021
+  tps: 116.88029
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 100.43322
-  tps: 206.7217
+  dps: 100.04509
+  tps: 206.33357
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 52.97193
-  tps: 58.28636
+  dps: 53.07122
+  tps: 58.38564
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-Settings-Human-p1ret-P1 Seal of Command Ret-p1ret-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 65.56642
-  tps: 73.60891
+  dps: 65.6961
+  tps: 73.7386
  }
 }
 dps_results: {
  key: "TestRetribution-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 233.86841
-  tps: 240.88132
+  dps: 233.26457
+  tps: 240.27747
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 546.46321
-  tps: 560.19666
+  dps: 544.62229
+  tps: 558.37377
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-SoulforgeArmor"
  value: {
-  dps: 327.52646
-  tps: 335.36102
+  dps: 325.60669
+  tps: 333.41375
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 470.96511
-  tps: 484.88019
+  dps: 468.93625
+  tps: 482.80272
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 486.02225
-  tps: 496.44432
+  dps: 483.29966
+  tps: 493.70004
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 548.4983
-  tps: 562.00552
+  dps: 548.61548
+  tps: 562.12304
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 429.91227
-  tps: 674.9001
+  dps: 419.18903
+  tps: 658.81985
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 205.35988
-  tps: 217.22901
+  dps: 204.79834
+  tps: 216.65936
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 227.60289
-  tps: 239.32088
+  dps: 227.66526
+  tps: 239.38324
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 238.54461
-  tps: 400.36395
+  dps: 234.29971
+  tps: 393.64451
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 107.99244
-  tps: 116.00768
+  dps: 107.82373
+  tps: 115.83897
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 132.10906
-  tps: 142.83317
+  dps: 132.14217
+  tps: 142.86628
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 429.52991
-  tps: 674.45611
+  dps: 417.04106
+  tps: 653.55207
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 205.29952
-  tps: 217.11827
+  dps: 204.8499
+  tps: 216.6593
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 228.38983
-  tps: 240.10812
+  dps: 228.45203
+  tps: 240.17033
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 238.81254
-  tps: 400.2672
+  dps: 236.71967
+  tps: 397.45738
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 108.35624
-  tps: 116.41357
+  dps: 108.2034
+  tps: 116.26073
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 132.38776
-  tps: 143.16816
+  dps: 132.42077
+  tps: 143.20117
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 516.61655
-  tps: 529.97864
+  dps: 514.43962
+  tps: 527.77771
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 1126.13527
-  tps: 1164.54067
+  dps: 1125.85858
+  tps: 1164.31199
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-SoulforgeArmor"
  value: {
-  dps: 733.69783
-  tps: 768.12046
+  dps: 733.93401
+  tps: 768.38962
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 977.90371
-  tps: 1016.35238
+  dps: 979.22521
+  tps: 1017.72037
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1115.05641
-  tps: 1153.4549
+  dps: 1111.97788
+  tps: 1150.30924
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1136.71557
-  tps: 1175.09789
+  dps: 1136.05918
+  tps: 1174.45671
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1443.20567
-  tps: 1984.88419
+  dps: 1443.31925
+  tps: 1984.92111
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 338.88685
-  tps: 366.00403
+  dps: 338.44428
+  tps: 365.55762
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 400.41198
-  tps: 428.02316
+  dps: 400.52869
+  tps: 428.13987
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 511.87633
-  tps: 785.75421
+  dps: 511.7067
+  tps: 785.58458
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 138.52917
-  tps: 152.22306
+  dps: 138.35953
+  tps: 152.05343
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 195.13245
-  tps: 212.93379
+  dps: 194.61283
+  tps: 212.41416
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1451.4421
-  tps: 1996.41021
+  dps: 1450.5652
+  tps: 1995.45665
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 342.37064
-  tps: 369.59921
+  dps: 342.19786
+  tps: 369.42643
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 402.94345
-  tps: 430.57606
+  dps: 403.14615
+  tps: 430.77876
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 501.673
-  tps: 776.71621
+  dps: 500.45425
+  tps: 775.49746
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 142.16671
-  tps: 155.91887
+  dps: 141.79319
+  tps: 155.54535
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 196.13679
-  tps: 214.02606
+  dps: 195.88752
+  tps: 213.7768
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1076.46553
-  tps: 1114.32392
+  dps: 1073.30308
+  tps: 1111.25164
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1693.16566
-  tps: 1732.15523
+  dps: 1659.89859
+  tps: 1698.19246
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 3625.9255
-  tps: 3675.66346
+  dps: 3632.16411
+  tps: 3681.33234
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1693.77262
-  tps: 1732.91515
+  dps: 1659.92805
+  tps: 1698.27371
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1779.4781
-  tps: 1818.94027
+  dps: 1763.91769
+  tps: 1803.10747
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 3673.57979
-  tps: 3723.1539
+  dps: 3692.04208
+  tps: 3741.1291
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 2229.02519
-  tps: 2280.02876
+  dps: 2258.14998
+  tps: 2309.11464
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 3592.72811
-  tps: 3642.12383
+  dps: 3584.18877
+  tps: 3633.22352
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1575.48636
-  tps: 1614.65441
+  dps: 1537.54125
+  tps: 1576.05204
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 3204.34088
-  tps: 3254.20814
+  dps: 3204.82638
+  tps: 3254.00635
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 2359.70664
-  tps: 2403.16601
+  dps: 2366.51737
+  tps: 2409.31341
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3686.03323
-  tps: 3735.41389
+  dps: 3679.36858
+  tps: 3728.5934
  }
 }
 dps_results: {
@@ -988,43 +988,43 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2195.8767
-  tps: 2774.45657
+  dps: 2113.98571
+  tps: 2677.92132
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 995.10871
-  tps: 1024.18428
+  dps: 998.23855
+  tps: 1027.29937
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1125.47156
-  tps: 1158.83116
+  dps: 1135.04685
+  tps: 1168.40645
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 688.62076
-  tps: 1059.91252
+  dps: 699.39198
+  tps: 1070.89266
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 355.86899
-  tps: 374.42313
+  dps: 357.22025
+  tps: 375.77439
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 479.33709
-  tps: 502.77629
+  dps: 481.03563
+  tps: 504.47483
  }
 }
 dps_results: {
@@ -1072,15 +1072,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 334.40108
-  tps: 763.89963
+  dps: 334.58215
+  tps: 764.0807
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 290.97268
-  tps: 312.44761
+  dps: 291.09185
+  tps: 312.56677
  }
 }
 dps_results: {
@@ -1092,22 +1092,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 237.59581
-  tps: 572.88822
+  dps: 240.11438
+  tps: 575.40679
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 182.54271
-  tps: 199.30733
+  dps: 183.16826
+  tps: 199.93288
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 70.81871
-  tps: 89.17372
+  dps: 66.18046
+  tps: 84.53547
  }
 }
 dps_results: {
@@ -1155,43 +1155,43 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2218.95488
-  tps: 2800.42313
+  dps: 2165.26132
+  tps: 2730.99284
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 994.44097
-  tps: 1023.43869
+  dps: 998.20771
+  tps: 1027.20052
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1124.65321
-  tps: 1158.08522
+  dps: 1134.00572
+  tps: 1167.43774
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 685.56197
-  tps: 1057.98498
+  dps: 691.19729
+  tps: 1063.6203
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 354.44349
-  tps: 373.09616
+  dps: 356.09037
+  tps: 374.74305
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 484.80105
-  tps: 508.28743
+  dps: 486.28353
+  tps: 509.76991
  }
 }
 dps_results: {
@@ -1239,15 +1239,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 346.57546
-  tps: 778.35543
+  dps: 345.31015
+  tps: 777.09012
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 298.00447
-  tps: 319.61313
+  dps: 297.94508
+  tps: 319.55374
  }
 }
 dps_results: {
@@ -1259,106 +1259,106 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 239.69954
-  tps: 575.48037
+  dps: 239.36515
+  tps: 575.14597
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 185.4878
-  tps: 202.26621
+  dps: 185.94433
+  tps: 202.72274
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 72.04642
-  tps: 90.42018
+  dps: 67.55519
+  tps: 85.92895
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3012.2552
-  tps: 3061.36391
+  dps: 2976.48924
+  tps: 3025.27895
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 2390.16803
-  tps: 2447.37194
+  dps: 2378.0297
+  tps: 2434.71004
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 4420.29191
-  tps: 4476.38954
+  dps: 4438.40657
+  tps: 4494.74115
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 2395.09479
-  tps: 2452.9513
+  dps: 2379.31828
+  tps: 2436.60092
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 2549.6704
-  tps: 2609.17312
+  dps: 2539.93306
+  tps: 2598.92634
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 4500.27074
-  tps: 4556.28618
+  dps: 4522.05654
+  tps: 4578.24805
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 3868.51504
-  tps: 3931.27152
+  dps: 3877.80872
+  tps: 3941.15255
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 4375.16382
-  tps: 4430.69149
+  dps: 4388.04121
+  tps: 4444.01111
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1914.81056
-  tps: 1966.75214
+  dps: 1873.41958
+  tps: 1923.64291
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 3739.79765
-  tps: 3795.79937
+  dps: 3797.59515
+  tps: 3853.95139
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 4108.06147
-  tps: 4166.40503
+  dps: 4091.50736
+  tps: 4149.43616
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4479.2392
-  tps: 4535.47129
+  dps: 4479.89757
+  tps: 4536.3157
  }
 }
 dps_results: {
@@ -1530,7 +1530,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3652.23401
-  tps: 3707.04344
+  dps: 3647.00211
+  tps: 3702.34274
  }
 }

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -99,12 +99,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestShockadin-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.71754
-  weights: 0.11352
+  weights: 0.71804
+  weights: 0.1204
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.1802
+  weights: 0.18035
   weights: 0
   weights: 0
   weights: 0
@@ -112,13 +112,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.74531
-  weights: 0.18066
+  weights: 1.77931
+  weights: 0.17672
   weights: 0
   weights: 0
-  weights: 0.2965
-  weights: 5.08587
-  weights: 4.63411
+  weights: 0.29671
+  weights: 5.15293
+  weights: 4.57561
   weights: 0
   weights: 0
   weights: 0
@@ -148,12 +148,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestShockadin-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 0.50911
-  weights: 3.62931
+  weights: 0.50863
+  weights: 1.87896
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.43741
+  weights: 1.43794
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.08263
-  weights: 13.2863
+  weights: 0.63405
+  weights: 12.2439
   weights: 0
   weights: 0
-  weights: 0.18294
-  weights: 7.67896
-  weights: 26.34304
+  weights: 0.18276
+  weights: 7.84947
+  weights: 24.03686
   weights: 0
   weights: 0
   weights: 0
@@ -197,50 +197,50 @@ stat_weights_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 504.45966
-  tps: 528.84909
+  dps: 504.59014
+  tps: 528.94766
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-SoulforgeArmor"
  value: {
-  dps: 384.12299
-  tps: 403.81257
+  dps: 384.17911
+  tps: 403.88708
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBelt-231330"
  value: {
-  dps: 446.50042
-  tps: 470.88997
+  dps: 446.61088
+  tps: 471.00163
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 500.67931
-  tps: 525.12289
+  dps: 500.20797
+  tps: 524.62794
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 512.07483
-  tps: 536.41457
+  dps: 512.17379
+  tps: 536.51048
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 545.35166
-  tps: 824.0562
+  dps: 545.35844
+  tps: 824.06297
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 147.14497
-  tps: 161.04846
+  dps: 147.15029
+  tps: 161.05377
  }
 }
 dps_results: {
@@ -253,15 +253,15 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 257.61091
-  tps: 442.55719
+  dps: 257.61526
+  tps: 442.56154
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 77.77845
-  tps: 87.02577
+  dps: 77.75211
+  tps: 86.99943
  }
 }
 dps_results: {
@@ -274,15 +274,15 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 557.92089
-  tps: 837.05075
+  dps: 557.35472
+  tps: 836.37459
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 146.95012
-  tps: 160.91294
+  dps: 146.71806
+  tps: 160.67813
  }
 }
 dps_results: {
@@ -295,15 +295,15 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 263.83922
-  tps: 450.1165
+  dps: 263.72985
+  tps: 450.00713
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 78.07802
-  tps: 87.39188
+  dps: 77.95938
+  tps: 87.27325
  }
 }
 dps_results: {
@@ -316,64 +316,64 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 480.61019
-  tps: 504.7873
+  dps: 480.57571
+  tps: 504.7627
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1955.06651
-  tps: 2010.47052
+  dps: 1911.57976
+  tps: 1965.8646
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1969.68841
-  tps: 2024.04962
+  dps: 1919.39135
+  tps: 1972.65843
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1969.61984
-  tps: 2023.05794
+  dps: 1940.62588
+  tps: 1993.11932
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 3875.10001
-  tps: 3962.71223
+  dps: 3884.97976
+  tps: 3973.43182
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 2850.68223
-  tps: 2936.79793
+  dps: 2854.89228
+  tps: 2941.22706
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 3601.62015
-  tps: 3687.79977
+  dps: 3590.80406
+  tps: 3676.93993
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1575.01892
-  tps: 1615.00176
+  dps: 1561.30397
+  tps: 1601.03606
  }
 }
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 3955.88222
-  tps: 4041.04814
+  dps: 3956.06294
+  tps: 4041.31543
  }
 }
 dps_results: {
@@ -463,7 +463,7 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3725.95802
-  tps: 3810.52684
+  dps: 3734.08986
+  tps: 3818.94451
  }
 }

--- a/sim/paladin/soc.go
+++ b/sim/paladin/soc.go
@@ -116,7 +116,6 @@ func (paladin *Paladin) registerSealOfCommand() {
 						spell.DealDamage(sim, result)
 					},
 				})
-
 			},
 		})
 

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.10086
+  weights: 0.10247
   weights: 0
-  weights: 0.28841
-  weights: 0
-  weights: 0
+  weights: 0.28779
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22232
   weights: 0
   weights: 0
-  weights: 0.37114
+  weights: 0.22206
+  weights: 0
+  weights: 0
+  weights: 0.36995
   weights: 0
   weights: 0
   weights: 0
@@ -298,18 +298,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.23153
+  weights: 0.01233
   weights: 0
-  weights: 0.80259
-  weights: 0
-  weights: 0
+  weights: 0.80115
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.80259
   weights: 0
   weights: 0
-  weights: 1.82422
+  weights: 0.80115
+  weights: 0
+  weights: 0
+  weights: 1.78676
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.55838
+  weights: 0.34297
   weights: 0
-  weights: 1.11177
-  weights: 0
-  weights: 0
+  weights: 1.11123
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.11177
   weights: 0
   weights: 0
-  weights: 8.24006
+  weights: 1.11123
+  weights: 0
+  weights: 0
+  weights: 8.2918
   weights: 0
   weights: 0
   weights: 0
@@ -398,16 +398,16 @@ stat_weights_results: {
   weights: 0
   weights: 0.34437
   weights: 0
-  weights: 1.9798
+  weights: 1.97984
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.9798
+  weights: 1.97984
   weights: 0
   weights: 0
-  weights: 23.35755
+  weights: 23.35429
   weights: 0
   weights: 0
   weights: 0
@@ -447,16 +447,16 @@ stat_weights_results: {
   weights: 0
   weights: 0.42382
   weights: 0
-  weights: 1.94097
+  weights: 1.94102
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.94097
+  weights: 1.94102
   weights: 0
   weights: 0
-  weights: 30.234
+  weights: 30.22078
   weights: 0
   weights: 0
   weights: 0
@@ -491,106 +491,106 @@ stat_weights_results: {
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-AllItems-VestmentsoftheVirtuous"
  value: {
-  dps: 54.36306
-  tps: 57.47404
+  dps: 54.36378
+  tps: 57.48017
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 96.08593
-  tps: 80.74056
+  dps: 96.12764
+  tps: 80.78292
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 102.91958
-  tps: 177.14688
+  dps: 102.83634
+  tps: 177.16043
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 102.91958
-  tps: 87.65574
+  dps: 102.83634
+  tps: 87.66928
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 115.02908
+  dps: 114.61423
   tps: 104.90497
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 67.86099
-  tps: 142.30149
+  dps: 67.79886
+  tps: 142.29871
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 67.86099
-  tps: 59.23709
+  dps: 67.79886
+  tps: 59.23431
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-NightElf-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 87.79327
-  tps: 79.72751
+  dps: 86.65417
+  tps: 79.36138
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 96.42072
-  tps: 169.16059
+  dps: 96.40348
+  tps: 169.24013
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 96.42072
-  tps: 80.81894
+  dps: 96.40348
+  tps: 80.89848
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 112.87632
+  dps: 112.4646
   tps: 101.30099
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 66.15934
-  tps: 139.41962
+  dps: 66.16485
+  tps: 139.48447
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 66.15934
-  tps: 57.40022
+  dps: 66.16485
+  tps: 57.46507
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 84.48138
-  tps: 76.36982
+  dps: 84.13832
+  tps: 76.26142
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 96.42072
-  tps: 80.81894
+  dps: 96.40348
+  tps: 80.89848
  }
 }
 dps_results: {
@@ -603,145 +603,145 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 616.49393
-  tps: 491.92817
+  dps: 616.36966
+  tps: 491.91368
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 615.01434
-  tps: 778.46208
+  dps: 614.07089
+  tps: 777.97399
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 615.01434
-  tps: 490.45125
+  dps: 614.07089
+  tps: 489.91091
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 589.29676
+  dps: 588.09828
   tps: 476.17304
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 418.54616
+  dps: 418.40522
   tps: 536.81367
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 418.54616
+  dps: 418.40522
   tps: 332.12354
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 457.99676
+  dps: 457.29279
   tps: 369.58089
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 615.47117
-  tps: 776.37738
+  dps: 615.76983
+  tps: 776.9357
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 615.47117
-  tps: 490.44925
+  dps: 615.76983
+  tps: 490.95531
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 588.13719
+  dps: 586.93871
   tps: 475.20992
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 412.36962
+  dps: 412.32511
   tps: 529.29259
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 412.36962
+  dps: 412.32511
   tps: 327.01546
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 458.42658
-  tps: 369.45174
+  dps: 456.71813
+  tps: 369.12507
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 618.41339
-  tps: 492.85567
+  dps: 618.26167
+  tps: 493.04169
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-AllItems-VestmentsoftheVirtuous"
  value: {
   dps: 298.82108
-  tps: 238.63274
+  tps: 238.56474
   hps: 4.65023
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1281.32454
-  tps: 1028.97747
-  hps: 11.81188
+  dps: 1281.42357
+  tps: 1029.17891
+  hps: 11.8172
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1742.95137
-  tps: 1780.49978
-  hps: 11.40421
+  dps: 1732.82807
+  tps: 1772.61738
+  hps: 11.40193
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 1282.34742
-  tps: 1027.35516
-  hps: 12.27402
+  dps: 1282.66557
+  tps: 1028.2553
+  hps: 12.31728
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 1302.93738
-  tps: 978.63613
+  dps: 1300.70233
+  tps: 979.992
   hps: 13.25709
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 846.9925
+  dps: 846.70858
   tps: 920.27959
   hps: 6.611
  }
@@ -749,7 +749,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 722.76441
+  dps: 722.48049
   tps: 573.28679
   hps: 7.98433
  }
@@ -757,39 +757,39 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-NightElf-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 874.7396
-  tps: 662.43288
+  dps: 873.56163
+  tps: 663.44907
   hps: 10.59667
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1710.0167
-  tps: 1748.83591
-  hps: 10.97158
+  dps: 1704.92405
+  tps: 1744.54468
+  hps: 10.98296
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 1270.77231
-  tps: 1020.652
-  hps: 12.06226
+  dps: 1268.61862
+  tps: 1019.35976
+  hps: 12.01216
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 1305.11635
-  tps: 981.88624
+  dps: 1302.96122
+  tps: 983.21613
   hps: 12.88138
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 833.14527
+  dps: 832.86134
   tps: 906.45084
   hps: 6.382
  }
@@ -797,7 +797,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 708.24001
+  dps: 707.95608
   tps: 559.99959
   hps: 7.84917
  }
@@ -805,115 +805,115 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 871.84474
-  tps: 660.59867
+  dps: 870.66677
+  tps: 661.06158
   hps: 10.31042
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1272.37092
-  tps: 1021.98242
-  hps: 12.05543
+  dps: 1272.78351
+  tps: 1022.84238
+  hps: 12.05315
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-BenevolentProphet'sVestments"
  value: {
-  dps: 2126.29383
-  tps: 2033.16304
+  dps: 2126.49565
+  tps: 2033.42716
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1688.98217
-  tps: 1611.68948
+  dps: 1689.64903
+  tps: 1612.46481
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-BloodGuard'sSatin"
  value: {
-  dps: 1558.71791
-  tps: 1488.94578
+  dps: 1559.34915
+  tps: 1489.70529
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1679.73166
-  tps: 1602.89623
+  dps: 1680.39558
+  tps: 1603.67164
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-EmeraldWovenGarb"
  value: {
-  dps: 1557.4136
-  tps: 1487.69049
+  dps: 1558.04483
+  tps: 1488.45221
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 648.20512
-  tps: 593.36248
+  dps: 648.42626
+  tps: 593.6857
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1688.98217
-  tps: 1611.68948
+  dps: 1689.64903
+  tps: 1612.46481
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-KnightLieutenant'sSatin"
  value: {
-  dps: 1558.71791
-  tps: 1488.94578
+  dps: 1559.34915
+  tps: 1489.70529
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 2254.26355
-  tps: 2154.03071
+  dps: 2254.67408
+  tps: 2154.47919
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-AllItems-VestmentsoftheVirtuous"
  value: {
-  dps: 644.45295
-  tps: 590.44256
+  dps: 644.67171
+  tps: 590.783
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3510.82658
-  tps: 3265.85244
+  dps: 3510.88314
+  tps: 3265.97672
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3995.98038
-  tps: 4279.00851
+  dps: 3996.6475
+  tps: 4279.64612
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3476.141
-  tps: 3223.75763
+  dps: 3476.28302
+  tps: 3224.05184
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3387.95166
-  tps: 2998.6868
+  dps: 3389.89741
+  tps: 3001.01242
  }
 }
 dps_results: {
@@ -927,35 +927,35 @@ dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 1902.24623
-  tps: 1756.9813
+  tps: 1757.04003
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 1873.77846
-  tps: 1646.58506
+  tps: 1646.93962
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4007.86357
-  tps: 4299.88601
+  dps: 4008.20427
+  tps: 4301.0732
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3476.4059
-  tps: 3224.70284
+  dps: 3476.54792
+  tps: 3224.98899
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3404.81164
-  tps: 3015.31425
+  dps: 3405.57243
+  tps: 3016.50038
  }
 }
 dps_results: {
@@ -969,119 +969,119 @@ dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 1891.30226
-  tps: 1747.00843
+  tps: 1747.07064
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 1873.40315
-  tps: 1647.02887
+  tps: 1647.42805
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3485.41477
-  tps: 3236.61612
+  dps: 3485.55679
+  tps: 3236.88414
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-BenevolentProphet'sVestments"
  value: {
-  dps: 2335.91271
-  tps: 2227.53962
+  dps: 2335.95874
+  tps: 2227.92177
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1825.07351
-  tps: 1738.31782
+  dps: 1825.43916
+  tps: 1738.9453
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-BloodGuard'sSatin"
  value: {
-  dps: 1689.21752
-  tps: 1610.39791
+  dps: 1689.5632
+  tps: 1611.0355
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1815.68343
-  tps: 1729.35988
+  dps: 1816.04743
+  tps: 1729.99143
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-EmeraldWovenGarb"
  value: {
-  dps: 1688.60046
-  tps: 1609.5553
+  dps: 1688.94615
+  tps: 1610.20634
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
   dps: 679.84452
-  tps: 622.33219
+  tps: 622.2118
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1825.07351
-  tps: 1738.31782
+  dps: 1825.43916
+  tps: 1738.9453
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-KnightLieutenant'sSatin"
  value: {
-  dps: 1689.21752
-  tps: 1610.39791
+  dps: 1689.5632
+  tps: 1611.0355
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 2465.39193
-  tps: 2350.2287
+  dps: 2465.57958
+  tps: 2350.70846
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-AllItems-VestmentsoftheVirtuous"
  value: {
   dps: 676.30735
-  tps: 619.25154
+  tps: 619.10013
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 3914.62348
-  tps: 3626.24544
+  dps: 3914.87856
+  tps: 3626.58355
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4189.06643
-  tps: 4435.68704
+  dps: 4189.65215
+  tps: 4441.15438
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3874.55468
-  tps: 3582.47598
+  dps: 3875.15605
+  tps: 3583.13453
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 3703.2354
-  tps: 3241.19119
+  tps: 3241.35205
  }
 }
 dps_results: {
@@ -1095,35 +1095,35 @@ dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 2081.87622
-  tps: 1910.90014
+  tps: 1910.97262
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 2029.10804
-  tps: 1765.71297
+  tps: 1766.09432
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 5034.2917
-  tps: 5119.52352
+  dps: 5035.2678
+  tps: 5131.32311
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3965.34789
-  tps: 3667.69722
+  dps: 3965.78061
+  tps: 3668.64101
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3779.5716
-  tps: 3316.71282
+  dps: 3783.17843
+  tps: 3322.8173
  }
 }
 dps_results: {
@@ -1137,35 +1137,35 @@ dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 2222.39335
-  tps: 2045.77252
+  tps: 2046.15802
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 2144.49094
-  tps: 1872.27435
+  tps: 1874.20185
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4168.95251
-  tps: 4430.15716
+  dps: 4169.7416
+  tps: 4435.10462
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3867.68545
-  tps: 3576.98332
+  dps: 3868.28681
+  tps: 3577.63957
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 3696.20063
-  tps: 3237.40171
+  tps: 3237.50702
  }
 }
 dps_results: {
@@ -1179,35 +1179,35 @@ dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 2077.36901
-  tps: 1906.72999
+  tps: 1906.8004
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 2025.49982
-  tps: 1763.01039
+  tps: 1763.39319
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 5016.68517
-  tps: 5110.17357
+  dps: 5017.48371
+  tps: 5120.83635
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3959.50541
-  tps: 3662.536
+  dps: 3959.68617
+  tps: 3663.23791
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3776.21259
-  tps: 3317.03148
+  dps: 3777.94963
+  tps: 3321.34097
  }
 }
 dps_results: {
@@ -1221,20 +1221,20 @@ dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
   dps: 2218.56131
-  tps: 2042.26223
+  tps: 2042.64933
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
   dps: 2140.00882
-  tps: 1870.06062
+  tps: 1871.99612
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
   dps: 3888.09149
-  tps: 3599.02151
+  tps: 3599.10046
  }
 }

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestAssassination-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.30636
-  weights: 0.51894
+  weights: 0.30559
+  weights: 0.5116
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.27851
-  weights: 2.52031
-  weights: 2.19659
+  weights: 0.27781
+  weights: 2.47318
+  weights: 2.20149
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestAssassination-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.37853
-  weights: 0.62929
+  weights: 0.37633
+  weights: 0.63147
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.34412
-  weights: 5.18188
-  weights: 4.2533
+  weights: 0.34212
+  weights: 5.14343
+  weights: 4.25831
   weights: 0
   weights: 0
   weights: 0
@@ -197,15 +197,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestAssassination-Phase1-Lvl25-AllItems-DarkmantleArmor"
  value: {
-  dps: 145.02684
-  tps: 102.96905
+  dps: 144.79724
+  tps: 102.80604
  }
 }
 dps_results: {
  key: "TestAssassination-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 273.75018
-  tps: 194.36263
+  dps: 273.37217
+  tps: 194.09424
  }
 }
 dps_results: {
@@ -295,22 +295,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 261.66137
-  tps: 185.77957
+  dps: 261.72602
+  tps: 185.82548
  }
 }
 dps_results: {
  key: "TestAssassination-Phase2-Lvl40-AllItems-DarkmantleArmor"
  value: {
-  dps: 207.55559
-  tps: 147.36447
+  dps: 207.17383
+  tps: 147.09342
  }
 }
 dps_results: {
  key: "TestAssassination-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 570.02535
-  tps: 404.718
+  dps: 568.12431
+  tps: 403.36826
  }
 }
 dps_results: {
@@ -400,7 +400,7 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 548.88284
-  tps: 389.70681
+  dps: 548.13568
+  tps: 389.17633
  }
 }

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestCombat-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.24298
-  weights: 0.45889
+  weights: 0.24272
+  weights: 0.45075
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22089
-  weights: 1.66493
-  weights: 1.81572
+  weights: 0.22065
+  weights: 1.85171
+  weights: 1.82161
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestCombat-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.36319
-  weights: 0.58576
+  weights: 0.36156
+  weights: 0.58814
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.33018
-  weights: 3.66536
-  weights: 3.68081
+  weights: 0.32869
+  weights: 3.8469
+  weights: 3.65987
   weights: 0
   weights: 0
   weights: 0
@@ -197,15 +197,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestCombat-Phase1-Lvl25-AllItems-DarkmantleArmor"
  value: {
-  dps: 259.43493
-  tps: 184.1988
+  dps: 258.17768
+  tps: 183.30616
  }
 }
 dps_results: {
  key: "TestCombat-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 214.7804
-  tps: 152.49408
+  dps: 214.72666
+  tps: 152.45593
  }
 }
 dps_results: {
@@ -295,22 +295,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 202.00453
-  tps: 143.42322
+  dps: 202.00594
+  tps: 143.42422
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-AllItems-DarkmantleArmor"
  value: {
-  dps: 265.13611
-  tps: 188.24664
+  dps: 264.57647
+  tps: 187.8493
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 522.66673
-  tps: 371.09338
+  dps: 521.54556
+  tps: 370.29735
  }
 }
 dps_results: {
@@ -400,7 +400,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 500.5303
-  tps: 355.37652
+  dps: 497.77303
+  tps: 353.41885
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -298,18 +298,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.98263
+  weights: 1.0974
   weights: 0
-  weights: 0.83676
+  weights: 0.837
   weights: 0
-  weights: 0.25479
-  weights: 0
-  weights: 0
-  weights: 0.58198
+  weights: 0.25475
   weights: 0
   weights: 0
-  weights: 6.81858
-  weights: 3.26972
+  weights: 0.58225
+  weights: 0
+  weights: 0
+  weights: 6.95667
+  weights: 3.28275
   weights: 0
   weights: 0
   weights: 0
@@ -396,9 +396,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.19735
+  weights: 2.19734
   weights: 0
-  weights: 1.73101
+  weights: 1.731
   weights: 0
   weights: 0.54471
   weights: 0
@@ -407,7 +407,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 30.70618
-  weights: 16.11833
+  weights: 16.1169
   weights: 0
   weights: 0
   weights: 0
@@ -491,8 +491,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestElemental-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 197.03751
-  tps: 157.08273
+  dps: 197.0368
+  tps: 157.08202
  }
 }
 dps_results: {
@@ -589,8 +589,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 601.44136
-  tps: 505.87897
+  dps: 601.437
+  tps: 505.88737
  }
 }
 dps_results: {
@@ -680,15 +680,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 596.84955
-  tps: 504.58152
+  dps: 596.75114
+  tps: 504.33358
  }
 }
 dps_results: {
  key: "TestElemental-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1515.21219
-  tps: 1315.48896
+  dps: 1515.21218
+  tps: 1315.48894
  }
 }
 dps_results: {
@@ -848,8 +848,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3226.24543
-  tps: 1972.8315
+  dps: 3226.24581
+  tps: 1972.83162
  }
 }
 dps_results: {
@@ -1009,8 +1009,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4222.71714
-  tps: 2550.60172
+  dps: 4222.71645
+  tps: 2550.60123
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -246,8 +246,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase1-Lvl25-StatWeights-Default"
  value: {
-  weights: 0.34792
-  weights: 0.24153
+  weights: 0.34791
+  weights: 0.24781
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.15815
-  weights: 1.33554
-  weights: 1.66171
+  weights: 0.15814
+  weights: 1.33335
+  weights: 1.68198
   weights: 0
   weights: 0
   weights: 0
@@ -295,16 +295,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 1.01354
-  weights: 0.85346
+  weights: 1.01243
+  weights: 0.40709
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37164
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.3719
   weights: 0
   weights: 0
   weights: 0
@@ -312,9 +308,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.4607
-  weights: 3.73667
-  weights: 7.28111
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.46019
+  weights: 3.14901
+  weights: 6.81633
   weights: 0
   weights: 0
   weights: 0
@@ -344,16 +344,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.60272
-  weights: 0.76683
+  weights: 1.60127
+  weights: 0.61636
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.43084
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.43188
   weights: 0
   weights: 0
   weights: 0
@@ -361,9 +357,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.67455
-  weights: 6.62175
-  weights: 10.15468
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.67393
+  weights: 5.63375
+  weights: 10.11767
   weights: 0
   weights: 0
   weights: 0
@@ -393,16 +393,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.07498
-  weights: 0.50573
+  weights: 2.07157
+  weights: 0.20361
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.76241
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.75973
   weights: 0
   weights: 0
   weights: 0
@@ -410,9 +406,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.94317
-  weights: 29.15617
-  weights: 10.97165
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.94162
+  weights: 26.60824
+  weights: 9.6735
   weights: 0
   weights: 0
   weights: 0
@@ -442,16 +442,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestEnhancement-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.51507
-  weights: 0.78946
+  weights: 2.52146
+  weights: 0.98864
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.83835
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
+  weights: 0.83925
   weights: 0
   weights: 0
   weights: 0
@@ -459,9 +455,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.9941
-  weights: 28.18901
-  weights: 14.0186
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.99662
+  weights: 26.56841
+  weights: 13.04911
   weights: 0
   weights: 0
   weights: 0
@@ -491,8 +491,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestEnhancement-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 163.89109
-  tps: 163.05328
+  dps: 163.88671
+  tps: 163.0489
  }
 }
 dps_results: {
@@ -666,15 +666,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 154.97819
-  tps: 154.08401
+  dps: 154.9952
+  tps: 154.10102
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 814.75955
-  tps: 865.86165
+  dps: 814.69254
+  tps: 865.80412
  }
 }
 dps_results: {
@@ -848,15 +848,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 751.67928
-  tps: 798.92317
+  dps: 753.13724
+  tps: 800.85362
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1719.73143
-  tps: 1259.19952
+  dps: 1719.34681
+  tps: 1258.78226
  }
 }
 dps_results: {
@@ -1030,78 +1030,78 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1602.98804
-  tps: 1170.47499
+  dps: 1599.282
+  tps: 1170.67529
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-BloodGuard'sInscribedMail"
  value: {
-  dps: 1851.65307
-  tps: 1876.06964
+  dps: 1849.47794
+  tps: 1875.79395
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 1920.47366
-  tps: 1943.59256
+  dps: 1918.07366
+  tps: 1943.13934
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-BloodGuard'sPulsingMail"
  value: {
-  dps: 1976.34323
-  tps: 2004.6623
+  dps: 1956.08072
+  tps: 1982.90661
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-EmeraldChainmail"
  value: {
-  dps: 1897.14554
-  tps: 1921.44245
+  dps: 1894.62572
+  tps: 1921.1968
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-EmeraldLadenChain"
  value: {
-  dps: 1851.17435
-  tps: 1875.55821
+  dps: 1848.4291
+  tps: 1875.01903
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 1898.2085
-  tps: 1921.67734
+  dps: 1895.23608
+  tps: 1920.91075
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-OstracizedBerserker'sBattlemail"
  value: {
-  dps: 2798.9139
-  tps: 2856.00767
+  dps: 2810.13676
+  tps: 2870.68055
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-ShunnedDevotee'sChainmail"
  value: {
-  dps: 2740.59115
-  tps: 2798.17715
+  dps: 2755.81179
+  tps: 2818.85444
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-AllItems-TheFiveThunders"
  value: {
-  dps: 1515.63934
-  tps: 1548.20316
+  dps: 1521.68227
+  tps: 1555.65418
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3723.99979
-  tps: 2658.73994
+  dps: 3721.81576
+  tps: 2657.21696
  }
 }
 dps_results: {
@@ -1443,78 +1443,78 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3007.68156
-  tps: 2149.26574
+  dps: 3014.34786
+  tps: 2149.12888
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-BloodGuard'sInscribedMail"
  value: {
-  dps: 1950.337
-  tps: 1968.3169
+  dps: 1945.13433
+  tps: 1961.04784
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 2026.11203
-  tps: 2042.72108
+  dps: 2021.34564
+  tps: 2035.95824
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-BloodGuard'sPulsingMail"
  value: {
-  dps: 2070.91439
-  tps: 2087.74756
+  dps: 2072.22355
+  tps: 2088.2461
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-EmeraldChainmail"
  value: {
-  dps: 1999.11383
-  tps: 2016.73964
+  dps: 1993.99775
+  tps: 2009.56583
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-EmeraldLadenChain"
  value: {
-  dps: 1949.461
-  tps: 1967.5402
+  dps: 1944.78047
+  tps: 1960.87422
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 1995.7668
-  tps: 2012.9365
+  dps: 1991.10622
+  tps: 2006.27953
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-OstracizedBerserker'sBattlemail"
  value: {
-  dps: 3199.57164
-  tps: 3250.77537
+  dps: 3195.99393
+  tps: 3243.88992
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-ShunnedDevotee'sChainmail"
  value: {
-  dps: 3136.17647
-  tps: 3190.58288
+  dps: 3133.53913
+  tps: 3183.88531
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-AllItems-TheFiveThunders"
  value: {
-  dps: 1590.68827
-  tps: 1620.33677
+  dps: 1591.50943
+  tps: 1620.21196
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4350.04005
-  tps: 3099.42381
+  dps: 4346.95992
+  tps: 3097.73429
  }
 }
 dps_results: {
@@ -1856,7 +1856,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3589.80429
-  tps: 2552.58564
+  dps: 3586.45636
+  tps: 2555.03835
  }
 }

--- a/sim/shaman/warden/TestWardenShaman.results
+++ b/sim/shaman/warden/TestWardenShaman.results
@@ -50,24 +50,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestWardenShaman-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 1.10709
+  weights: 1.10733
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.48758
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0.50322
+  weights: 0.48821
   weights: 0
   weights: 0
   weights: 0
@@ -78,7 +66,19 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.94812
+  weights: 0
+  weights: 0.50333
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.95019
   weights: 0
   weights: 0
   weights: 0
@@ -99,64 +99,64 @@ stat_weights_results: {
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-BloodGuard'sInscribedMail"
  value: {
-  dps: 1129.45538
-  tps: 1170.54804
+  dps: 1130.37677
+  tps: 1171.93995
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-BloodGuard'sMail"
  value: {
-  dps: 1177.31269
-  tps: 1216.89486
+  dps: 1178.21861
+  tps: 1218.20431
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-BloodGuard'sPulsingMail"
  value: {
-  dps: 1170.38676
-  tps: 1213.41062
+  dps: 1169.52495
+  tps: 1212.63273
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-EmeraldChainmail"
  value: {
-  dps: 1156.94948
-  tps: 1197.98387
+  dps: 1157.93481
+  tps: 1199.37725
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-EmeraldLadenChain"
  value: {
-  dps: 1129.28813
-  tps: 1170.02297
+  dps: 1130.20952
+  tps: 1171.32503
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-EmeraldScalemail"
  value: {
-  dps: 1162.03191
-  tps: 1201.90605
+  dps: 1162.94275
+  tps: 1203.1976
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-OstracizedBerserker'sBattlemail"
  value: {
-  dps: 1733.09486
-  tps: 1923.79469
+  dps: 1734.01986
+  tps: 1924.86118
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-AllItems-TheFiveThunders"
  value: {
-  dps: 1031.91261
-  tps: 1064.15773
+  dps: 1032.16452
+  tps: 1064.34119
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 1945.48666
-  tps: 1558.48667
+  dps: 1945.40033
+  tps: 1558.35717
  }
 }
 dps_results: {
@@ -246,7 +246,7 @@ dps_results: {
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1676.85039
-  tps: 1363.68216
+  dps: 1678.84637
+  tps: 1366.52146
  }
 }

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.35323
+  weights: -2.23037
   weights: 0
-  weights: 1.21386
-  weights: 0
-  weights: 0
+  weights: 0.82749
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 13.02962
-  weights: 10.2224
+  weights: 0
+  weights: 0
+  weights: 12.68882
+  weights: 10.58563
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Phase1-Lvl25-AllItems-DeathmistRaiment"
  value: {
-  dps: 127.14306
-  tps: 104.02001
+  dps: 127.14277
+  tps: 104.02084
  }
 }
 dps_results: {
@@ -267,78 +267,78 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1466.14183
-  tps: 1700.27973
+  dps: 1468.46347
+  tps: 1704.48836
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 1290.64359
-  tps: 1466.41987
+  dps: 1287.45869
+  tps: 1463.26225
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1455.19224
-  tps: 1685.58911
+  dps: 1452.05859
+  tps: 1677.9522
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 1994.08044
-  tps: 3968.83875
+  dps: 1995.79641
+  tps: 3961.39606
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 1238.32529
-  tps: 1393.08421
+  dps: 1237.50858
+  tps: 1395.06028
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 1976.71094
-  tps: 3940.1778
+  dps: 1976.7724
+  tps: 3928.99779
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1466.14183
-  tps: 1700.27973
+  dps: 1468.46347
+  tps: 1704.48836
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1638.79406
-  tps: 3278.1879
+  dps: 1643.14514
+  tps: 3290.60963
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1616.44151
-  tps: 3225.40016
+  dps: 1619.30817
+  tps: 3229.97996
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 1992.14926
-  tps: 3968.83875
+  dps: 1993.91348
+  tps: 3961.39606
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2016.49578
-  tps: 4011.9689
+  dps: 2016.3894
+  tps: 4011.14971
  }
 }
 dps_results: {
@@ -386,7 +386,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1967.58015
-  tps: 3905.17213
+  dps: 1973.05036
+  tps: 3918.19344
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.55984
+  weights: 3.21349
   weights: 0
-  weights: 1.85685
-  weights: 0
-  weights: 0
+  weights: 1.45493
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 17.01172
-  weights: 8.8908
+  weights: 0
+  weights: 0
+  weights: 19.36688
+  weights: 13.04155
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestDemonology-Phase2-Lvl40-AllItems-DeathmistRaiment"
  value: {
-  dps: 129.81835
-  tps: 144.88996
+  dps: 129.81135
+  tps: 144.88213
  }
 }
 dps_results: {
@@ -211,8 +211,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 361.90423
-  tps: 1085.03784
+  dps: 361.90365
+  tps: 1085.03655
  }
 }
 dps_results: {
@@ -267,8 +267,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1138.59531
-  tps: 433.34571
+  dps: 1143.57956
+  tps: 439.59268
  }
 }
 dps_results: {
@@ -281,15 +281,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1139.40543
-  tps: 440.10116
+  dps: 1132.87223
+  tps: 435.90495
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2212.39829
-  tps: 4552.88934
+  dps: 2212.53865
+  tps: 4570.46869
  }
 }
 dps_results: {
@@ -302,91 +302,91 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 2283.44355
-  tps: 4508.60797
+  dps: 2281.57517
+  tps: 4515.28522
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1138.59531
-  tps: 433.34571
+  dps: 1143.57956
+  tps: 439.59268
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1226.7776
-  tps: 1392.15732
+  dps: 1224.9529
+  tps: 1384.03985
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1208.39807
-  tps: 1371.11636
+  dps: 1213.09309
+  tps: 1380.32209
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2212.39829
-  tps: 4552.88934
+  dps: 2212.53865
+  tps: 4570.46869
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2224.59628
-  tps: 4592.99086
+  dps: 2223.38054
+  tps: 4591.0074
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2802.7323
-  tps: 8636.29423
+  dps: 2803.28523
+  tps: 8643.52803
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2161.97755
-  tps: 4421.3263
+  dps: 2164.89277
+  tps: 4420.34769
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 2138.59165
-  tps: 4401.05935
+  dps: 2138.17889
+  tps: 4402.18279
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1197.32184
+  dps: 1196.00105
   tps: 5398.49904
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 901.78358
+  dps: 900.49345
   tps: 2060.23075
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 902.53661
+  dps: 896.86728
   tps: 2093.08757
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2182.67939
-  tps: 4495.98194
+  dps: 2181.43303
+  tps: 4483.11976
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.16679
+  weights: -0.12449
   weights: 0
-  weights: 0.70239
-  weights: 0
-  weights: 0
+  weights: 0.70121
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 5.47005
-  weights: 3.33947
+  weights: 0
+  weights: 0
+  weights: 5.63167
+  weights: 3.35675
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.94295
+  weights: 1.27754
   weights: 0
-  weights: 2.03278
-  weights: 0
-  weights: 0
+  weights: 1.66816
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 15.27461
-  weights: 11.90709
+  weights: 0
+  weights: 0
+  weights: 16.5242
+  weights: 12.45582
   weights: 0
   weights: 0
   weights: 0
@@ -393,8 +393,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestDestruction-Phase1-Lvl25-AllItems-DeathmistRaiment"
  value: {
-  dps: 105.2716
-  tps: 68.20073
+  dps: 105.32162
+  tps: 68.66172
  }
 }
 dps_results: {
@@ -463,22 +463,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-AllItems-DeathmistRaiment"
  value: {
-  dps: 143.72003
-  tps: 90.88508
+  dps: 143.71864
+  tps: 90.89054
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 471.12143
-  tps: 1324.67265
+  dps: 471.63877
+  tps: 1325.84737
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 467.45396
-  tps: 1313.67479
+  dps: 467.37423
+  tps: 1313.37879
  }
 }
 dps_results: {
@@ -526,32 +526,32 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 461.20141
-  tps: 1300.21692
+  dps: 461.58637
+  tps: 1301.56464
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-AllItems-DeathmistRaiment"
  value: {
-  dps: 344.46525
-  tps: 228.28192
-  hps: 7.27404
+  dps: 344.27526
+  tps: 228.46012
+  hps: 7.3256
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 1317.32864
-  tps: 2684.22587
-  hps: 11.94084
+  dps: 1317.32886
+  tps: 2684.22626
+  hps: 11.94107
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1316.26654
-  tps: 2680.22524
-  hps: 11.54273
+  dps: 1316.26539
+  tps: 2680.22266
+  hps: 11.54306
  }
 }
 dps_results: {
@@ -605,86 +605,86 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1299.42006
-  tps: 2643.93201
-  hps: 11.69731
+  dps: 1299.42028
+  tps: 2643.9324
+  hps: 11.69753
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1520.02024
-  tps: 1854.53454
+  dps: 1522.46659
+  tps: 1858.58549
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 1332.17163
-  tps: 1598.29642
+  dps: 1337.8832
+  tps: 1610.90965
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1515.92318
-  tps: 1853.45874
+  dps: 1525.6606
+  tps: 1867.8479
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2018.07197
-  tps: 4173.52306
+  dps: 2021.84495
+  tps: 4190.19379
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 1283.14264
-  tps: 1532.59682
+  dps: 1275.02635
+  tps: 1518.05902
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 2011.36919
-  tps: 4168.8194
+  dps: 2010.87578
+  tps: 4171.98596
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1520.02024
-  tps: 1854.53454
+  dps: 1522.46659
+  tps: 1858.58549
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1666.90939
-  tps: 3494.41565
+  dps: 1664.17472
+  tps: 3483.86113
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1659.5448
-  tps: 3480.04968
+  dps: 1664.71966
+  tps: 3490.06343
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2016.19416
-  tps: 4173.52306
+  dps: 2019.88093
+  tps: 4190.19379
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2034.59444
-  tps: 4219.18374
+  dps: 2035.04597
+  tps: 4219.62322
  }
 }
 dps_results: {
@@ -732,7 +732,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1987.31149
-  tps: 4143.74094
+  dps: 1984.5261
+  tps: 4131.05885
  }
 }

--- a/sim/warrior/dps_warrior/TestDualWieldWarrior.results
+++ b/sim/warrior/dps_warrior/TestDualWieldWarrior.results
@@ -148,8 +148,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.94302
-  weights: 1.01776
+  weights: 0.1642
+  weights: 0.07715
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.58982
-  weights: 7.17749
-  weights: 8.54288
+  weights: 0.71965
+  weights: 8.44477
+  weights: 8.35111
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.08894
-  weights: 1.0931
+  weights: 2.06213
+  weights: 1.4984
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +214,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.88147
-  weights: 2.81365
-  weights: 24.54815
+  weights: 1.17945
+  weights: 5.54724
+  weights: 24.85866
   weights: 0
   weights: 0
   weights: 0
@@ -246,8 +246,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 1.70501
-  weights: 1.00876
+  weights: 2.36943
+  weights: 1.67032
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.29549
-  weights: 36.03048
-  weights: 24.87437
+  weights: 0.45228
+  weights: 38.08932
+  weights: 25.51098
   weights: 0
   weights: 0
   weights: 0
@@ -295,15 +295,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-AllItems-BattlegearofHeroism"
  value: {
-  dps: 548.19856
-  tps: 487.19115
+  dps: 549.93761
+  tps: 488.71629
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 608.16526
-  tps: 537.4594
+  dps: 607.36853
+  tps: 536.6699
  }
 }
 dps_results: {
@@ -393,57 +393,57 @@ dps_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 569.57811
-  tps: 504.09767
+  dps: 562.85785
+  tps: 498.46466
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
-  dps: 2639.76655
-  tps: 2287.1778
+  dps: 2640.40383
+  tps: 2285.16758
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 1989.92848
-  tps: 1756.64517
+  dps: 2006.20591
+  tps: 1771.85472
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
-  dps: 2383.14096
-  tps: 2063.07283
+  dps: 2380.76863
+  tps: 2062.39792
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
-  dps: 2336.87499
-  tps: 2025.53882
+  dps: 2343.79433
+  tps: 2030.92792
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
-  dps: 2383.14096
-  tps: 2063.07283
+  dps: 2380.76863
+  tps: 2062.39792
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
-  dps: 2797.62709
-  tps: 2413.38735
+  dps: 2809.42001
+  tps: 2424.62313
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3617.97964
-  tps: 2841.24899
+  dps: 3650.52686
+  tps: 2864.96759
  }
 }
 dps_results: {
@@ -533,57 +533,57 @@ dps_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2840.1998
-  tps: 2237.93399
+  dps: 2860.91955
+  tps: 2251.81103
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
-  dps: 2983.8361
-  tps: 2565.68699
+  dps: 3018.44087
+  tps: 2594.68586
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 2065.16729
-  tps: 1812.30237
+  dps: 2083.31057
+  tps: 1826.4189
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
-  dps: 2525.35944
-  tps: 2175.23509
+  dps: 2528.78496
+  tps: 2176.47446
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
-  dps: 2491.20194
-  tps: 2147.10994
+  dps: 2497.57838
+  tps: 2150.89473
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
-  dps: 2525.35944
-  tps: 2175.23509
+  dps: 2528.78496
+  tps: 2176.47446
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
-  dps: 3198.42156
-  tps: 2744.70651
+  dps: 3219.55159
+  tps: 2763.33934
  }
 }
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4210.88702
-  tps: 3277.22592
+  dps: 4247.68499
+  tps: 3309.32956
  }
 }
 dps_results: {
@@ -757,7 +757,7 @@ dps_results: {
 dps_results: {
  key: "TestDualWieldWarrior-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3349.17822
-  tps: 2599.69152
+  dps: 3355.53135
+  tps: 2609.97597
  }
 }

--- a/sim/warrior/dps_warrior/TestTwoHandedWarrior.results
+++ b/sim/warrior/dps_warrior/TestTwoHandedWarrior.results
@@ -99,8 +99,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.25244
-  weights: 0.77304
+  weights: 1.28624
+  weights: 0.95655
   weights: 0
   weights: 0
   weights: 0
@@ -116,9 +116,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.56223
-  weights: 16.38978
-  weights: 10.07868
+  weights: 0.50989
+  weights: 15.71723
+  weights: 10.32656
   weights: 0
   weights: 0
   weights: 0
@@ -148,8 +148,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 3.34876
-  weights: 1.0076
+  weights: 2.35203
+  weights: 1.10467
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.03342
+  weights: 1.07254
   weights: 0
-  weights: 22.78528
+  weights: 21.72808
   weights: 0
   weights: 0
   weights: 0
@@ -197,15 +197,15 @@ stat_weights_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-AllItems-BattlegearofHeroism"
  value: {
-  dps: 800.40886
-  tps: 693.884
+  dps: 800.37525
+  tps: 689.41703
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1166.94161
-  tps: 996.96535
+  dps: 1168.22826
+  tps: 998.0197
  }
 }
 dps_results: {
@@ -295,57 +295,57 @@ dps_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1089.05509
-  tps: 930.74883
+  dps: 1088.73646
+  tps: 934.41168
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
-  dps: 2504.77138
-  tps: 2083.76618
+  dps: 2518.71782
+  tps: 2094.62934
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 1565.42218
-  tps: 1327.72205
+  dps: 1564.08877
+  tps: 1326.46969
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
-  dps: 1873.49327
-  tps: 1579.06599
+  dps: 1875.8462
+  tps: 1581.55023
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
-  dps: 1850.97693
-  tps: 1559.77514
+  dps: 1857.29159
+  tps: 1565.29553
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
-  dps: 1873.49327
-  tps: 1579.06599
+  dps: 1875.8462
+  tps: 1581.55023
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
-  dps: 2726.18727
-  tps: 2268.80937
+  dps: 2736.74289
+  tps: 2276.7602
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4225.43592
-  tps: 3208.61384
+  dps: 4249.86633
+  tps: 3224.99437
  }
 }
 dps_results: {
@@ -519,7 +519,7 @@ dps_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3474.08653
-  tps: 2619.60305
+  dps: 3490.71511
+  tps: 2629.23325
  }
 }

--- a/sim/warrior/tank_warrior/TestTankWarrior.results
+++ b/sim/warrior/tank_warrior/TestTankWarrior.results
@@ -50,7 +50,7 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestTankWarrior-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 0.67457
+  weights: 0.8209
   weights: 0
   weights: 0
   weights: 0
@@ -67,7 +67,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.33114
+  weights: 0.81875
   weights: 0
   weights: 0
   weights: 0
@@ -78,9 +78,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.98529
+  weights: 1.08872
   weights: 0
-  weights: 0.52203
+  weights: 0.52154
   weights: 0
   weights: 0
   weights: 0
@@ -99,50 +99,50 @@ stat_weights_results: {
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
-  dps: 1569.66853
-  tps: 3500.40882
+  dps: 1578.6191
+  tps: 3514.79604
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 892.14386
-  tps: 1833.87664
+  dps: 894.07226
+  tps: 1833.25799
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
-  dps: 894.06096
-  tps: 1873.17485
+  dps: 896.47086
+  tps: 1878.68094
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
-  dps: 885.04529
-  tps: 1854.793
+  dps: 887.05895
+  tps: 1859.49476
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
-  dps: 894.06096
-  tps: 1873.17485
+  dps: 896.47086
+  tps: 1878.68094
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
-  dps: 1653.52702
-  tps: 3604.66287
+  dps: 1660.38468
+  tps: 3617.59261
  }
 }
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 1489.19615
-  tps: 3861.70571
+  dps: 1493.58665
+  tps: 3875.08542
  }
 }
 dps_results: {
@@ -232,7 +232,7 @@ dps_results: {
 dps_results: {
  key: "TestTankWarrior-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1268.18215
-  tps: 3318.34203
+  dps: 1269.68994
+  tps: 3325.92185
  }
 }

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -826,7 +826,7 @@ export class Timeline extends ResultComponent {
 			const totalDamage = castLog.totalDamage();
 
 			if (index > 0) {
-				let timeDelta = 0.0;
+				let timeDelta = null;
 
 				for (let i = index - 1; i >= 0; i--) {
 					if (castLog.timestamp != castLogs[i].timestamp) {
@@ -834,7 +834,7 @@ export class Timeline extends ResultComponent {
 						break;
 					}
 				}
-				if (timeDelta < 0.21) {
+				if (timeDelta != null && timeDelta < 0.21) {
 					stackedDamageCount = stackedDamageCount + castLog.damageDealtLogs.length;
 					stackedIconCount = stackedIconCount + 1;
 				} else {


### PR DESCRIPTION
Rework WS to work like https://github.com/magey/classic-warrior/wiki/Windfury-Totem#triggered-by-melee-spell
Autos have a cast batch where damage and result are calculated, and a damage batch where autos are applied.

This should allow two Instant stike GCD's in a row to proc WS with the second ability benefiting from the AP of the first proc.
(Same for autos but harder to time / align)

Refactored WS/ WF totem to share the same helper function code.

Still need to prevent WS/WF AP from turning off in the middle of a batch though.