### PR TITLE
Sanctified changes from PTR

### DIFF
--- a/sim/common/sod/item_effects/phase_7.go
+++ b/sim/common/sod/item_effects/phase_7.go
@@ -9,48 +9,39 @@ import (
 )
 
 const (
-	BulwarkOfIre                     = 235868
-	OlReliable                       = 235891
-	TunicOfUndeadSlaying             = 236707
-	BreastplateOfUndeadSlaying       = 236708
-	ChestguardOfUndeadSlaying        = 236709
-	WristguardsOfUndeadSlaying       = 236710
-	WristwrapsOfUndeadSlaying        = 236711
-	BracersOfUndeadSlaying           = 236712
-	HandwrapsOfUndeadSlaying         = 236713
-	GauntletsOfUndeadSlaying         = 236714
-	HandguardsOfUndeadSlaying        = 236715
-	BracersOfUndeadCleansing         = 236716
-	GlovesOfUndeadCleansing          = 236717
-	RobeofUndeadCleansing            = 236718
-	BracersOfUndeadPurificationCloth = 236719
-	GlovesOfUndeadPurification       = 236720
-	RobeOfUndeadPurification         = 236721
-	BracersOfUndeadWardingCloth      = 236722
-	GlovesOfUndeadWarding            = 236723
-	RobeOfUndeadWarding              = 236724
-	WristwrapsOfUndeadCleansing      = 236725
-	HandwrapsOfUndeadCleansing       = 236726
-	TunicOfUndeadCleansing           = 236727
-	WristwrapsOfUndeadWarding        = 236731
-	HandwrapsOfUndeadWarding         = 236732
-	TunicOfUndeadWarding             = 236733
-	WristguardsOfUndeadCleansing     = 236734
-	HandguardsOfUndeadCleansing      = 236735
-	ChestguardOfUndeadCleansing      = 236736
-	WristguardsOfUndeadWarding       = 236737
-	HandguardsOfUndeadWarding        = 236738
-	ChestguardOfUndeadWarding        = 236739
-	WristguardsOfUndeadPurification  = 236740
-	HandguardsOfUndeadPurification   = 236741
-	ChestguardOfUndeadPurification   = 236742
-	BracersOfUndeadPurificationPlate = 236743
-	GauntletsOfUndeadPurification    = 236744
-	BreastplateOfUndeadPurification  = 236745
-	BracersOfUndeadWardingPlate      = 236746
-	GauntletsOfUndeadWarding         = 236747
-	BreastplateOfUndeadWarding       = 236748
-	BladeOfInquisition               = 237512
+	BulwarkOfIre                 = 235868
+	OlReliable                   = 235891
+	TunicOfUndeadSlaying         = 236707
+	BreastplateOfUndeadSlaying   = 236708
+	ChestguardOfUndeadSlaying    = 236709
+	WristguardsOfUndeadSlaying   = 236710
+	WristwrapsOfUndeadSlaying    = 236711
+	BracersOfUndeadSlaying       = 236712
+	HandwrapsOfUndeadSlaying     = 236713
+	GauntletsOfUndeadSlaying     = 236714
+	HandguardsOfUndeadSlaying    = 236715
+	BracersOfUndeadCleansing     = 236716
+	GlovesOfUndeadCleansing      = 236717
+	RobeofUndeadCleansing        = 236718
+	BracersOfUndeadWardingCloth  = 236722
+	GlovesOfUndeadWarding        = 236723
+	RobeOfUndeadWarding          = 236724
+	WristwrapsOfUndeadCleansing  = 236725
+	HandwrapsOfUndeadCleansing   = 236726
+	TunicOfUndeadCleansing       = 236727
+	WristwrapsOfUndeadWarding    = 236731
+	HandwrapsOfUndeadWarding     = 236732
+	TunicOfUndeadWarding         = 236733
+	WristguardsOfUndeadCleansing = 236734
+	HandguardsOfUndeadCleansing  = 236735
+	ChestguardOfUndeadCleansing  = 236736
+	WristguardsOfUndeadWarding   = 236737
+	HandguardsOfUndeadWarding    = 236738
+	ChestguardOfUndeadWarding    = 236739
+	BracersOfUndeadWardingPlate  = 236746
+	GauntletsOfUndeadWarding     = 236747
+	BreastplateOfUndeadWarding   = 236748
+	BladeOfInquisition           = 237512
 
 	// Atiesh
 	AtieshSpellPower = 236398
@@ -209,80 +200,46 @@ func init() {
 	///////////////////////////////////////////////////////////////////////////
 
 	// https://www.wowhead.com/classic/item=236356/squires-seal-of-the-dawn
-	core.NewItemEffect(AspirantsSealOfTheDawnDamage, sanctifiedDamageEffect(1219539, 0.83))
-	core.NewItemEffect(InitiatesSealOfTheDawnDamage, sanctifiedDamageEffect(1223348, 2.92))
-	core.NewItemEffect(SquiresSealOfTheDawnDamage, sanctifiedDamageEffect(1223349, 4.17))
-	core.NewItemEffect(KnightsSealOfTheDawnDamage, sanctifiedDamageEffect(1223350, 6.67))
-	core.NewItemEffect(TemplarsSealOfTheDawnDamage, sanctifiedDamageEffect(1223351, 8.33))
-	core.NewItemEffect(ChampionsSealOfTheDawnDamage, sanctifiedDamageEffect(1223352, 12.08))
-	core.NewItemEffect(VanguardsSealOfTheDawnDamage, sanctifiedDamageEffect(1223353, 14.17))
-	core.NewItemEffect(CrusadersSealOfTheDawnDamage, sanctifiedDamageEffect(1223354, 18.75))
-	core.NewItemEffect(CommandersSealOfTheDawnDamage, sanctifiedDamageEffect(1223355, 21.67))
-	core.NewItemEffect(HighlordsSSealOfTheDawnDamage, sanctifiedDamageEffect(1223357, 25.0))
+	core.NewItemEffect(AspirantsSealOfTheDawnDamage, sanctifiedDamageEffect(1219539, 1.25))
+	core.NewItemEffect(InitiatesSealOfTheDawnDamage, sanctifiedDamageEffect(1223348, 4.38))
+	core.NewItemEffect(SquiresSealOfTheDawnDamage, sanctifiedDamageEffect(1223349, 6.25))
+	core.NewItemEffect(KnightsSealOfTheDawnDamage, sanctifiedDamageEffect(1223350, 10.0))
+	core.NewItemEffect(TemplarsSealOfTheDawnDamage, sanctifiedDamageEffect(1223351, 12.5))
+	core.NewItemEffect(ChampionsSealOfTheDawnDamage, sanctifiedDamageEffect(1223352, 18.13))
+	core.NewItemEffect(VanguardsSealOfTheDawnDamage, sanctifiedDamageEffect(1223353, 21.25))
+	core.NewItemEffect(CrusadersSealOfTheDawnDamage, sanctifiedDamageEffect(1223354, 28.13))
+	core.NewItemEffect(CommandersSealOfTheDawnDamage, sanctifiedDamageEffect(1223355, 32.5))
+	core.NewItemEffect(HighlordsSSealOfTheDawnDamage, sanctifiedDamageEffect(1223357, 37.5))
 
 	// https://www.wowhead.com/classic/item=236383/squires-seal-of-the-dawn
-	core.NewItemEffect(AspirantsSealOfTheDawnHealing, sanctifiedHealingEffect(1219548, 0.83))
-	core.NewItemEffect(InitiatesSealOfTheDawnHealing, sanctifiedHealingEffect(1223379, 2.92))
-	core.NewItemEffect(SquiresSealOfTheDawnHealing, sanctifiedHealingEffect(1223380, 4.17))
-	core.NewItemEffect(KnightsSealOfTheDawnHealing, sanctifiedHealingEffect(1223381, 6.67))
-	core.NewItemEffect(TemplarsSealOfTheDawnHealing, sanctifiedHealingEffect(1223382, 8.33))
-	core.NewItemEffect(ChampionsSealOfTheDawnHealing, sanctifiedHealingEffect(1223383, 12.08))
-	core.NewItemEffect(VanguardsSealOfTheDawnHealing, sanctifiedHealingEffect(1223384, 14.17))
-	core.NewItemEffect(CrusadersSealOfTheDawnHealing, sanctifiedHealingEffect(1223385, 18.75))
-	core.NewItemEffect(CommandersSealOfTheDawnHealing, sanctifiedHealingEffect(1223386, 21.67))
-	core.NewItemEffect(HighlordsSSealOfTheDawnHealing, sanctifiedHealingEffect(1223387, 25.0))
+	core.NewItemEffect(AspirantsSealOfTheDawnHealing, sanctifiedHealingEffect(1219548, 1.25))
+	core.NewItemEffect(InitiatesSealOfTheDawnHealing, sanctifiedHealingEffect(1223379, 4.38))
+	core.NewItemEffect(SquiresSealOfTheDawnHealing, sanctifiedHealingEffect(1223380, 6.25))
+	core.NewItemEffect(KnightsSealOfTheDawnHealing, sanctifiedHealingEffect(1223381, 10.0))
+	core.NewItemEffect(TemplarsSealOfTheDawnHealing, sanctifiedHealingEffect(1223382, 12.5))
+	core.NewItemEffect(ChampionsSealOfTheDawnHealing, sanctifiedHealingEffect(1223383, 18.13))
+	core.NewItemEffect(VanguardsSealOfTheDawnHealing, sanctifiedHealingEffect(1223384, 21.25))
+	core.NewItemEffect(CrusadersSealOfTheDawnHealing, sanctifiedHealingEffect(1223385, 28.13))
+	core.NewItemEffect(CommandersSealOfTheDawnHealing, sanctifiedHealingEffect(1223386, 32.5))
+	core.NewItemEffect(HighlordsSSealOfTheDawnHealing, sanctifiedHealingEffect(1223387, 37.5))
 
 	// https://www.wowhead.com/classic/item=236394/squires-seal-of-the-dawn
-	core.NewItemEffect(AspirantsSealOfTheDawnTanking, sanctifiedTankingEffect(1220514, 2.08, 0.83))
-	core.NewItemEffect(InitiatesSealOfTheDawnTanking, sanctifiedTankingEffect(1223367, 2.92, 2.92))
-	core.NewItemEffect(SquiresSealOfTheDawnTanking, sanctifiedTankingEffect(1223368, 3.33, 4.17))
-	core.NewItemEffect(KnightsSealOfTheDawnTanking, sanctifiedTankingEffect(1223370, 3.75, 6.67))
-	core.NewItemEffect(TemplarsSealOfTheDawnTanking, sanctifiedTankingEffect(1223371, 4.17, 8.33))
-	core.NewItemEffect(ChampionsSealOfTheDawnTanking, sanctifiedTankingEffect(1223372, 5.0, 12.08))
-	core.NewItemEffect(VanguardsSealOfTheDawnTanking, sanctifiedTankingEffect(1223373, 5.42, 14.17))
-	core.NewItemEffect(CrusadersSealOfTheDawnTanking, sanctifiedTankingEffect(1223374, 6.25, 18.75))
-	core.NewItemEffect(CommandersSealOfTheDawnTanking, sanctifiedTankingEffect(1223375, 6.67, 21.67))
-	core.NewItemEffect(HighlordsSSealOfTheDawnTanking, sanctifiedTankingEffect(1223376, 7.08, 25.0))
+	core.NewItemEffect(AspirantsSealOfTheDawnTanking, sanctifiedTankingEffect(1220514, 3.13, 1.25))
+	core.NewItemEffect(InitiatesSealOfTheDawnTanking, sanctifiedTankingEffect(1223367, 4.38, 4.38))
+	core.NewItemEffect(SquiresSealOfTheDawnTanking, sanctifiedTankingEffect(1223368, 5.0, 6.25))
+	core.NewItemEffect(KnightsSealOfTheDawnTanking, sanctifiedTankingEffect(1223370, 5.63, 10))
+	core.NewItemEffect(TemplarsSealOfTheDawnTanking, sanctifiedTankingEffect(1223371, 6.25, 12.5))
+	core.NewItemEffect(ChampionsSealOfTheDawnTanking, sanctifiedTankingEffect(1223372, 7.5, 18.13))
+	core.NewItemEffect(VanguardsSealOfTheDawnTanking, sanctifiedTankingEffect(1223373, 8.13, 21.25))
+	// Updated tooltip for Crusader's actually says 21.83% for health but that's not consistent with others
+	// and most likely a typo where the 8 and the 1 has swapped places.
+	core.NewItemEffect(CrusadersSealOfTheDawnTanking, sanctifiedTankingEffect(1223374, 9.38, 28.13))
+	core.NewItemEffect(CommandersSealOfTheDawnTanking, sanctifiedTankingEffect(1223375, 10.0, 32.5))
+	core.NewItemEffect(HighlordsSSealOfTheDawnTanking, sanctifiedTankingEffect(1223376, 10.63, 37.5))
 
 	///////////////////////////////////////////////////////////////////////////
 	//                                 Other
 	///////////////////////////////////////////////////////////////////////////
-
-	// https://www.wowhead.com/classic/item=236716/bracers-of-undead-cleansing
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
-	core.NewMobTypeSpellPowerEffect(BracersOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
-
-	// https://www.wowhead.com/classic/item=236719/bracers-of-undead-purification
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
-	core.NewMobTypeSpellPowerEffect(BracersOfUndeadPurificationCloth, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
-
-	// https://www.wowhead.com/classic/item=236743/bracers-of-undead-purification
-	// +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(BracersOfUndeadPurificationPlate, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
-
-	// https://www.wowhead.com/classic/item=236712/bracers-of-undead-slaying
-	// +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(BracersOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
-
-	// https://www.wowhead.com/classic/item=236722/bracers-of-undead-warding
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
-	core.NewMobTypeSpellPowerEffect(BracersOfUndeadWardingCloth, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
-
-	// https://www.wowhead.com/classic/item=236746/bracers-of-undead-warding
-	// +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(BracersOfUndeadWardingPlate, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
-
-	// https://www.wowhead.com/classic/item=236745/breastplate-of-undead-purification
-	// +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(BreastplateOfUndeadPurification, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
-
-	// https://www.wowhead.com/classic/item=236708/breastplate-of-undead-slaying
-	// +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(BreastplateOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
-
-	// https://www.wowhead.com/classic/item=236748/breastplate-of-undead-warding
-	// +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(BreastplateOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
 
 	// https://www.wowhead.com/classic/item=235868/bulwark-of-ire
 	// Deal 100 Shadow damage to melee attackers.
@@ -315,130 +272,130 @@ func init() {
 		}))
 	})
 
-	// https://www.wowhead.com/classic/item=236736/chestguard-of-undead-cleansing
-	// Equip: +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(ChestguardOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
+	// https://www.wowhead.com/classic/item=236707/tunic-of-undead-slaying
+	// Equip: +108 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(TunicOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 108)
 
-	// https://www.wowhead.com/classic/item=236742/chestguard-of-undead-purification
-	// Equip: +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(ChestguardOfUndeadPurification, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
+	// https://www.wowhead.com/classic/item=236708/breastplate-of-undead-slaying
+	// Equip: +108 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(BreastplateOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 108)
 
 	// https://www.wowhead.com/classic/item=236709/chestguard-of-undead-slaying
-	// Equip: +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(ChestguardOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
-
-	// https://www.wowhead.com/classic/item=236739/chestguard-of-undead-warding
-	// Equip: +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(ChestguardOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
-
-	// https://www.wowhead.com/classic/item=236744/gauntlets-of-undead-purification
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(GauntletsOfUndeadPurification, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236714/gauntlets-of-undead-slaying
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(GauntletsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236738/handguards-of-undead-warding
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(GauntletsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236717/gloves-of-undead-cleansing
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 35.
-	core.NewMobTypeSpellPowerEffect(GlovesOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 35)
-
-	// https://www.wowhead.com/classic/item=236720/gloves-of-undead-purification
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 35.
-	core.NewMobTypeSpellPowerEffect(GlovesOfUndeadPurification, []proto.MobType{proto.MobType_MobTypeUndead}, 35)
-
-	// https://www.wowhead.com/classic/item=236723/gloves-of-undead-warding
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 35.
-	core.NewMobTypeSpellPowerEffect(GlovesOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 35)
-
-	// https://www.wowhead.com/classic/item=236735/handguards-of-undead-cleansing
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(HandguardsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236741/handguards-of-undead-purification
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(HandguardsOfUndeadPurification, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236715/handguards-of-undead-slaying
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(HandguardsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236738/handguards-of-undead-warding
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(HandguardsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236726/handwraps-of-undead-cleansing
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(HandwrapsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236713/handwraps-of-undead-slaying
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(HandwrapsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236732/handwraps-of-undead-warding
-	// Equip: +60 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(HandwrapsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
-
-	// https://www.wowhead.com/classic/item=236718/robe-of-undead-cleansing/
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 48.
-	core.NewMobTypeSpellPowerEffect(RobeofUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 48)
-
-	// https://www.wowhead.com/classic/item=236721/robe-of-undead-purification
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 48.
-	core.NewMobTypeSpellPowerEffect(RobeOfUndeadPurification, []proto.MobType{proto.MobType_MobTypeUndead}, 48)
-
-	// https://www.wowhead.com/classic/item=236724/robe-of-undead-warding
-	// Equip: Increases damage done to Undead by magical spells and effects by up to 48.
-	core.NewMobTypeSpellPowerEffect(RobeOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 48)
-
-	// https://www.wowhead.com/classic/item=236727/tunic-of-undead-cleansing
-	// Equip: +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(TunicOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
-
-	// https://www.wowhead.com/classic/item=236707/tunic-of-undead-slaying
-	// Equip: +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(TunicOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
-
-	// https://www.wowhead.com/classic/item=236733/tunic-of-undead-warding
-	// Equip: +81 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(TunicOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
-
-	// https://www.wowhead.com/classic/item=236734/wristguards-of-undead-cleansing
-	// Equip: +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(WristguardsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
-
-	// https://www.wowhead.com/classic/item=236740/wristguards-of-undead-purification
-	// Equip: +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(WristguardsOfUndeadPurification, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+	// Equip: +108 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(ChestguardOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 108)
 
 	// https://www.wowhead.com/classic/item=236710/wristguards-of-undead-slaying
-	// Equip: +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(WristguardsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
-
-	// https://www.wowhead.com/classic/item=236737/wristguards-of-undead-warding
-	// Equip: +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(WristguardsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
-
-	// https://www.wowhead.com/classic/item=236725/wristwraps-of-undead-cleansing
-	// Equip: +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(WristwrapsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+	// Equip: +60 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(WristguardsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
 
 	// https://www.wowhead.com/classic/item=236711/wristwraps-of-undead-slaying
+	// Equip: +60 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(WristwrapsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
+
+	// https://www.wowhead.com/classic/item=236712/bracers-of-undead-slaying
+	// Equip: +60 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(BracersOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 60)
+
+	// https://www.wowhead.com/classic/item=236713/handwraps-of-undead-slaying
+	// Equip: +81 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(HandwrapsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
+
+	// https://www.wowhead.com/classic/item=236714/gauntlets-of-undead-slaying
+	// Equip: +81 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(GauntletsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
+
+	// https://www.wowhead.com/classic/item=236715/handguards-of-undead-slaying
+	// Equip: +81 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(HandguardsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 81)
+
+	// https://www.wowhead.com/classic/item=236716/bracers-of-undead-cleansing
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 35.
+	core.NewMobTypeSpellPowerEffect(BracersOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 35)
+
+	// https://www.wowhead.com/classic/item=236717/gloves-of-undead-cleansing
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 48.
+	core.NewMobTypeSpellPowerEffect(GlovesOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 48)
+
+	// https://www.wowhead.com/classic/item=236718/robe-of-undead-cleansing/
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 65.
+	core.NewMobTypeSpellPowerEffect(RobeofUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 65)
+
+	// https://www.wowhead.com/classic/item=236722/bracers-of-undead-warding
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
+	core.NewMobTypeSpellPowerEffect(BracersOfUndeadWardingCloth, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
+
+	// https://www.wowhead.com/classic/item=236723/gloves-of-undead-warding
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
+	core.NewMobTypeSpellPowerEffect(GlovesOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
+
+	// https://www.wowhead.com/classic/item=236724/robe-of-undead-warding
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
+	core.NewMobTypeSpellPowerEffect(RobeOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
+
+	// https://www.wowhead.com/classic/item=236725/wristwraps-of-undead-cleansing
+	// Equip: +35 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(WristwrapsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 35)
+
+	// https://www.wowhead.com/classic/item=236726/handwraps-of-undead-cleansing
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 48.
+	core.NewMobTypeSpellPowerEffect(HandwrapsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 48)
+
+	// https://www.wowhead.com/classic/item=236727/tunic-of-undead-cleansing
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 65.
+	core.NewMobTypeSpellPowerEffect(TunicOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 65)
+
+	// https://www.wowhead.com/classic/item=236731/wristwraps-of-undead-warding
 	// Equip: +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(WristwrapsOfUndeadSlaying, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+	core.NewMobTypeAttackPowerEffect(WristwrapsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
 
 	// https://www.wowhead.com/classic/item=236732/handwraps-of-undead-warding
 	// Equip: +45 Attack Power when fighting Undead.
-	core.NewMobTypeAttackPowerEffect(WristwrapsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+	core.NewMobTypeAttackPowerEffect(HandwrapsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+
+	// https://www.wowhead.com/classic/item=236733/tunic-of-undead-warding
+	// Equip: +45 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(TunicOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+
+	// https://www.wowhead.com/classic/item=236734/wristguards-of-undead-cleansing
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 35.
+	core.NewMobTypeSpellPowerEffect(WristguardsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 35)
+
+	// https://www.wowhead.com/classic/item=236735/handguards-of-undead-cleansing
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 48.
+	core.NewMobTypeSpellPowerEffect(HandguardsOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 48)
+
+	// https://www.wowhead.com/classic/item=236736/chestguard-of-undead-cleansing
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 65.
+	core.NewMobTypeSpellPowerEffect(ChestguardOfUndeadCleansing, []proto.MobType{proto.MobType_MobTypeUndead}, 65)
+
+	// https://www.wowhead.com/classic/item=236737/wristguards-of-undead-warding
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
+	core.NewMobTypeSpellPowerEffect(WristguardsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 36)
+
+	// https://www.wowhead.com/classic/item=236738/handguards-of-undead-warding
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
+	core.NewMobTypeSpellPowerEffect(HandguardsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
+
+	// https://www.wowhead.com/classic/item=236739/chestguard-of-undead-warding
+	// Equip: Increases damage done to Undead by magical spells and effects by up to 26.
+	core.NewMobTypeSpellPowerEffect(ChestguardOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 26)
+
+	// https://www.wowhead.com/classic/item=236746/bracers-of-undead-warding
+	// Equip: +45 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(BracersOfUndeadWardingPlate, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+
+	// https://www.wowhead.com/classic/item=236747/gauntlets-of-undead-warding
+	//  Equip: +45 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(GauntletsOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
+
+	// https://www.wowhead.com/classic/item=236748/breastplate-of-undead-warding
+	// +45 Attack Power when fighting Undead.
+	core.NewMobTypeAttackPowerEffect(BreastplateOfUndeadWarding, []proto.MobType{proto.MobType_MobTypeUndead}, 45)
 
 	core.AddEffectsToTest = true
 }
 
-const MaxSanctifiedBonus = 12
+const MaxSanctifiedBonus = 8
 
 // Equip: Unlocks your potential while inside Naxxramas.
 // Increasing your damage by X% and your health by X% for each piece of Sanctified armor equipped.
@@ -456,7 +413,7 @@ func sanctifiedDamageEffect(spellID int32, percentIncrease float64) core.ApplyEf
 				ActionID:   core.ActionID{SpellID: spellID},
 				BuildPhase: core.CharacterBuildPhaseGear,
 				OnInit: func(aura *core.Aura, sim *core.Simulation) {
-					sanctifiedBonus = min(12, character.PseudoStats.SanctifiedBonus)
+					sanctifiedBonus = min(MaxSanctifiedBonus, character.PseudoStats.SanctifiedBonus)
 					multiplier = 1.0 + percentIncrease/100.0*float64(sanctifiedBonus)
 				},
 				OnGain: func(aura *core.Aura, sim *core.Simulation) {
@@ -552,7 +509,7 @@ func sanctifiedTankingEffect(spellID int32, threatPercentIncrease float64, damag
 				ActionID:   core.ActionID{SpellID: spellID},
 				BuildPhase: core.CharacterBuildPhaseGear,
 				OnInit: func(aura *core.Aura, sim *core.Simulation) {
-					sanctifiedBonus = min(12, character.PseudoStats.SanctifiedBonus)
+					sanctifiedBonus = min(MaxSanctifiedBonus, character.PseudoStats.SanctifiedBonus)
 					damageHealthMultiplier = 1.0 + damageHealthPercentIncrease/100.0*float64(sanctifiedBonus)
 					threatMultiplier = 1.0 + threatPercentIncrease/100.0*float64(sanctifiedBonus)
 				},
@@ -612,12 +569,12 @@ func UnholyMightAura(character *core.Character) *core.Aura {
 		Label:    "Unholy Might",
 		Duration: time.Second * 8,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.AddStatDynamic(sim, stats.Strength, 400)
-			character.PseudoStats.DamageTakenMultiplier *= 1.20
+			aura.Unit.AddStatDynamic(sim, stats.Strength, 350)
+			character.PseudoStats.DamageTakenMultiplier *= 1.05
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			aura.Unit.AddStatDynamic(sim, stats.Strength, -400)
-			character.PseudoStats.DamageTakenMultiplier /= 1.20
+			aura.Unit.AddStatDynamic(sim, stats.Strength, -350)
+			character.PseudoStats.DamageTakenMultiplier /= 1.05
 		},
 	})
 }

--- a/sim/common/sod/items_sets/phase_7.go
+++ b/sim/common/sod/items_sets/phase_7.go
@@ -11,10 +11,10 @@ import (
 var ItemSetRegaliaOfUndeadCleansing = core.NewItemSet(core.ItemSet{
 	Name: "Regalia of Undead Cleansing",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -22,10 +22,10 @@ var ItemSetRegaliaOfUndeadCleansing = core.NewItemSet(core.ItemSet{
 var ItemSetRegaliaOfUndeadPurification = core.NewItemSet(core.ItemSet{
 	Name: "Regalia of Undead Purification",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -33,10 +33,10 @@ var ItemSetRegaliaOfUndeadPurification = core.NewItemSet(core.ItemSet{
 var ItemSetRegaliaOfUndeadWarding = core.NewItemSet(core.ItemSet{
 	Name: "Regalia of Undead Warding",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -48,10 +48,10 @@ var ItemSetRegaliaOfUndeadWarding = core.NewItemSet(core.ItemSet{
 var ItemSetUndeadCleansersArmor = core.NewItemSet(core.ItemSet{
 	Name: "Undead Cleanser's Armor",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -59,10 +59,10 @@ var ItemSetUndeadCleansersArmor = core.NewItemSet(core.ItemSet{
 var ItemSetUndeadPurifiersArmor = core.NewItemSet(core.ItemSet{
 	Name: "Undead Purifier's Armor",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -70,10 +70,10 @@ var ItemSetUndeadPurifiersArmor = core.NewItemSet(core.ItemSet{
 var ItemSetUndeadSlayersArmor = core.NewItemSet(core.ItemSet{
 	Name: "Undead Slayer's Armor",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -81,10 +81,10 @@ var ItemSetUndeadSlayersArmor = core.NewItemSet(core.ItemSet{
 var ItemSetUndeadWardersArmor = core.NewItemSet(core.ItemSet{
 	Name: "Undead Warder's Armor",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -96,10 +96,10 @@ var ItemSetUndeadWardersArmor = core.NewItemSet(core.ItemSet{
 var ItemSetGarbOfTheUndeadCleansing = core.NewItemSet(core.ItemSet{
 	Name: "Garb of the Undead Cleansing",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -107,10 +107,10 @@ var ItemSetGarbOfTheUndeadCleansing = core.NewItemSet(core.ItemSet{
 var ItemSetGarbOfTheUndeadPurifier = core.NewItemSet(core.ItemSet{
 	Name: "Garb of the Undead Purifier",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -118,10 +118,10 @@ var ItemSetGarbOfTheUndeadPurifier = core.NewItemSet(core.ItemSet{
 var ItemSetGarbOfTheUndeadSlayer = core.NewItemSet(core.ItemSet{
 	Name: "Garb of the Undead Slayer",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -129,10 +129,10 @@ var ItemSetGarbOfTheUndeadSlayer = core.NewItemSet(core.ItemSet{
 var ItemSetGarbOfTheUndeadWarder = core.NewItemSet(core.ItemSet{
 	Name: "Garb of the Undead Warder",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -144,10 +144,10 @@ var ItemSetGarbOfTheUndeadWarder = core.NewItemSet(core.ItemSet{
 var ItemSetBattlegearOfUndeadPurification = core.NewItemSet(core.ItemSet{
 	Name: "Battlegear of Undead Purification",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -155,10 +155,10 @@ var ItemSetBattlegearOfUndeadPurification = core.NewItemSet(core.ItemSet{
 var ItemSetBattlegearOfUndeadSlaying = core.NewItemSet(core.ItemSet{
 	Name: "Battlegear of Undead Slaying",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })
@@ -166,10 +166,10 @@ var ItemSetBattlegearOfUndeadSlaying = core.NewItemSet(core.ItemSet{
 var ItemSetBattlegearOfUndeadWarding = core.NewItemSet(core.ItemSet{
 	Name: "Battlegear of Undead Warding",
 	Bonuses: map[int32]core.ApplyEffect{
-		// Treats your Seal of the Dawn bonus as if you were wearing 3 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 12)
+		// Treats your Seal of the Dawn bonus as if you were wearing 2 additional pieces of Sanctified armor. (Your total number of Sanctified armor pieces cannot exceed 8)
 		3: func(agent core.Agent) {
 			character := agent.GetCharacter()
-			character.PseudoStats.SanctifiedBonus += 3
+			character.PseudoStats.SanctifiedBonus += 2
 		},
 	},
 })

--- a/sim/paladin/items.go
+++ b/sim/paladin/items.go
@@ -55,7 +55,7 @@ func init() {
 	})
 
 	// https://www.wowhead.com/classic/item=236299/claymore-of-unholy-might
-	// Chance on hit: Increases the wielder's Strength by 400, but they also take 20% more damage from all sources for 8 sec.
+	// Chance on hit: Increases the wielder's Strength by 350, but they also take 5% more damage from all sources for 8 sec.
 	// TODO: Proc rate assumed and needs testing
 	itemhelpers.CreateWeaponProcAura(ClaymoreOfUnholyMight, "Claymore of Unholy Might", 1.0, item_effects.UnholyMightAura)
 

--- a/sim/shaman/items.go
+++ b/sim/shaman/items.go
@@ -687,7 +687,7 @@ func init() {
 	})
 
 	// https://www.wowhead.com/classic/item=237577/totem-of-unholy-might
-	// Chance on hit: Increases the wielder's Strength by 400, but they also take 20% more damage from all sources for 8 sec.
+	// Chance on hit: Increases the wielder's Strength by 350, but they also take 5% more damage from all sources for 8 sec.
 	// TODO: Proc rate assumed and needs testing
 	itemhelpers.CreateWeaponProcAura(TotemOfUnholyMight, "Totem of Unholy Might", 1.0, item_effects.UnholyMightAura)
 


### PR DESCRIPTION
* Sanctified item cap now 8 (was 12)
* Undead Slaying/Warding/Cleansing sets now give +2 sanctified (was +3)
* Tweak Claymore/Totem of Unholy Might proc numbers