### PR TITLE
Hunter - Updated LnL and cast parameters for traps

### DIFF
--- a/sim/hunter/TestBM.results
+++ b/sim/hunter/TestBM.results
@@ -162,43 +162,43 @@ dps_results: {
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 567.26085
-  tps: 553.95917
+  dps: 562.98969
+  tps: 652.08788
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 505.20776
-  tps: 254.57938
+  dps: 499.13554
+  tps: 255.50927
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 545.03818
-  tps: 272.18488
+  dps: 543.41093
+  tps: 273.10354
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 315.55257
-  tps: 443.55725
+  dps: 310.85323
+  tps: 537.92342
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 273.46457
-  tps: 150.82965
+  dps: 268.97345
+  tps: 152.46171
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-NightElf-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 301.16659
-  tps: 158.07909
+  dps: 299.52732
+  tps: 160.35994
  }
 }
 dps_results: {
@@ -330,43 +330,43 @@ dps_results: {
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 571.31483
-  tps: 552.66641
+  dps: 565.97312
+  tps: 646.00883
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 510.27201
-  tps: 251.468
+  dps: 503.39582
+  tps: 253.18597
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 550.33215
-  tps: 269.14844
+  dps: 548.74107
+  tps: 270.25405
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 317.77559
-  tps: 436.8621
+  dps: 314.79992
+  tps: 527.30323
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 277.23403
-  tps: 148.24697
+  dps: 273.11766
+  tps: 149.79524
  }
 }
 dps_results: {
  key: "TestBM-Phase2-Lvl40-Settings-Orc-p2_melee-Basic-p2_ranged_bm-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 305.64124
-  tps: 156.42683
+  dps: 303.67211
+  tps: 159.52613
  }
 }
 dps_results: {

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestMM-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.5578
+  weights: 0.56071
   weights: 0
   weights: 0
   weights: 0
@@ -167,7 +167,7 @@ stat_weights_results: {
   weights: 0
   weights: 0.19929
   weights: 0
-  weights: 4.92355
+  weights: 4.91485
   weights: 0
   weights: 0
   weights: 0
@@ -175,7 +175,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.04142
+  weights: 0.0416
   weights: 0
   weights: 0
   weights: 0
@@ -325,41 +325,41 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 883.16066
-  tps: 883.26743
-  hps: 12.98671
+  dps: 882.86792
+  tps: 882.97468
+  hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 881.83734
-  tps: 881.94411
-  hps: 12.98671
+  dps: 881.52041
+  tps: 881.62717
+  hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 874.8801
-  tps: 874.98686
-  hps: 12.98671
+  dps: 874.59814
+  tps: 874.7049
+  hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 649.97155
-  tps: 650.082
-  hps: 9.5936
+  dps: 649.6826
+  tps: 649.79305
+  hps: 9.63591
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 884.64938
-  tps: 884.75614
-  hps: 12.98671
+  dps: 884.35663
+  tps: 884.4634
+  hps: 13.05826
  }
 }
 dps_results: {
@@ -373,49 +373,49 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 882.79632
-  tps: 882.90309
-  hps: 12.81677
+  dps: 883.53127
+  tps: 883.63803
+  hps: 12.90919
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 871.0379
-  tps: 871.14467
-  hps: 12.98671
+  dps: 870.75085
+  tps: 870.85761
+  hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 830.17486
-  tps: 830.28163
-  hps: 12.98671
+  dps: 829.64064
+  tps: 829.74741
+  hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 753.54921
-  tps: 753.65598
-  hps: 12.98671
+  dps: 753.74121
+  tps: 753.84798
+  hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 867.37004
-  tps: 867.47681
-  hps: 12.98671
+  dps: 867.17621
+  tps: 867.28297
+  hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 886.58041
-  tps: 886.68136
-  hps: 13.05262
+  dps: 890.51203
+  tps: 890.62612
+  hps: 13.07849
  }
 }
 dps_results: {
@@ -517,8 +517,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 734.31858
-  tps: 734.42404
-  hps: 11.10659
+  dps: 736.7815
+  tps: 736.88696
+  hps: 11.07677
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestSV-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 3.16173
+  weights: 2.91573
   weights: 0
   weights: 0
   weights: 0
@@ -165,17 +165,17 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.41796
+  weights: 0.40288
   weights: 0
-  weights: 20.03472
-  weights: 0
-  weights: 0
+  weights: 19.94752
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.48544
+  weights: 0
+  weights: 0
+  weights: 0.43042
   weights: 0
   weights: 0
   weights: 0
@@ -309,216 +309,216 @@ dps_results: {
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 1121.31781
-  tps: 892.78286
-  hps: 14.0543
+  dps: 1076.76436
+  tps: 849.47529
+  hps: 14.05876
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 1394.3078
-  tps: 1141.90996
-  hps: 14.0543
+  dps: 1211.32045
+  tps: 960.10953
+  hps: 14.05876
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 1395.09295
-  tps: 1397.06216
-  hps: 11.3294
+  dps: 1678.51503
+  tps: 1685.54194
+  hps: 13.51585
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 3499.2091
-  tps: 3107.79585
+  dps: 3204.71962
+  tps: 2819.08332
   hps: 20.32407
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 3470.58514
-  tps: 3082.48228
+  dps: 3178.40028
+  tps: 2795.96696
   hps: 20.32407
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 2078.56504
-  tps: 1804.91406
-  hps: 15.36912
+  dps: 1898.85226
+  tps: 1631.46002
+  hps: 15.28197
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 1423.76871
-  tps: 1425.73792
-  hps: 11.3294
+  dps: 1712.09163
+  tps: 1719.11854
+  hps: 13.51585
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 1394.3078
-  tps: 1141.90996
-  hps: 14.0543
+  dps: 1211.32045
+  tps: 960.10953
+  hps: 14.05876
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 3518.23729
-  tps: 3131.87442
-  hps: 20.19509
+  dps: 3228.56145
+  tps: 2849.57035
+  hps: 19.98627
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 3428.3682
-  tps: 3050.01685
-  hps: 20.34556
+  dps: 3131.60599
+  tps: 2751.90642
+  hps: 20.321
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 3137.99584
-  tps: 2794.43882
+  dps: 2875.67596
+  tps: 2538.64555
   hps: 19.7321
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 3115.61924
-  tps: 2743.61142
+  dps: 3032.54458
+  tps: 2667.26604
   hps: 19.7321
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 3390.38091
-  tps: 3019.10767
+  dps: 3109.09914
+  tps: 2744.91256
   hps: 19.7321
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3511.31666
-  tps: 3125.68098
-  hps: 19.93002
+  dps: 3227.35685
+  tps: 2839.84554
+  hps: 19.95266
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 7784.10226
-  tps: 7823.47078
-  hps: 20.52872
+  dps: 5034.46671
+  tps: 5049.91661
+  hps: 20.37209
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3225.46469
-  tps: 2869.72268
-  hps: 19.69037
+  dps: 2952.14417
+  tps: 2576.02186
+  hps: 20.25233
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3131.33177
-  tps: 2800.25178
-  hps: 18.45587
+  dps: 2931.06513
+  tps: 2563.12935
+  hps: 19.3617
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3935.14358
-  tps: 4191.03807
-  hps: 10.68949
+  dps: 3231.50141
+  tps: 3481.22334
+  hps: 10.57823
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1493.85006
-  tps: 1332.01278
-  hps: 10.12495
+  dps: 1438.32739
+  tps: 1274.39176
+  hps: 10.35297
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1485.94174
-  tps: 1307.81638
-  hps: 9.88405
+  dps: 1450.8756
+  tps: 1268.2009
+  hps: 10.57364
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 8304.19886
-  tps: 8320.90564
-  hps: 20.41202
+  dps: 5343.20805
+  tps: 5347.10403
+  hps: 20.5287
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3492.44156
-  tps: 3103.20124
-  hps: 20.07423
+  dps: 3182.86107
+  tps: 2786.07711
+  hps: 19.98516
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3363.8044
-  tps: 3001.32724
-  hps: 18.42516
+  dps: 3191.82495
+  tps: 2808.39821
+  hps: 19.51525
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3945.21877
-  tps: 4189.58395
-  hps: 10.73362
+  dps: 3246.10692
+  tps: 3485.67583
+  hps: 10.49824
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1495.19005
-  tps: 1328.12385
-  hps: 10.08173
+  dps: 1425.9588
+  tps: 1260.90564
+  hps: 10.44308
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1477.33671
-  tps: 1304.12257
-  hps: 9.4703
+  dps: 1469.96185
+  tps: 1288.31983
+  hps: 10.61961
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3267.04787
-  tps: 2963.3495
-  hps: 19.51638
+  dps: 3003.97818
+  tps: 2693.91637
+  hps: 19.39968
  }
 }

