### PR TITLE
Add new 4pc TAQ ret bonus and fix Sheath

### DIFF
--- a/sim/common/vanilla/item_effects.go
+++ b/sim/common/vanilla/item_effects.go
@@ -1208,8 +1208,8 @@ func init() {
 
 	itemhelpers.CreateWeaponCoHProcDamage(JoonhosMercy, "Joonho's Mercy", 1.0, 20883, core.SpellSchoolArcane, 70, 0, 0, core.DefenseTypeMagic)
 
-	itemhelpers.CreateWeaponCoHProcDamage(KalimdorsRevenge, "Kalimdor's Revenge", 1.25, 1213355, core.SpellSchoolNature, 339, 138, 0, core.DefenseTypeMagic)            // TODO Update PPM/scaling from PTR
-	itemhelpers.CreateWeaponCoHProcDamage(KalimdorsRevengeVoidTouched, "Kalimdor's Revenge", 1.25, 1213355, core.SpellSchoolNature, 339, 138, 0, core.DefenseTypeMagic) // TODO Update PPM/scaling from PTR
+	itemhelpers.CreateWeaponCoHProcDamage(KalimdorsRevenge, "Kalimdor's Revenge", 14, 1213355, core.SpellSchoolNature, 339, 38, 0.25, core.DefenseTypeMagic)
+	itemhelpers.CreateWeaponCoHProcDamage(KalimdorsRevengeVoidTouched, "Kalimdor's Revenge", 14, 1213355, core.SpellSchoolNature, 339, 38, 0.25, core.DefenseTypeMagic)
 
 	itemhelpers.CreateWeaponCoHProcDamage(LinkensSwordOfMastery, "Linken's Sword of Mastery", 1.0, 18089, core.SpellSchoolNature, 45, 30, 0, core.DefenseTypeMagic)
 
@@ -3072,6 +3072,7 @@ func BlazefuryTriggerAura(character *core.Character, spellID int32, spellSchool 
 		Flags:            core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
+		//BonusCoefficient: 0.10,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMagicCrit)
 		},

--- a/sim/paladin/item_sets_pve.go
+++ b/sim/paladin/item_sets_pve.go
@@ -456,12 +456,40 @@ var ItemSetAvengersRadiance = core.NewItemSet(core.ItemSet{
 		},
 		4: func(agent core.Agent) {
 			paladin := agent.(PaladinAgent).GetPaladin()
-			paladin.OnSpellRegistered(func(spell *core.Spell) {
-				//"S03 - Item - TAQ - Paladin - Retribution 4P Bonus",
-				if spell.SpellCode == SpellCode_PaladinHolyWrath || spell.SpellCode == SpellCode_PaladinConsecration || spell.SpellCode == SpellCode_PaladinExorcism || spell.SpellCode == SpellCode_PaladinHolyShock || spell.SpellCode == SpellCode_PaladinHammerOfWrath {
-					// 4 Set: Increases the critical strike damage bonus of your Exorcism, Holy Wrath, Holy Shock, Hammer of Wrath, and Consecration by 60%.
-					spell.CritDamageBonus += 0.6
-				}
+
+			taq4pcAura := paladin.GetOrRegisterAura(core.Aura{
+				Label:     "Empower Exorcism",
+				ActionID:  core.ActionID{SpellID: 415073}, // temp id
+				Duration:  time.Second * 20,
+				MaxStacks: 3,
+				OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks int32, newStacks int32) {
+					for _, exorcism := range paladin.exorcism {
+						exorcism.DamageMultiplierAdditive -= 0.4 * float64(oldStacks)
+						exorcism.DamageMultiplierAdditive += 0.4 * float64(newStacks)
+
+						if newStacks == 0 {
+							aura.Activate(sim)
+						}
+					}
+				},
+			})
+
+			paladin.RegisterAura(core.Aura{
+				Label:    "S03 - Item - TAQ - Paladin - Retribution 4P Bonus",
+				Duration: core.NeverExpires,
+				OnReset: func(aura *core.Aura, sim *core.Simulation) {
+					aura.Activate(sim)
+				},
+				OnSpellHitDealt: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if result.Landed() && spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
+						if !taq4pcAura.IsActive() {
+							taq4pcAura.Activate(sim)
+						}
+						taq4pcAura.AddStack(sim)
+					} else if spell.SpellCode == SpellCode_PaladinExorcism {
+						taq4pcAura.SetStacks(sim, 0)
+					}
+				},
 			})
 		},
 	},

