### PR TITLE
Fix feral 2pt2 rake tick count with 2pt3

### DIFF
--- a/sim/druid/item_sets_pve_phase_5.go
+++ b/sim/druid/item_sets_pve_phase_5.go
@@ -148,7 +148,7 @@ func (druid *Druid) applyT2Feral2PBonus() {
 					continue
 				}
 
-				dot.NumberOfTicks += 2
+				dot.NumberOfTicks += int32(6 / dot.TickLength.Seconds())
 				dot.RecomputeAuraDuration()
 				oldOnSnapshot := dot.OnSnapshot
 				dot.OnSnapshot = func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {


### PR DESCRIPTION
Makes the added ticks from 2pt2 depend on tick length instead of a hardcoded 2.