--- a/sim/hunter/explosive_trap.go
+++ b/sim/hunter/explosive_trap.go
@@ -42,9 +42,6 @@ func (hunter *Hunter) getExplosiveTrapConfig(rank int, timer *core.Timer) core.S
 			},
 			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
 		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return hunter.DistanceFromTarget <= hunter.trapRange()
-		},
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
@@ -72,6 +69,10 @@ func (hunter *Hunter) getExplosiveTrapConfig(rank int, timer *core.Timer) core.S
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			if hunter.DistanceFromTarget > hunter.trapRange() {
+				return
+			}
+
 			spell.WaitTravelTime(sim, func(s *core.Simulation) {
 				curTarget := target
 				// Traps gain no benefit from hit bonuses except for the Trap Mastery talent, since this is a unique interaction this is my workaround

--- a/sim/hunter/freezing_trap.go
+++ b/sim/hunter/freezing_trap.go
@@ -31,9 +31,6 @@ func (hunter *Hunter) getFreezingTrapConfig(timer *core.Timer) core.SpellConfig 
 			},
 			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
 		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return hunter.DistanceFromTarget <= hunter.trapRange()
-		},
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,

--- a/sim/hunter/immolation_trap.go
+++ b/sim/hunter/immolation_trap.go
@@ -38,9 +38,6 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 			},
 			IgnoreHaste: true, // Hunter GCD is locked at 1.5s
 		},
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return hunter.DistanceFromTarget <= hunter.trapRange()
-		},
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
@@ -63,6 +60,9 @@ func (hunter *Hunter) getImmolationTrapConfig(rank int, timer *core.Timer) core.
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			if hunter.DistanceFromTarget > hunter.trapRange() {
+				return
+			}
 			// Traps gain no benefit from hit bonuses except for the Trap Mastery talent, since this is a unique interaction this is my workaround
 			spellHit := spell.Unit.GetStat(stats.SpellHit) + target.PseudoStats.BonusSpellHitRatingTaken
 			spell.Unit.AddStatDynamic(sim, stats.SpellHit, spellHit*-1)