--- a/sim/paladin/retribution/TestExodin.results
+++ b/sim/paladin/retribution/TestExodin.results
@@ -99,12 +99,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestExodin-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.08924
-  weights: 1.32549
+  weights: 2.08778
+  weights: 1.35289
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.71332
+  weights: 0.71334
   weights: 0
   weights: 0
   weights: 0
@@ -112,13 +112,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.70432
-  weights: 1.75474
+  weights: 9.63781
+  weights: 1.75575
   weights: 0
   weights: 0
-  weights: 0.86332
+  weights: 0.86272
   weights: 0
-  weights: 20.5932
+  weights: 20.62655
   weights: 0
   weights: 0
   weights: 0
@@ -148,12 +148,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestExodin-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.92004
-  weights: 1.28357
+  weights: 2.92125
+  weights: 1.45994
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.9338
+  weights: 0.93364
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 17.1092
-  weights: 2.70635
+  weights: 17.37402
+  weights: 2.80271
   weights: 0
   weights: 0
-  weights: 1.04924
+  weights: 1.04968
   weights: 0
-  weights: 31.44168
+  weights: 31.34991
   weights: 0
   weights: 0
   weights: 0
@@ -197,50 +197,50 @@ stat_weights_results: {
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1365.35127
-  tps: 1400.55117
+  dps: 1366.31761
+  tps: 1401.51751
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 3261.63152
-  tps: 3294.18106
+  dps: 3260.76851
+  tps: 3293.31805
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1365.51854
-  tps: 1401.57388
+  dps: 1366.4617
+  tps: 1402.51704
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1464.56379
-  tps: 1501.92216
+  dps: 1465.59532
+  tps: 1502.95369
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 3306.97394
-  tps: 3339.03831
+  dps: 3305.44691
+  tps: 3337.51128
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1609.09952
-  tps: 1646.84562
+  dps: 1608.75962
+  tps: 1646.50572
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 3178.5478
-  tps: 3210.69657
+  dps: 3177.18361
+  tps: 3209.33238
  }
 }
 dps_results: {
@@ -260,155 +260,155 @@ dps_results: {
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 1691.8112
-  tps: 1729.66143
+  dps: 1693.41304
+  tps: 1731.26327
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3289.83957
-  tps: 3321.83201
+  dps: 3288.59479
+  tps: 3320.58868
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1485.28105
-  tps: 2026.72163
+  dps: 2404.60638
+  tps: 2946.04696
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 635.06881
-  tps: 662.36013
+  dps: 838.56677
+  tps: 865.85809
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 714.57228
-  tps: 745.51515
+  dps: 956.4267
+  tps: 987.36958
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 600.37781
-  tps: 970.82097
+  dps: 806.69521
+  tps: 1177.13837
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 269.33743
-  tps: 287.84914
+  dps: 315.88042
+  tps: 334.39214
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 369.76825
-  tps: 393.09976
+  dps: 443.66441
+  tps: 466.99592
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1515.87995
-  tps: 2064.49478
+  dps: 2449.57516
+  tps: 2998.18998
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 648.37752
-  tps: 675.86928
+  dps: 854.29699
+  tps: 881.78875
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 717.41863
-  tps: 748.4031
+  dps: 959.16336
+  tps: 990.14783
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 604.13882
-  tps: 975.50681
+  dps: 818.86336
+  tps: 1190.23135
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 275.30928
-  tps: 293.88819
+  dps: 321.96937
+  tps: 340.54828
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4ret-exodin-6pcT1-P4 Seal of Martyrdom Ret-p4ret-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 372.66311
-  tps: 396.09591
+  dps: 446.65075
+  tps: 470.08355
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2722.28793
-  tps: 2757.08753
+  dps: 2720.94307
+  tps: 2755.74268
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1700.55388
-  tps: 1736.33205
+  dps: 1701.40651
+  tps: 1737.18468
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 4600.24241
-  tps: 4639.28899
+  dps: 4602.01372
+  tps: 4641.0603
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1700.83818
-  tps: 1737.43554
+  dps: 1701.69081
+  tps: 1738.28817
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1821.63546
-  tps: 1859.45513
+  dps: 1822.5847
+  tps: 1860.40436
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 4685.83167
-  tps: 4724.35554
+  dps: 4688.14528
+  tps: 4726.66915
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1988.83998
-  tps: 2026.73597
+  dps: 1990.44585
+  tps: 2028.34183
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 4554.95191
-  tps: 4592.91136
+  dps: 4557.44457
+  tps: 4595.40403
  }
 }
 dps_results: {
@@ -428,105 +428,105 @@ dps_results: {
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 2116.26236
-  tps: 2154.33996
+  dps: 2117.36468
+  tps: 2155.44228
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4673.58072
-  tps: 4711.62448
+  dps: 4674.541
+  tps: 4712.58552
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 2524.64357
-  tps: 3139.63852
+  dps: 4077.18088
+  tps: 4692.17583
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1084.29782
-  tps: 1116.68705
+  dps: 1404.55875
+  tps: 1436.94797
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1171.83821
-  tps: 1210.65475
+  dps: 1522.65806
+  tps: 1561.47459
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 805.89881
-  tps: 1173.89325
+  dps: 1107.82519
+  tps: 1475.81964
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 357.55888
-  tps: 375.99991
+  dps: 423.62373
+  tps: 442.06477
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 509.95279
-  tps: 534.19584
+  dps: 612.63658
+  tps: 636.87963
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 2574.53614
-  tps: 3196.90154
+  dps: 4167.78393
+  tps: 4790.14933
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1088.33163
-  tps: 1120.88766
+  dps: 1409.95398
+  tps: 1442.51001
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1180.31137
-  tps: 1219.35343
+  dps: 1529.53106
+  tps: 1568.57312
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 817.31141
-  tps: 1186.11427
+  dps: 1126.8518
+  tps: 1495.65466
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 366.40482
-  tps: 384.81847
+  dps: 432.72895
+  tps: 451.1426
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5exodin-P5 Seal of Martyrdom Ret-p5ret-exodin-6CF2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 507.29631
-  tps: 531.54807
+  dps: 609.98955
+  tps: 634.24131
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3845.56477
-  tps: 3887.31597
+  dps: 3844.53317
+  tps: 3886.28437
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -295,8 +295,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.66066
-  weights: 0.3795
+  weights: 0.65869
+  weights: 0.38696
   weights: 0
   weights: 0
   weights: 0
@@ -308,13 +308,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.74055
+  weights: 1.72445
   weights: 0.08283
   weights: 0
   weights: 0
-  weights: 0.3003
-  weights: 5.10188
-  weights: 5.19765
+  weights: 0.29941
+  weights: 5.09085
+  weights: 5.21642
   weights: 0
   weights: 0
   weights: 0
@@ -344,8 +344,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.13609
-  weights: 1.54767
+  weights: 1.13586
+  weights: 1.53051
   weights: 0
   weights: 0
   weights: 0
@@ -357,13 +357,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.68167
-  weights: 0.46614
+  weights: 2.68261
+  weights: 0.46638
   weights: 0
   weights: 0
-  weights: 0.4303
-  weights: 13.06784
-  weights: 9.7732
+  weights: 0.43021
+  weights: 13.09911
+  weights: 9.75172
   weights: 0
   weights: 0
   weights: 0
@@ -393,12 +393,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.63426
-  weights: 2.1278
+  weights: 2.63626
+  weights: 2.22617
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.40961
+  weights: 0.40919
   weights: 0
   weights: 0
   weights: 0
@@ -406,13 +406,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.10129
-  weights: 0.78095
+  weights: 7.72214
+  weights: 0.78881
   weights: 0
   weights: 0
-  weights: 0.94656
-  weights: 1.40777
-  weights: 26.92219
+  weights: 0.94727
+  weights: 1.53281
+  weights: 26.66426
   weights: 0
   weights: 0
   weights: 0
@@ -442,8 +442,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.98646
-  weights: 2.63389
+  weights: 2.98358
+  weights: 2.61015
   weights: 0
   weights: 0
   weights: 0
@@ -455,13 +455,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 11.10187
-  weights: 0.72436
+  weights: 11.29299
+  weights: 0.72035
   weights: 0
   weights: 0
-  weights: 1.04849
-  weights: 2.12294
-  weights: 40.66965
+  weights: 1.04621
+  weights: 2.14063
+  weights: 40.58258
   weights: 0
   weights: 0
   weights: 0
@@ -603,99 +603,99 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 548.61548
-  tps: 562.12304
+  dps: 547.7208
+  tps: 561.22836
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 419.18903
-  tps: 658.81985
+  dps: 626.93792
+  tps: 866.56874
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 204.79834
-  tps: 216.65936
+  dps: 251.5353
+  tps: 263.39632
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 227.66526
-  tps: 239.38324
+  dps: 279.12669
+  tps: 290.84468
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 234.29971
-  tps: 393.64451
+  dps: 329.32752
+  tps: 488.67232
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 107.82373
-  tps: 115.83897
+  dps: 123.0746
+  tps: 131.08985
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Dwarf-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 132.14217
-  tps: 142.86628
+  dps: 156.70634
+  tps: 167.43046
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 417.04106
-  tps: 653.55207
+  dps: 623.91079
+  tps: 860.42181
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 204.8499
-  tps: 216.6593
+  dps: 251.50132
+  tps: 263.31071
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 228.45203
-  tps: 240.17033
+  dps: 279.80933
+  tps: 291.52763
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 236.71967
-  tps: 397.45738
+  dps: 332.81276
+  tps: 493.55046
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 108.2034
-  tps: 116.26073
+  dps: 123.55962
+  tps: 131.61695
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Settings-Human-p2retsoc-P2 Seal of Command Ret-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 132.42077
-  tps: 143.20117
+  dps: 156.86535
+  tps: 167.64574
  }
 }
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 514.43962
-  tps: 527.77771
+  dps: 513.56765
+  tps: 526.90574
  }
 }
 dps_results: {
@@ -708,148 +708,148 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1135.62899
-  tps: 1174.35939
+  dps: 1135.63287
+  tps: 1174.36327
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1436.37297
-  tps: 1983.23056
+  dps: 2205.13237
+  tps: 2751.98995
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 335.23267
-  tps: 362.55732
+  dps: 417.84826
+  tps: 445.17291
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 400.52869
-  tps: 428.14686
+  dps: 509.74844
+  tps: 537.36662
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 511.7067
-  tps: 785.58458
+  dps: 709.03555
+  tps: 982.91343
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 138.35953
-  tps: 152.05343
+  dps: 165.00234
+  tps: 178.69624
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Dwarf-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 194.61283
-  tps: 212.41416
+  dps: 228.54212
+  tps: 246.34346
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1437.10672
-  tps: 1986.58416
+  dps: 2203.17303
+  tps: 2752.65047
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 341.16056
-  tps: 368.59347
+  dps: 424.17785
+  tps: 451.61076
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 403.14615
-  tps: 430.79101
+  dps: 512.51056
+  tps: 540.15542
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 500.45425
-  tps: 775.49746
+  dps: 693.36999
+  tps: 968.41321
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 141.79319
-  tps: 155.54535
+  dps: 168.192
+  tps: 181.94417
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-Settings-Human-p3retsom-P3 Seal of Martyrdom Ret-p3ret-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 195.88752
-  tps: 213.7768
+  dps: 229.94765
+  tps: 247.83693
  }
 }
 dps_results: {
  key: "TestRetribution-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1072.02188
-  tps: 1110.27079
+  dps: 1071.91757
+  tps: 1110.16648
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1763.3917
-  tps: 1803.01105
+  dps: 1762.7164
+  tps: 1802.33575
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 3767.05587
-  tps: 3816.23588
+  dps: 3767.00664
+  tps: 3816.1351
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1732.62272
-  tps: 1771.57311
+  dps: 1732.99263
+  tps: 1771.94303
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1858.63262
-  tps: 1898.7405
+  dps: 1859.10215
+  tps: 1899.21003
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 3809.80346
-  tps: 3858.95339
+  dps: 3810.13814
+  tps: 3859.23721
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 2338.36158
-  tps: 2389.47207
+  dps: 2337.73188
+  tps: 2388.84237
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 3708.61658
-  tps: 3757.61109
+  dps: 3711.91289
+  tps: 3761.00332
  }
 }
 dps_results: {
@@ -869,155 +869,155 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 2450.24524
-  tps: 2493.1316
+  dps: 2449.21968
+  tps: 2492.10604
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3810.22051
-  tps: 3859.39721
+  dps: 3812.36279
+  tps: 3861.55807
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 173.24126
-  tps: 373.85142
+  dps: 264.52701
+  tps: 465.13717
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 147.19839
-  tps: 157.2289
+  dps: 165.03955
+  tps: 175.07006
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 424.06937
-  tps: 442.03105
+  dps: 500.79832
+  tps: 518.75999
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 57.90535
-  tps: 238.65218
+  dps: 76.58147
+  tps: 257.32829
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 47.57767
-  tps: 56.61501
+  dps: 51.95606
+  tps: 60.9934
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 113.20927
-  tps: 128.39303
+  dps: 117.56734
+  tps: 132.7511
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2191.43807
-  tps: 2756.14223
+  dps: 3326.19679
+  tps: 3890.90096
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1028.12205
-  tps: 1057.21437
+  dps: 1236.51265
+  tps: 1265.60497
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1174.08396
-  tps: 1207.44356
+  dps: 1421.04151
+  tps: 1454.4011
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 699.39198
-  tps: 1070.89266
+  dps: 931.4956
+  tps: 1302.99628
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 357.22025
-  tps: 375.77439
+  dps: 395.27186
+  tps: 413.82601
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 481.03563
-  tps: 504.47483
+  dps: 541.16286
+  tps: 564.60206
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 134.96661
-  tps: 330.85677
+  dps: 197.74896
+  tps: 393.63912
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 117.06984
-  tps: 126.86435
+  dps: 129.57946
+  tps: 139.37397
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 375.21782
-  tps: 392.66324
+  dps: 421.12567
+  tps: 438.5711
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 44.67389
-  tps: 225.42071
+  dps: 57.22564
+  tps: 237.97247
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 37.46651
-  tps: 46.50385
+  dps: 39.83995
+  tps: 48.87729
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 88.86678
-  tps: 104.05054
+  dps: 90.93803
+  tps: 106.12179
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 346.62788
-  tps: 775.98482
+  dps: 501.59353
+  tps: 930.95047
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 303.10741
-  tps: 324.57525
+  dps: 328.23608
+  tps: 349.70393
  }
 }
 dps_results: {
@@ -1029,162 +1029,162 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 240.11438
-  tps: 575.40679
+  dps: 314.82846
+  tps: 650.12087
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 183.16826
-  tps: 199.93288
+  dps: 196.06126
+  tps: 212.82588
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 66.18046
-  tps: 84.53547
+  dps: 72.25259
+  tps: 90.6076
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 174.66036
-  tps: 375.56552
+  dps: 264.31529
+  tps: 465.22044
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 148.53943
-  tps: 158.58469
+  dps: 164.96478
+  tps: 175.01004
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 424.30396
-  tps: 442.26563
+  dps: 501.5703
+  tps: 519.53198
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 57.71908
-  tps: 238.4659
+  dps: 78.27654
+  tps: 259.02337
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 46.52561
-  tps: 55.56295
+  dps: 50.91737
+  tps: 59.95471
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 116.22168
-  tps: 131.40544
+  dps: 121.22341
+  tps: 136.40717
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2235.35457
-  tps: 2802.20945
+  dps: 3386.71448
+  tps: 3953.56937
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1033.33084
-  tps: 1062.31456
+  dps: 1239.10783
+  tps: 1268.09155
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1174.0042
-  tps: 1207.43621
+  dps: 1422.2702
+  tps: 1455.70222
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 691.19729
-  tps: 1063.6203
+  dps: 912.30195
+  tps: 1284.72497
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 356.09037
-  tps: 374.74305
+  dps: 395.72222
+  tps: 414.3749
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4ret-twisting-6pcT1-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 486.28353
-  tps: 509.76991
+  dps: 548.1632
+  tps: 571.64959
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 135.21901
-  tps: 331.01083
+  dps: 198.01507
+  tps: 393.80689
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 117.22433
-  tps: 127.01392
+  dps: 129.80993
+  tps: 139.59952
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 380.90459
-  tps: 398.35001
+  dps: 427.60715
+  tps: 445.05257
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 43.88909
-  tps: 224.63592
+  dps: 57.09503
+  tps: 237.84185
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 36.52855
-  tps: 45.56589
+  dps: 39.52679
+  tps: 48.56414
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 89.52059
-  tps: 104.70435
+  dps: 91.58501
+  tps: 106.76877
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 357.8814
-  tps: 789.66137
+  dps: 530.75807
+  tps: 962.53805
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 311.56706
-  tps: 333.17573
+  dps: 338.13468
+  tps: 359.74334
  }
 }
 dps_results: {
@@ -1196,78 +1196,78 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 239.36515
-  tps: 575.14597
+  dps: 311.04827
+  tps: 646.82909
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 185.94433
-  tps: 202.72274
+  dps: 198.75523
+  tps: 215.53364
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4rettwist-P4 Seal of Martyrdom Ret-p4ret-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 67.55519
-  tps: 85.92895
+  dps: 73.38269
+  tps: 91.75645
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3060.78208
-  tps: 3109.45956
+  dps: 3053.12911
+  tps: 3101.79136
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 2480.86309
-  tps: 2538.07545
+  dps: 2483.14892
+  tps: 2540.36128
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Hero'sBrand-231328"
  value: {
-  dps: 4591.39488
-  tps: 4647.59841
+  dps: 4597.34666
+  tps: 4653.55018
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 2478.97087
-  tps: 2536.81226
+  dps: 2481.15773
+  tps: 2538.99913
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 2635.03539
-  tps: 2694.42591
+  dps: 2637.22407
+  tps: 2696.61459
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-LibramofDraconicDestruction-221457"
  value: {
-  dps: 4685.84133
-  tps: 4742.1406
+  dps: 4691.81723
+  tps: 4748.1165
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 4015.88509
-  tps: 4079.32353
+  dps: 4019.40743
+  tps: 4082.84588
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-SanctifiedOrb-20512"
  value: {
-  dps: 4540.1775
-  tps: 4596.09113
+  dps: 4544.07648
+  tps: 4599.99011
  }
 }
 dps_results: {
@@ -1287,92 +1287,92 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ZandalarFreethinker'sBreastplate-231329"
  value: {
-  dps: 4237.11268
-  tps: 4294.80933
+  dps: 4243.24125
+  tps: 4300.93789
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4640.59871
-  tps: 4697.0404
+  dps: 4648.92264
+  tps: 4705.36497
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 842.81736
-  tps: 1093.38086
+  dps: 1164.93611
+  tps: 1415.4996
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 750.75012
-  tps: 763.29796
+  dps: 798.48034
+  tps: 811.02818
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1171.74296
-  tps: 1191.91714
+  dps: 1198.3105
+  tps: 1218.48467
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 186.04551
-  tps: 366.79234
+  dps: 240.73883
+  tps: 421.48566
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 154.42317
-  tps: 163.46051
+  dps: 162.39335
+  tps: 171.43069
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 343.56898
-  tps: 358.75274
+  dps: 349.10552
+  tps: 364.28928
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 45.33345
-  tps: 231.58694
+  dps: 64.87151
+  tps: 251.125
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 41.98591
-  tps: 51.29859
+  dps: 52.69992
+  tps: 62.01259
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 93.85226
-  tps: 109.74893
+  dps: 113.80849
+  tps: 129.70517
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 15.33826
-  tps: 193.58055
+  dps: 19.04451
+  tps: 197.28679
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 14.18331
-  tps: 23.09542
+  dps: 16.4443
+  tps: 25.35642
  }
 }
 dps_results: {
@@ -1384,78 +1384,78 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 878.55915
-  tps: 1130.10598
+  dps: 1201.38397
+  tps: 1452.93079
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 782.0752
-  tps: 794.68204
+  dps: 821.50167
+  tps: 834.10851
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1172.71439
-  tps: 1192.91315
+  dps: 1199.84116
+  tps: 1220.03992
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 188.48315
-  tps: 369.22997
+  dps: 249.94396
+  tps: 430.69078
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 154.37303
-  tps: 163.41037
+  dps: 166.52027
+  tps: 175.55761
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.5-3.6-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 346.84906
-  tps: 362.03282
+  dps: 352.96728
+  tps: 368.15103
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 43.96805
-  tps: 230.31987
+  dps: 63.30699
+  tps: 249.65882
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 40.62051
-  tps: 49.9381
+  dps: 51.15316
+  tps: 60.47076
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 95.45496
-  tps: 111.35164
+  dps: 116.32819
+  tps: 132.22486
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 17.05148
-  tps: 197.79831
+  dps: 21.00669
+  tps: 201.75352
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5twisting-P5 Seal of Martyrdom Ret-p5ret-twist-4DR-3.7-4.0-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 15.95254
-  tps: 24.98988
+  dps: 18.48366
+  tps: 27.521
  }
 }
 dps_results: {
@@ -1467,7 +1467,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3763.99455
-  tps: 3819.39576
+  dps: 3767.46336
+  tps: 3823.00604
  }
 }

