### PR TITLE
Updates Idol of Feline Ferocity to match Idol of the Dream implementation.

### DIFF
--- a/sim/druid/items.go
+++ b/sim/druid/items.go
@@ -228,12 +228,13 @@ func init() {
 	core.NewItemEffect(IdolOfFelineFerocity, func(agent core.Agent) {
 		druid := agent.(DruidAgent).GetDruid()
 		druid.RegisterAura(core.Aura{
-			Label: "Improved Wrath/Moonfire",
+			Label: "Improved Shred/Ferocious Bite,
 			OnInit: func(aura *core.Aura, sim *core.Simulation) {
+				// Shred is handled inside Shred.go similaryly to Idol of the Dream
+				// due to interactions with the SoD shred buff aura.
 				affectedSpells := core.FilterSlice(
 					[]*DruidSpell{
 						druid.FerociousBite,
-						druid.Shred,
 					},
 					func(spell *DruidSpell) bool { return spell != nil },
 				)

--- a/sim/druid/shred.go
+++ b/sim/druid/shred.go
@@ -30,8 +30,14 @@ func (druid *Druid) registerShredSpell() {
 		flatDamageBonus *= 1.02
 	}
 
-	// In-game testing concluded that, unintuitively, Idol of the Drea's 1.02x damage applies to the original 2.25x
-	// Shred mod, and to the flat damage bonus, but that the .75x SoD buff happens additively after Idol
+	if druid.Ranged().ID == IdolOfFelineFerocity {
+		damageMultiplier *= 1.03
+		flatDamageBonus *= 1.03
+	}
+
+	// In-game testing concluded that, unintuitively, Idol of the Dream's 1.02x damage applies to the original 2.25x
+	// Shred mod, and to the flat damage bonus, but that the .75x SoD buff happens additively after Idol.
+	// Idol of Feline Ferocity uses the same spell effect as Dream.
 	damageMultiplier += ShredWeaponMultiplierBuff
 
 	druid.Shred = druid.RegisterSpell(Cat, core.SpellConfig{


### PR DESCRIPTION
Testing showed a strange interaction between Idol of the Dream's +2% spell effectiveness to Shred and the SoD tuning aura's Shred buff. Since the new idol uses the same +spell effectiveness effect as dream, except with +3%, this updates the new idol to match.

Made this via the web UI on a device that doesn't have git or a dev environment set up, so feel free to copy paste/edit and submit elsewhere if tests or other stuff needs to be updated.