--- a/sim/hunter/runes.go
+++ b/sim/hunter/runes.go
@@ -248,11 +248,6 @@ func (hunter *Hunter) applyLockAndLoad() {
 
 	lockAndLoadMetrics := hunter.Metrics.NewResourceMetrics(core.ActionID{SpellID: 415413}, proto.ResourceType_ResourceTypeMana)
 
-	// icd := core.Cooldown{
-	// 	Timer:    hunter.NewTimer(),
-	// 	Duration: time.Second * 8,
-	// }
-
 	hunter.LockAndLoadAura = hunter.GetOrRegisterAura(core.Aura{
 		Label:    "Lock And Load",
 		ActionID: core.ActionID{SpellID: 415413},
@@ -273,12 +268,7 @@ func (hunter *Hunter) applyLockAndLoad() {
 		Label: "Lock And Load Trigger",
 		OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
 			if spell.Flags.Matches(SpellFlagTrap) {
-				spell.WaitTravelTime(sim, func(s *core.Simulation) {
-					// if icd.IsReady(sim) {
-					// 	icd.Use(sim)
 					hunter.LockAndLoadAura.Activate(sim)
-					// }
-				})
 			}
 		},
 	}))


### PR DESCRIPTION
Traps can still be cast even when they don't hit the target, this is important because with the most recent PTR traps no longer need to hit a target to trigger Lock and Load but rather grant the bonus when cast.