--- a/sim/paladin/retribution/TestShockadin.results
+++ b/sim/paladin/retribution/TestShockadin.results
@@ -117,7 +117,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0.29671
-  weights: 5.15293
+  weights: 5.1565
   weights: 4.57561
   weights: 0
   weights: 0
@@ -204,92 +204,92 @@ dps_results: {
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 512.17379
-  tps: 536.51048
+  dps: 512.17122
+  tps: 536.50791
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 545.35844
-  tps: 824.06297
+  dps: 836.26649
+  tps: 1114.97102
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 147.15029
-  tps: 161.05377
+  dps: 184.5388
+  tps: 198.44228
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 174.53791
-  tps: 190.39564
+  dps: 221.45363
+  tps: 237.31136
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 257.61526
-  tps: 442.56154
+  dps: 361.06725
+  tps: 546.01353
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 77.75211
-  tps: 86.99943
+  dps: 93.83845
+  tps: 103.08576
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Dwarf-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 105.39775
-  tps: 116.32798
+  dps: 128.2035
+  tps: 139.13372
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 557.35472
-  tps: 836.37459
+  dps: 855.73418
+  tps: 1134.75404
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 146.71806
-  tps: 160.67813
+  dps: 184.75847
+  tps: 198.71854
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 176.27547
-  tps: 192.16162
+  dps: 223.88305
+  tps: 239.7692
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 263.72985
-  tps: 450.00713
+  dps: 368.38067
+  tps: 554.65795
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 77.95938
-  tps: 87.27325
+  dps: 94.11959
+  tps: 103.43345
  }
 }
 dps_results: {
  key: "TestShockadin-Phase2-Lvl40-Settings-Human-p2retsom-P2 Seal of Martyrdom Shockadin-p2ret-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 107.47706
-  tps: 118.46779
+  dps: 130.81641
+  tps: 141.80714
  }
 }
 dps_results: {

--- a/ui/protection_paladin/sim.ts
+++ b/ui/protection_paladin/sim.ts
@@ -167,7 +167,11 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 		ProtectionPaladinInputs.AuraSelection,
 	],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
