### PR TITLE
Changes to some set bonuses from additive to multiplicative and more

### DIFF
--- a/sim/paladin/crusader_strike.go
+++ b/sim/paladin/crusader_strike.go
@@ -16,10 +16,11 @@ func (paladin *Paladin) registerCrusaderStrike() {
 		return
 	}
 
-	manaMetrics := paladin.NewManaMetrics(core.ActionID{SpellID: int32(proto.PaladinRune_RuneHandsCrusaderStrike)})
+	actionID := core.ActionID{SpellID: int32(proto.PaladinRune_RuneHandsCrusaderStrike)}
+	manaMetrics := paladin.NewManaMetrics(actionID)
 
 	crusaderStrikeSpell := paladin.RegisterSpell(core.SpellConfig{
-		ActionID:    manaMetrics.ActionID,
+		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolHoly,
 		DefenseType: core.DefenseTypeMelee,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,

--- a/sim/paladin/divine_storm.go
+++ b/sim/paladin/divine_storm.go
@@ -19,10 +19,11 @@ func (paladin *Paladin) registerDivineStorm() {
 
 	numTargets := min(4, paladin.Env.GetNumTargets())
 
-	healthMetrics := paladin.NewHealthMetrics(core.ActionID{SpellID: int32(proto.PaladinRune_RuneChestDivineStorm)})
+	actionID := core.ActionID{SpellID: int32(proto.PaladinRune_RuneChestDivineStorm)}
+	healthMetrics := paladin.NewHealthMetrics(actionID)
 
 	divineStormSpell := paladin.RegisterSpell(core.SpellConfig{
-		ActionID:    healthMetrics.ActionID,
+		ActionID:    actionID,
 		SpellSchool: core.SpellSchoolPhysical,
 		DefenseType: core.DefenseTypeMelee,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,

--- a/sim/paladin/item_sets_pve.go
+++ b/sim/paladin/item_sets_pve.go
@@ -32,6 +32,9 @@ const (
 	PaladinT2Ret2P   = 467518
 	PaladinT2Ret4P   = 467526
 	PaladinT2Ret6P   = 467529
+	PaladinT3Ret2P   = 1219189
+	PaladinT3Ret4P   = 1219191
+	PaladinT3Ret6P   = 1219193
 	PaladinTAQRet2P  = 1213397
 	PaladinTAQRet4P  = 1213406
 	PaladinZG2P      = 468401

--- a/sim/paladin/runes.go
+++ b/sim/paladin/runes.go
@@ -16,7 +16,7 @@ func (paladin *Paladin) ApplyRunes() {
 	paladin.registerRV()
 	paladin.registerFanaticism()
 
-	// "RuneHeadWrath" is handled in Exorcism, Holy Shock, Consecration (and Holy Wrath once implemented)
+	// "RuneHeadWrath" is handled in Exorcism, Holy Shock, Consecration and Holy Wrath
 	paladin.registerMalleableProtection()
 	paladin.registerHammerOfTheRighteous()
 	// "RuneWristImprovedHammerOfWrath" is handled Hammer of Wrath

--- a/sim/priest/item_sets_pve_phase_7.go
+++ b/sim/priest/item_sets_pve_phase_7.go
@@ -78,11 +78,10 @@ func (priest *Priest) applyNaxxramasShadow6PBonus() {
 	priest.RegisterAura(core.Aura{
 		Label: label,
 		OnInit: func(aura *core.Aura, sim *core.Simulation) {
-			affectedSpells := core.Flatten([][]*core.Spell{
-				priest.MindBlast,
-				{priest.MindSpike},
-			})
-
+			affectedSpells := priest.MindBlast
+			if priest.HasRune(proto.PriestRune_RuneWaistMindSpike) {
+				affectedSpells = append(affectedSpells, priest.MindSpike)
+			}
 			if priest.HasRune(proto.PriestRune_RuneBracersDespair) {
 				affectedSpells = append(affectedSpells, core.Flatten(priest.MindFlay)...)
 			}
@@ -94,14 +93,14 @@ func (priest *Priest) applyNaxxramasShadow6PBonus() {
 
 				oldApplyEffects := spell.ApplyEffects
 				spell.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-					critChanceBonus := 0.0
+					critChanceBonus := 1.0
 					if target.MobType == proto.MobType_MobTypeUndead {
-						critChanceBonus = priest.GetStat(stats.SpellCrit) / 100
+						critChanceBonus += priest.GetStat(stats.SpellCrit) / 100.0
 					}
 
-					spell.DamageMultiplierAdditive += critChanceBonus
+					spell.DamageMultiplier *= critChanceBonus
 					oldApplyEffects(sim, target, spell)
-					spell.DamageMultiplierAdditive -= critChanceBonus
+					spell.DamageMultiplier /= critChanceBonus
 				}
 			}
 		},

--- a/sim/shaman/lava_burst.go
+++ b/sim/shaman/lava_burst.go
@@ -85,9 +85,9 @@ func (shaman *Shaman) newLavaBurstSpellConfig(isOverload bool) core.SpellConfig 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := sim.Roll(baseDamageLow, baseDamageHigh)
 
-			damageMultiplier := 0.0
+			damageMultiplier := 1.0
 			if shaman.useLavaBurstCritScaling {
-				damageMultiplier = shaman.GetStat(stats.SpellCrit) / 100
+				damageMultiplier += shaman.GetStat(stats.SpellCrit) / 100.0
 			}
 
 			flameShockActive := false
@@ -102,16 +102,16 @@ func (shaman *Shaman) newLavaBurstSpellConfig(isOverload bool) core.SpellConfig 
 				}
 			}
 
-			spell.DamageMultiplierAdditive += damageMultiplier
 			if flameShockActive {
-				spell.BonusCritRating += 100 * core.SpellCritRatingPerCritChance
+				spell.BonusCritRating += 100.0 * core.SpellCritRatingPerCritChance
 			}
 
+			spell.DamageMultiplier *= damageMultiplier
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
+			spell.DamageMultiplier /= damageMultiplier
 
-			spell.DamageMultiplierAdditive -= damageMultiplier
 			if flameShockActive {
-				spell.BonusCritRating -= 100 * core.SpellCritRatingPerCritChance
+				spell.BonusCritRating -= 100.0 * core.SpellCritRatingPerCritChance
 			}
 
 			spell.WaitTravelTime(sim, func(sim *core.Simulation) {


### PR DESCRIPTION
* Ret 6p T3 is changed after findings to multiplicative as well as gaining damage from Exorcist, Wrath rune and can result in more than 100% extra damage
* Shadow 6p T3 is changed to multiplicative
* Elemental AQ10 3p is changed to multiplicative (has no real effect unless the 3% dmg totem is also used)