### PR TITLE
Hunter - TAQ 4P Ranged Killshot CDR Fix

### DIFF
--- a/sim/hunter/item_sets_pve_phase_6.go
+++ b/sim/hunter/item_sets_pve_phase_6.go
@@ -128,7 +128,7 @@ func (hunter *Hunter) applyTAQRanged4PBonus() {
 	hunter.RegisterAura(core.Aura{
 		Label: label,
 		OnInit: func(aura *core.Aura, sim *core.Simulation) {
-			hunter.KillShot.CD.FlatModifier -= 6 * time.Second
+			hunter.KillShot.CD.Multiplier *= 0.5
 
 			if !hunter.HasRune(proto.HunterRune_RuneHelmRapidKilling) {
 				return


### PR DESCRIPTION
Killshot was using a flat 6s modifier instead of a 50% multiplier causing the cooldown to be incorrect when combining T3 4P and T2.5 4P bonuses