-	includeBuffDebuffInputs: [BuffDebuffInputs.SpellScorchDebuff],
+
+	includeBuffDebuffInputs: [
+		BuffDebuffInputs.SpellScorchDebuff,
+		BuffDebuffInputs.NatureSpellDamageDebuff],
+
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {

--- a/ui/retribution_paladin/presets.ts
+++ b/ui/retribution_paladin/presets.ts
@@ -255,6 +255,7 @@ export const DefaultRaidBuffs = RaidBuffs.create({
 export const DefaultDebuffs = Debuffs.create({
 	curseOfRecklessness: true,
 	homunculi: 70, // 70% average uptime default
+	dreamstate: true,
 	faerieFire: true,
 	giftOfArthas: true,
 	sunderArmor: true,

--- a/ui/retribution_paladin/sim.ts
+++ b/ui/retribution_paladin/sim.ts
@@ -126,7 +126,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 	// IconInputs to include in the 'Player' section on the settings tab.
 	playerIconInputs: [RetributionPaladinInputs.PrimarySealSelection, RetributionPaladinInputs.AuraSelection],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
-	includeBuffDebuffInputs: [BuffDebuffInputs.SpellScorchDebuff],
+	includeBuffDebuffInputs: [
+		BuffDebuffInputs.SpellScorchDebuff,
+		BuffDebuffInputs.NatureSpellDamageDebuff],
+	
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {


### PR DESCRIPTION
Add new 4pc TAQ ret bonus 
fix sheathe of light to not be fully dynamic (updates on anything that has proc mask melee)