### PR TITLE
(BUG) Fixed integer truncation bug in ranged aq2.5 set for hunters

### DIFF
--- a/sim/hunter/item_sets_pve.go
+++ b/sim/hunter/item_sets_pve.go
@@ -459,7 +459,8 @@ var StrikersPursuit = core.NewItemSet(core.ItemSet{
 					if hunter.HasActiveAura("Rapid Fire") {
 						spell.CD.Reset()
 					} else if sim.CurrentTime > sim.Encounter.Duration/2 {
-						spell.CD.Set(sim.CurrentTime + spell.CD.TimeToReady(sim)/time.Duration(1/(1.0-cdReduction)))
+						reducedCooldown := spell.CD.TimeToReady(sim) / 1000 * time.Duration(1000*(1.0-cdReduction))
+						spell.CD.Set(sim.CurrentTime + reducedCooldown)
 					}
 				},
 			}))


### PR DESCRIPTION
time.Duration was truncating my non-whole number of 1/0.35 (2.86) to 2 causing the cooldown to be 6s rather than 4.2s