### PR TITLE
Fixes for off hand imbues and add logging for paladin AoW procs

### DIFF
--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -565,6 +565,19 @@ func (character *Character) HasOHWeapon() bool {
 	return character.GetOHWeapon() != nil
 }
 
+// Returns the OH item if one is equipped, and null otherwise. Note that
+// shields / Held-in-off-hand items ARE counted in this function.
+func (character *Character) GetOHItem() *Item {
+	weapon := character.OffHand()
+	if weapon.ID == 0 {
+		return nil
+	}
+	return weapon
+}
+func (character *Character) HasOHItem() bool {
+	return character.GetOHItem() != nil
+}
+
 // Returns the ranged weapon if one is equipped, and null otherwise.
 func (character *Character) GetRangedWeapon() *Item {
 	weapon := character.Ranged()

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -114,7 +114,7 @@ func applyWeaponImbueConsumes(character *Character, consumes *proto.Consumes) {
 	if character.HasMHWeapon() {
 		addImbueStats(character, consumes.MainHandImbue, true, shadowOilIcd)
 	}
-	if character.OffHand() != nil {
+	if character.HasOHItem() {
 		addImbueStats(character, consumes.OffHandImbue, false, shadowOilIcd)
 	}
 }

--- a/sim/hunter/TestMM.results
+++ b/sim/hunter/TestMM.results
@@ -69,7 +69,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2023.05
   final_stats: 6
-  final_stats: 50.49271
+  final_stats: 48.49271
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -149,7 +149,7 @@ stat_weights_results: {
  key: "TestMM-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 0.52119
+  weights: 0.45304
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.19892
+  weights: 0.19594
   weights: 0
-  weights: 4.90375
+  weights: 5.42335
   weights: 0
   weights: 0
   weights: 0
@@ -309,112 +309,112 @@ dps_results: {
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 551.2998
-  tps: 551.41051
+  dps: 543.80213
+  tps: 543.91285
   hps: 10.10534
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 749.90036
-  tps: 750.01081
+  dps: 741.06355
+  tps: 741.174
   hps: 10.05412
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 873.84069
-  tps: 873.95114
+  dps: 864.5631
+  tps: 864.67355
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 872.84826
-  tps: 872.95871
+  dps: 865.21294
+  tps: 865.32339
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 865.94683
-  tps: 866.05728
+  dps: 858.33233
+  tps: 858.44278
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 643.41364
-  tps: 643.52409
+  dps: 637.34453
+  tps: 637.45498
   hps: 9.63591
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 875.32463
-  tps: 875.43508
+  dps: 866.02699
+  tps: 866.13744
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 749.90036
-  tps: 750.01081
+  dps: 741.06355
+  tps: 741.174
   hps: 10.05412
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 875.87563
-  tps: 875.98608
+  dps: 865.76579
+  tps: 865.87624
   hps: 12.90919
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 861.75744
-  tps: 861.86789
+  dps: 852.62654
+  tps: 852.73699
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 823.14755
-  tps: 823.258
+  dps: 815.3012
+  tps: 815.41165
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 747.22255
-  tps: 747.333
+  dps: 737.32942
+  tps: 737.43987
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 859.12713
-  tps: 859.23758
+  dps: 850.45062
+  tps: 850.56107
   hps: 13.05826
  }
 }
 dps_results: {
  key: "TestMM-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 882.2824
-  tps: 882.40141
+  dps: 871.66331
+  tps: 871.78233
   hps: 13.07849
  }
 }

--- a/sim/hunter/TestSV.results
+++ b/sim/hunter/TestSV.results
@@ -69,7 +69,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2163.603
   final_stats: 6
-  final_stats: 51.78023
+  final_stats: 49.78023
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -118,7 +118,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2573.0133
   final_stats: 9
-  final_stats: 56.20316
+  final_stats: 54.20316
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -198,7 +198,7 @@ stat_weights_results: {
  key: "TestSV-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 2.89414
+  weights: 2.89705
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +214,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.39647
+  weights: 0.39263
   weights: 0
-  weights: 22.49626
+  weights: 22.03837
   weights: 0
   weights: 0
   weights: 0
@@ -247,7 +247,7 @@ stat_weights_results: {
  key: "TestSV-Phase5-Lvl60-StatWeights-Default"
  value: {
   weights: 0
-  weights: 3.26073
+  weights: 3.38693
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50784
+  weights: 0.50282
   weights: 0
-  weights: 27.89413
+  weights: 28.59856
   weights: 0
   weights: 0
   weights: 0
@@ -407,405 +407,405 @@ dps_results: {
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 1098.86222
-  tps: 872.59023
+  dps: 1090.42699
+  tps: 869.01881
   hps: 14.17231
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 1234.7259
-  tps: 982.7528
+  dps: 1225.49774
+  tps: 978.55079
   hps: 14.17231
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 1578.32437
-  tps: 1585.79875
+  dps: 1577.81457
+  tps: 1585.59647
   hps: 13.51585
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 3183.52144
-  tps: 2795.61439
+  dps: 3171.29732
+  tps: 2788.64606
   hps: 20.4684
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 3157.68478
-  tps: 2773.03931
+  dps: 3145.59545
+  tps: 2766.12194
   hps: 20.4684
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 1877.21263
-  tps: 1614.6016
+  dps: 1868.68205
+  tps: 1609.9241
   hps: 15.34389
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 1611.21978
-  tps: 1618.69416
+  dps: 1610.70998
+  tps: 1618.49188
   hps: 13.51585
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 1234.7259
-  tps: 982.7528
+  dps: 1225.49774
+  tps: 978.55079
   hps: 14.17231
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 3208.14444
-  tps: 2824.20346
+  dps: 3197.68999
+  tps: 2817.32866
   hps: 20.15517
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 3128.75551
-  tps: 2753.97276
+  dps: 3116.39806
+  tps: 2746.14194
   hps: 20.7632
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 2861.36327
-  tps: 2519.67643
+  dps: 2852.34774
+  tps: 2513.8397
   hps: 19.87223
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 3044.57123
-  tps: 2674.84571
+  dps: 3034.15443
+  tps: 2668.79262
   hps: 19.87223
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 3089.86652
-  tps: 2720.55929
+  dps: 3078.76023
+  tps: 2712.93351
   hps: 19.87223
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3213.36765
-  tps: 2829.67343
+  dps: 3198.46569
+  tps: 2820.36845
   hps: 20.17278
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4702.35119
-  tps: 4742.33545
+  dps: 4685.40187
+  tps: 4731.82763
   hps: 20.73445
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2969.3243
-  tps: 2601.27495
+  dps: 2956.43811
+  tps: 2593.1483
   hps: 20.62697
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3001.78964
-  tps: 2647.03719
+  dps: 2984.23032
+  tps: 2637.50747
   hps: 20.03729
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3320.83556
-  tps: 3579.98684
+  dps: 3312.65796
+  tps: 3574.57795
   hps: 10.45779
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1498.98234
-  tps: 1337.2676
+  dps: 1491.12539
+  tps: 1332.55626
   hps: 10.34377
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Dwarf-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1495.34277
-  tps: 1313.63335
+  dps: 1489.73805
+  tps: 1309.8573
   hps: 10.61961
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 5016.1643
-  tps: 5047.83752
+  dps: 4999.91857
+  tps: 5038.78382
   hps: 20.44579
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3203.50833
-  tps: 2815.64058
+  dps: 3183.63188
+  tps: 2806.30702
   hps: 20.51335
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3259.7443
-  tps: 2900.82137
+  dps: 3248.30715
+  tps: 2895.96489
   hps: 19.28493
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3266.2679
-  tps: 3516.83011
+  dps: 3256.62305
+  tps: 3511.24321
   hps: 10.60306
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1502.23092
-  tps: 1337.26112
+  dps: 1492.83469
+  tps: 1331.57531
   hps: 10.3401
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-Settings-Orc-p4_weave-Weave-p4_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1527.94234
-  tps: 1345.24603
+  dps: 1517.30068
+  tps: 1340.14761
   hps: 10.57364
  }
 }
 dps_results: {
  key: "TestSV-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2981.42232
-  tps: 2669.61506
+  dps: 2971.491
+  tps: 2665.78107
   hps: 19.89102
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-BeastmasterArmor"
  value: {
-  dps: 1164.87331
-  tps: 944.39344
+  dps: 1159.90113
+  tps: 942.4362
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-BloodGuard'sChain"
  value: {
-  dps: 1337.41408
-  tps: 1016.97607
+  dps: 1329.80221
+  tps: 1013.11132
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-BloodlashBow-216516"
  value: {
-  dps: 3762.97684
-  tps: 3102.98721
+  dps: 3748.01903
+  tps: 3094.31461
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-DevilsaurEye-19991"
  value: {
-  dps: 4144.65468
-  tps: 3514.03914
+  dps: 4123.64583
+  tps: 3501.75471
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-DevilsaurTooth-19992"
  value: {
-  dps: 4115.9595
-  tps: 3489.85472
+  dps: 4095.13779
+  tps: 3477.7093
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-DreadHunter'sChain"
  value: {
-  dps: 1956.51931
-  tps: 1594.46241
+  dps: 1945.59402
+  tps: 1590.56536
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-GurubashiPitFighter'sBow-221450"
  value: {
-  dps: 3799.41138
-  tps: 3136.42327
+  dps: 3784.38028
+  tps: 3127.70454
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-Knight-Lieutenant'sChain"
  value: {
-  dps: 1337.41408
-  tps: 1016.97607
+  dps: 1329.80221
+  tps: 1013.11132
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-Maelstrom'sWrath-231320"
  value: {
-  dps: 4129.29264
-  tps: 3501.11407
+  dps: 4110.33545
+  tps: 3488.98198
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-SignetofBeasts-209823"
  value: {
-  dps: 4082.47039
-  tps: 3460.76936
+  dps: 4058.75799
+  tps: 3447.16514
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-ZandalarPredator'sBelt-231322"
  value: {
-  dps: 3659.70101
-  tps: 3112.71616
+  dps: 3636.74482
+  tps: 3099.26411
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-ZandalarPredator'sBracers-231323"
  value: {
-  dps: 3765.60678
-  tps: 3375.09739
+  dps: 3748.48919
+  tps: 3364.37604
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-AllItems-ZandalarPredator'sMantle-231321"
  value: {
-  dps: 3872.95925
-  tps: 3354.32789
+  dps: 3850.83303
+  tps: 3341.80298
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4171.52593
-  tps: 3542.58318
+  dps: 4149.96335
+  tps: 3529.78638
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Dwarf-p5_weave-Weave-p5_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4580.67687
-  tps: 4463.23448
+  dps: 4563.95187
+  tps: 4455.97726
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Dwarf-p5_weave-Weave-p5_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 4060.61263
-  tps: 3426.12311
+  dps: 4045.09766
+  tps: 3419.00909
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Dwarf-p5_weave-Weave-p5_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 4043.65991
-  tps: 3386.94804
+  dps: 4033.51022
+  tps: 3381.44099
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Dwarf-p5_weave-Weave-p5_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2034.08819
-  tps: 2389.53367
+  dps: 2022.60973
+  tps: 2383.38644
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Dwarf-p5_weave-Weave-p5_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1733.44513
-  tps: 1496.75146
+  dps: 1723.57826
+  tps: 1490.08171
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Dwarf-p5_weave-Weave-p5_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1786.36231
-  tps: 1524.95956
+  dps: 1782.37511
+  tps: 1522.23191
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Orc-p5_weave-Weave-p5_weave-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4561.44776
-  tps: 4457.6074
+  dps: 4545.62747
+  tps: 4451.35466
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Orc-p5_weave-Weave-p5_weave-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 4023.93299
-  tps: 3385.69307
+  dps: 4008.69666
+  tps: 3377.54454
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Orc-p5_weave-Weave-p5_weave-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 4062.59008
-  tps: 3402.22561
+  dps: 4052.295
+  tps: 3396.63688
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Orc-p5_weave-Weave-p5_weave-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2036.01636
-  tps: 2375.02688
+  dps: 2026.77126
+  tps: 2370.49692
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Orc-p5_weave-Weave-p5_weave-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1766.81089
-  tps: 1511.61549
+  dps: 1756.65404
+  tps: 1505.86225
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-Settings-Orc-p5_weave-Weave-p5_weave-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1782.14292
-  tps: 1527.2338
+  dps: 1778.69664
+  tps: 1525.04823
  }
 }
 dps_results: {
  key: "TestSV-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3747.308
-  tps: 3233.71977
+  dps: 3730.78027
+  tps: 3224.1973
  }
 }

--- a/sim/paladin/retribution/TestExodin.results
+++ b/sim/paladin/retribution/TestExodin.results
@@ -6,7 +6,7 @@ character_stats_results: {
   final_stats: 535.095
   final_stats: 162.8
   final_stats: 173.25
-  final_stats: 204
+  final_stats: 180
   final_stats: 0
   final_stats: 10
   final_stats: 0
@@ -55,7 +55,7 @@ character_stats_results: {
   final_stats: 619.7235
   final_stats: 172.04
   final_stats: 199.2375
-  final_stats: 228
+  final_stats: 192
   final_stats: 0
   final_stats: 10
   final_stats: 0
@@ -64,7 +64,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 49.6
   final_stats: 4
-  final_stats: 41.37307
+  final_stats: 40.37307
   final_stats: 0
   final_stats: 0
   final_stats: 2792.102
@@ -100,7 +100,7 @@ stat_weights_results: {
  key: "TestExodin-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 2.09759
-  weights: 1.49225
+  weights: 1.48613
   weights: 0
   weights: 0
   weights: 0
@@ -112,13 +112,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.16271
-  weights: 1.95601
+  weights: 9.06215
+  weights: 1.92675
   weights: 0
   weights: 0
   weights: 0.86677
   weights: 0
-  weights: 22.95158
+  weights: 22.8683
   weights: 0
   weights: 0
   weights: 0
@@ -148,12 +148,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestExodin-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.95202
-  weights: 1.44609
+  weights: 2.95072
+  weights: 1.74785
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.94547
+  weights: 0.94279
   weights: 0
   weights: 0
   weights: 0
@@ -161,13 +161,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 17.69375
-  weights: 4.86052
+  weights: 14.60521
+  weights: 2.81848
   weights: 0
   weights: 0
-  weights: 1.06073
+  weights: 1.06027
   weights: 0
-  weights: 27.52974
+  weights: 26.41673
   weights: 0
   weights: 0
   weights: 0
@@ -197,266 +197,266 @@ stat_weights_results: {
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1373.79416
-  tps: 1409.00303
+  dps: 1367.56602
+  tps: 1402.77489
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1373.93825
-  tps: 1410.00203
+  dps: 1367.70676
+  tps: 1403.77054
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1472.28753
-  tps: 1509.61946
+  dps: 1466.05939
+  tps: 1503.39132
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 1632.47818
-  tps: 1670.23549
+  dps: 1625.71759
+  tps: 1663.4749
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1246.75619
-  tps: 1283.25646
+  dps: 1240.52805
+  tps: 1277.02832
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3336.41932
-  tps: 3368.49068
+  dps: 3319.1753
+  tps: 3351.24667
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2418.67028
-  tps: 2970.86794
+  dps: 2393.53507
+  tps: 2945.73273
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 864.01821
-  tps: 891.65661
+  dps: 858.1648
+  tps: 885.8032
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 980.46462
-  tps: 1011.40749
+  dps: 972.99977
+  tps: 1003.94264
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 887.04713
-  tps: 1257.49029
+  dps: 875.1542
+  tps: 1245.59736
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 354.02563
-  tps: 372.53734
+  dps: 351.14761
+  tps: 369.65932
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Dwarf-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 499.16478
-  tps: 522.49629
+  dps: 494.20506
+  tps: 517.53657
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2489.28715
-  tps: 3045.51831
+  dps: 2463.31433
+  tps: 3019.54549
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 870.26618
-  tps: 897.90231
+  dps: 864.37227
+  tps: 892.0084
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 983.5243
-  tps: 1014.50876
+  dps: 976.04929
+  tps: 1007.03376
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 890.99519
-  tps: 1262.78351
+  dps: 879.00058
+  tps: 1250.78891
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 361.50788
-  tps: 380.08679
+  dps: 358.61461
+  tps: 377.19351
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-Settings-Human-p4-exodin-6pcT1-P4 Exodin-p4-exodin-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 505.0558
-  tps: 528.4886
+  dps: 500.02039
+  tps: 523.45319
  }
 }
 dps_results: {
  key: "TestExodin-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2767.2818
-  tps: 2802.08042
+  dps: 2751.95945
+  tps: 2786.75806
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1803.23634
-  tps: 1843.25854
+  dps: 1789.20527
+  tps: 1829.22747
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1803.2488
-  tps: 1844.21681
+  dps: 1790.89364
+  tps: 1831.86165
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1930.1908
-  tps: 1972.59307
+  dps: 1915.85636
+  tps: 1958.25864
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 2395.85208
-  tps: 2438.72275
+  dps: 2381.68443
+  tps: 2424.5551
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1615.59858
-  tps: 1657.18019
+  dps: 1603.78452
+  tps: 1645.36613
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4781.13395
-  tps: 4819.53813
+  dps: 4743.17517
+  tps: 4781.67341
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 4305.07151
-  tps: 4949.33625
+  dps: 4237.12776
+  tps: 4881.3925
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1449.19655
-  tps: 1481.75331
+  dps: 1434.52417
+  tps: 1467.08092
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1565.19655
-  tps: 1604.14129
+  dps: 1551.17208
+  tps: 1590.11682
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 1240.37406
-  tps: 1607.77768
+  dps: 1213.21787
+  tps: 1580.62149
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 506.72977
-  tps: 525.04177
+  dps: 499.7017
+  tps: 518.01371
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Dwarf-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 701.83638
-  tps: 725.91907
+  dps: 689.39276
+  tps: 713.47544
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 4302.96975
-  tps: 4949.69529
+  dps: 4236.18644
+  tps: 4882.91199
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1453.44493
-  tps: 1486.01117
+  dps: 1440.15788
+  tps: 1472.72412
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1568.23298
-  tps: 1607.40363
+  dps: 1554.34365
+  tps: 1593.51431
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 1259.08511
-  tps: 1627.67873
+  dps: 1231.86544
+  tps: 1600.45906
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 509.17814
-  tps: 527.5883
+  dps: 502.69962
+  tps: 521.10978
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-Settings-Human-p5-exodin-P5 Exodin-p5-exodin-6CF-2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 699.68307
-  tps: 723.67344
+  dps: 687.60227
+  tps: 711.59264
  }
 }
 dps_results: {
  key: "TestExodin-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3952.47044
-  tps: 3994.67149
+  dps: 3911.73063
+  tps: 3954.14458
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -153,7 +153,7 @@ character_stats_results: {
   final_stats: 635.72575
   final_stats: 187.22
   final_stats: 199.2375
-  final_stats: 204
+  final_stats: 180
   final_stats: 0
   final_stats: 10
   final_stats: 0
@@ -202,7 +202,7 @@ character_stats_results: {
   final_stats: 640.09
   final_stats: 172.04
   final_stats: 199.2375
-  final_stats: 240
+  final_stats: 204
   final_stats: 0
   final_stats: 10
   final_stats: 0
@@ -211,7 +211,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 49.6
   final_stats: 4
-  final_stats: 40.37307
+  final_stats: 39.37307
   final_stats: 0
   final_stats: 0
   final_stats: 2759.791
@@ -251,7 +251,7 @@ character_stats_results: {
   final_stats: 602.2665
   final_stats: 172.04
   final_stats: 199.2375
-  final_stats: 85
+  final_stats: 40
   final_stats: 0
   final_stats: 40
   final_stats: 0
@@ -260,7 +260,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 61.6
   final_stats: 5
-  final_stats: 39.37307
+  final_stats: 38.37307
   final_stats: 0
   final_stats: 0
   final_stats: 3026.95
@@ -344,12 +344,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.66443
-  weights: 0.55502
+  weights: 0.66194
+  weights: 0.30699
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.2224
+  weights: 0.22025
   weights: 0
   weights: 0
   weights: 0
@@ -357,13 +357,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.99628
-  weights: 0.07348
+  weights: 1.83792
+  weights: 0.08257
   weights: 0
   weights: 0
-  weights: 0.30201
-  weights: 5.41004
-  weights: 5.22083
+  weights: 0.30088
+  weights: 5.44541
+  weights: 4.94471
   weights: 0
   weights: 0
   weights: 0
@@ -442,12 +442,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase4-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.63099
-  weights: 1.52041
+  weights: 2.63295
+  weights: 1.402
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.41216
+  weights: 0.41165
   weights: 0
   weights: 0
   weights: 0
@@ -455,13 +455,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.43455
-  weights: 0.82563
+  weights: 6.37166
+  weights: 0.87681
   weights: 0
   weights: 0
-  weights: 0.94538
-  weights: 2.29903
-  weights: 28.74367
+  weights: 0.94608
+  weights: 2.26384
+  weights: 29.11733
   weights: 0
   weights: 0
   weights: 0
@@ -491,12 +491,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 4.02344
-  weights: 2.37101
+  weights: 4.02397
+  weights: 2.35631
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.7113
+  weights: 0.71097
   weights: 0
   weights: 0
   weights: 0
@@ -504,13 +504,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 20.21913
-  weights: 0.58088
+  weights: 19.8326
+  weights: 0.4989
   weights: 0
   weights: 0
-  weights: 1.43532
-  weights: 4.16966
-  weights: 52.25149
+  weights: 1.43544
+  weights: 4.12214
+  weights: 52.08529
   weights: 0
   weights: 0
   weights: 0
@@ -540,12 +540,12 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestRetribution-Phase6-Lvl60-StatWeights-Default"
  value: {
-  weights: 4.67809
-  weights: 4.63992
+  weights: 4.67574
+  weights: 4.60618
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.68606
+  weights: 0.68573
   weights: 0
   weights: 0
   weights: 0
@@ -553,13 +553,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 11.86698
-  weights: 0.49536
+  weights: 11.70025
+  weights: 0.57295
   weights: 0
   weights: 0
-  weights: 1.71734
-  weights: 7.69381
-  weights: 59.59207
+  weights: 1.71692
+  weights: 7.60632
+  weights: 59.34876
   weights: 0
   weights: 0
   weights: 0
@@ -701,8 +701,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 549.58169
-  tps: 563.08933
+  dps: 547.19229
+  tps: 560.62339
  }
 }
 dps_results: {
@@ -792,8 +792,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 519.25717
-  tps: 532.69222
+  dps: 513.23904
+  tps: 526.63566
  }
 }
 dps_results: {
@@ -919,57 +919,57 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1769.56873
-  tps: 1808.64849
+  dps: 1764.73355
+  tps: 1803.81332
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1761.01321
-  tps: 1799.97952
+  dps: 1756.09012
+  tps: 1795.05643
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1869.47892
-  tps: 1909.43739
+  dps: 1864.71379
+  tps: 1904.67226
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 2375.22718
-  tps: 2426.33569
+  dps: 2368.14293
+  tps: 2419.25143
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1639.08702
-  tps: 1678.35455
+  dps: 1634.51264
+  tps: 1673.78017
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3849.77549
-  tps: 3899.08785
+  dps: 3838.80308
+  tps: 3888.39414
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 522.83562
-  tps: 953.74232
+  dps: 518.80223
+  tps: 949.70892
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 339.9031
-  tps: 361.45335
+  dps: 339.24662
+  tps: 360.79687
  }
 }
 dps_results: {
@@ -981,57 +981,57 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 335.99558
-  tps: 671.28799
+  dps: 332.23693
+  tps: 667.52934
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 218.08835
-  tps: 234.85297
+  dps: 217.37611
+  tps: 234.14073
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 75.61656
-  tps: 93.97157
+  dps: 75.30147
+  tps: 93.65647
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 19.32686
-  tps: 204.20369
+  dps: 19.03972
+  tps: 203.91655
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 19.32686
-  tps: 28.5707
+  dps: 19.03972
+  tps: 28.28357
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 60.89054
-  tps: 76.68888
+  dps: 59.98407
+  tps: 75.78242
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 11.73945
-  tps: 192.48627
+  dps: 11.54944
+  tps: 192.29626
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 11.73945
-  tps: 20.77679
+  dps: 11.54944
+  tps: 20.58678
  }
 }
 dps_results: {
@@ -1043,15 +1043,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 522.83562
-  tps: 953.74232
+  dps: 518.80223
+  tps: 949.70892
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 339.9031
-  tps: 361.45335
+  dps: 339.24662
+  tps: 360.79687
  }
 }
 dps_results: {
@@ -1063,57 +1063,57 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 335.99558
-  tps: 671.28799
+  dps: 332.23693
+  tps: 667.52934
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 218.08835
-  tps: 234.85297
+  dps: 217.37611
+  tps: 234.14073
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 75.61656
-  tps: 93.97157
+  dps: 75.30147
+  tps: 93.65647
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 19.32686
-  tps: 204.20369
+  dps: 19.03972
+  tps: 203.91655
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 19.32686
-  tps: 28.5707
+  dps: 19.03972
+  tps: 28.28357
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 60.89054
-  tps: 76.68888
+  dps: 59.98407
+  tps: 75.78242
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 11.73945
-  tps: 192.48627
+  dps: 11.54944
+  tps: 192.29626
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twist-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 11.73945
-  tps: 20.77679
+  dps: 11.54944
+  tps: 20.58678
  }
 }
 dps_results: {
@@ -1125,183 +1125,183 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3454.26482
-  tps: 4036.86602
+  dps: 3426.10854
+  tps: 4008.70974
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1260.65451
-  tps: 1290.01874
+  dps: 1255.28663
+  tps: 1284.65086
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1438.38981
-  tps: 1471.74941
+  dps: 1431.5871
+  tps: 1464.9467
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 996.62936
-  tps: 1367.92112
+  dps: 984.40481
+  tps: 1355.69657
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 436.73141
-  tps: 455.28556
+  dps: 434.47072
+  tps: 453.02486
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 598.03762
-  tps: 621.47682
+  dps: 594.25296
+  tps: 617.69216
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 25.00487
-  tps: 210.57003
+  dps: 24.65946
+  tps: 210.22462
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 25.00487
-  tps: 34.28313
+  dps: 24.65946
+  tps: 33.93772
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 85.50665
-  tps: 101.52624
+  dps: 84.32286
+  tps: 100.34245
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 12.85161
-  tps: 193.59844
+  dps: 12.65924
+  tps: 193.40607
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 12.85161
-  tps: 21.88895
+  dps: 12.65924
+  tps: 21.69658
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3.11878
-  tps: 18.30254
+  dps: 3.07159
+  tps: 18.25535
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3454.26482
-  tps: 4036.86602
+  dps: 3426.10854
+  tps: 4008.70974
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1260.65451
-  tps: 1290.01874
+  dps: 1255.28663
+  tps: 1284.65086
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1438.38981
-  tps: 1471.74941
+  dps: 1431.5871
+  tps: 1464.9467
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 996.62936
-  tps: 1367.92112
+  dps: 984.40481
+  tps: 1355.69657
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 436.73141
-  tps: 455.28556
+  dps: 434.47072
+  tps: 453.02486
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 598.03762
-  tps: 621.47682
+  dps: 594.25296
+  tps: 617.69216
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 25.00487
-  tps: 210.57003
+  dps: 24.65946
+  tps: 210.22462
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 25.00487
-  tps: 34.28313
+  dps: 24.65946
+  tps: 33.93772
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 85.50665
-  tps: 101.52624
+  dps: 84.32286
+  tps: 100.34245
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 12.85161
-  tps: 193.59844
+  dps: 12.65924
+  tps: 193.40607
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 12.85161
-  tps: 21.88895
+  dps: 12.65924
+  tps: 21.69658
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Dwarf-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3.11878
-  tps: 18.30254
+  dps: 3.07159
+  tps: 18.25535
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 545.13494
-  tps: 977.70158
+  dps: 540.80776
+  tps: 973.3744
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 346.97381
-  tps: 368.59498
+  dps: 346.2974
+  tps: 367.91857
  }
 }
 dps_results: {
@@ -1313,57 +1313,57 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 337.13246
-  tps: 672.91328
+  dps: 333.53891
+  tps: 669.31974
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 221.12097
-  tps: 237.89938
+  dps: 220.41067
+  tps: 237.18908
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 76.22686
-  tps: 94.60062
+  dps: 75.92592
+  tps: 94.29968
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 20.27715
-  tps: 205.44898
+  dps: 19.97621
+  tps: 205.14804
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 20.27715
-  tps: 29.53574
+  dps: 19.97621
+  tps: 29.2348
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 63.96393
-  tps: 79.78685
+  dps: 63.01127
+  tps: 78.83419
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 8.63366
-  tps: 189.38048
+  dps: 8.49341
+  tps: 189.24023
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 8.63366
-  tps: 17.671
+  dps: 8.49341
+  tps: 17.53075
  }
 }
 dps_results: {
@@ -1375,15 +1375,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 545.13494
-  tps: 977.70158
+  dps: 540.80776
+  tps: 973.3744
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 346.97381
-  tps: 368.59498
+  dps: 346.2974
+  tps: 367.91857
  }
 }
 dps_results: {
@@ -1395,57 +1395,57 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 337.13246
-  tps: 672.91328
+  dps: 333.53891
+  tps: 669.31974
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 221.12097
-  tps: 237.89938
+  dps: 220.41067
+  tps: 237.18908
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 76.22686
-  tps: 94.60062
+  dps: 75.92592
+  tps: 94.29968
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 20.27715
-  tps: 205.44898
+  dps: 19.97621
+  tps: 205.14804
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 20.27715
-  tps: 29.53574
+  dps: 19.97621
+  tps: 29.2348
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 63.96393
-  tps: 79.78685
+  dps: 63.01127
+  tps: 78.83419
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 8.63366
-  tps: 189.38048
+  dps: 8.49341
+  tps: 189.24023
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twist-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 8.63366
-  tps: 17.671
+  dps: 8.49341
+  tps: 17.53075
  }
 }
 dps_results: {
@@ -1457,253 +1457,253 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3507.49105
-  tps: 4093.68793
+  dps: 3478.97202
+  tps: 4065.16891
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1265.0267
-  tps: 1294.32894
+  dps: 1259.70035
+  tps: 1289.00259
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1439.28134
-  tps: 1472.71335
+  dps: 1432.45056
+  tps: 1465.88257
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 986.1775
-  tps: 1358.60051
+  dps: 974.22992
+  tps: 1346.65293
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 435.11827
-  tps: 453.77095
+  dps: 432.82598
+  tps: 451.47866
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 605.57642
-  tps: 629.06281
+  dps: 601.68403
+  tps: 625.17042
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 24.59313
-  tps: 210.05996
+  dps: 24.25373
+  tps: 209.72055
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 24.59313
-  tps: 33.86648
+  dps: 24.25373
+  tps: 33.52707
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 85.50665
-  tps: 101.52624
+  dps: 84.32286
+  tps: 100.34245
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 13.34744
-  tps: 194.09427
+  dps: 13.14757
+  tps: 193.8944
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 13.34744
-  tps: 22.38479
+  dps: 13.14757
+  tps: 22.18491
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist Stopattack-p5p6p7-twist-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3.74197
-  tps: 18.92573
+  dps: 3.68534
+  tps: 18.8691
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3507.49105
-  tps: 4093.68793
+  dps: 3478.97202
+  tps: 4065.16891
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1265.0267
-  tps: 1294.32894
+  dps: 1259.70035
+  tps: 1289.00259
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1439.28134
-  tps: 1472.71335
+  dps: 1432.45056
+  tps: 1465.88257
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 986.1775
-  tps: 1358.60051
+  dps: 974.22992
+  tps: 1346.65293
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 435.11827
-  tps: 453.77095
+  dps: 432.82598
+  tps: 451.47866
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p4-twisting-6pcT1-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 605.57642
-  tps: 629.06281
+  dps: 601.68403
+  tps: 625.17042
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 24.59313
-  tps: 210.05996
+  dps: 24.25373
+  tps: 209.72055
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 24.59313
-  tps: 33.86648
+  dps: 24.25373
+  tps: 33.52707
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 85.50665
-  tps: 101.52624
+  dps: 84.32286
+  tps: 100.34245
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 13.34744
-  tps: 194.09427
+  dps: 13.14757
+  tps: 193.8944
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 13.34744
-  tps: 22.38479
+  dps: 13.14757
+  tps: 22.18491
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-Settings-Human-p4-twisting-6pcT1-P4 Twist-p5p6p7-twist-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3.74197
-  tps: 18.92573
+  dps: 3.68534
+  tps: 18.8691
  }
 }
 dps_results: {
  key: "TestRetribution-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3138.26637
-  tps: 3186.88688
+  dps: 3132.89633
+  tps: 3182.03122
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 2548.08999
-  tps: 2573.13099
+  dps: 2538.25921
+  tps: 2563.30022
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 2548.08999
-  tps: 2573.42288
+  dps: 2538.25921
+  tps: 2563.59211
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 2712.25584
-  tps: 2738.24244
+  dps: 2702.40318
+  tps: 2728.38978
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 4625.36294
-  tps: 4659.63829
+  dps: 4604.57817
+  tps: 4638.85351
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 2090.06542
-  tps: 2113.51301
+  dps: 2083.26107
+  tps: 2106.70865
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 6279.33512
-  tps: 6326.74092
+  dps: 6253.07825
+  tps: 6300.48406
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5-twisting-P5 Twist-p5p6p7-twist-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 23.65346
-  tps: 208.92362
+  dps: 23.16369
+  tps: 208.43385
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5-twisting-P5 Twist-p5p6p7-twist-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 23.65346
-  tps: 32.91696
+  dps: 23.16369
+  tps: 32.4272
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5-twisting-P5 Twist-p5p6p7-twist-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 59.17449
-  tps: 74.84992
+  dps: 57.94503
+  tps: 73.62045
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5-twisting-P5 Twist-p5p6p7-twist-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 15.49338
-  tps: 193.33136
+  dps: 15.14618
+  tps: 192.98416
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Dwarf-p5-twisting-P5 Twist-p5p6p7-twist-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 15.49338
-  tps: 24.38528
+  dps: 15.14618
+  tps: 24.03808
  }
 }
 dps_results: {
@@ -1715,36 +1715,36 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5-twisting-P5 Twist-p5p6p7-twist-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 23.61418
-  tps: 208.88434
+  dps: 23.12551
+  tps: 208.39567
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5-twisting-P5 Twist-p5p6p7-twist-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 23.61418
-  tps: 32.87769
+  dps: 23.12551
+  tps: 32.38902
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5-twisting-P5 Twist-p5p6p7-twist-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 59.17449
-  tps: 74.84992
+  dps: 57.94503
+  tps: 73.62045
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5-twisting-P5 Twist-p5p6p7-twist-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 14.18825
-  tps: 194.93508
+  dps: 13.87018
+  tps: 194.617
  }
 }
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-Settings-Human-p5-twisting-P5 Twist-p5p6p7-twist-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 14.18825
-  tps: 23.22559
+  dps: 13.87018
+  tps: 22.90752
  }
 }
 dps_results: {
@@ -1756,147 +1756,147 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5350.73054
-  tps: 5397.76255
+  dps: 5325.60497
+  tps: 5372.63698
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 2603.68468
-  tps: 2626.98836
-  dtps: 2.01958
+  dps: 2594.32802
+  tps: 2617.63171
+  dtps: 1.95566
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 2603.68468
-  tps: 2627.31284
-  dtps: 2.01958
+  dps: 2594.70661
+  tps: 2618.33477
+  dtps: 1.98833
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 2755.67496
-  tps: 2779.87724
-  dtps: 2.01958
+  dps: 2746.2705
+  tps: 2770.47278
+  dtps: 1.95566
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 3631.38181
-  tps: 3657.23756
+  dps: 3616.93673
+  tps: 3642.79248
   dtps: 2.06392
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 2394.67923
-  tps: 2416.70602
-  dtps: 1.91635
+  dps: 2386.00835
+  tps: 2408.03514
+  dtps: 1.85242
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Average-Default"
  value: {
-  dps: 7102.01458
-  tps: 7150.45363
-  dtps: 2.26426
+  dps: 7070.44237
+  tps: 7118.88142
+  dtps: 2.25499
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Dwarf-p6-twisting-P6 Twist-p5p6p7-twist-FullBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 29.9
-  tps: 367.29695
+  dps: 29.06229
+  tps: 366.45923
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Dwarf-p6-twisting-P6 Twist-p5p6p7-twist-FullBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 29.9
-  tps: 46.76985
+  dps: 29.06229
+  tps: 45.93214
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Dwarf-p6-twisting-P6 Twist-p5p6p7-twist-FullBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 102.30228
-  tps: 131.50648
+  dps: 99.42839
+  tps: 128.63259
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Dwarf-p6-twisting-P6 Twist-p5p6p7-twist-NoBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 11.90926
-  tps: 326.59316
+  dps: 11.54631
+  tps: 326.23021
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Dwarf-p6-twisting-P6 Twist-p5p6p7-twist-NoBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 11.90926
-  tps: 27.64345
+  dps: 11.54631
+  tps: 27.2805
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Dwarf-p6-twisting-P6 Twist-p5p6p7-twist-NoBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 32.39003
-  tps: 59.76175
+  dps: 31.39749
+  tps: 58.76921
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Human-p6-twisting-P6 Twist-p5p6p7-twist-FullBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 30.40996
-  tps: 367.8069
+  dps: 29.55784
+  tps: 366.95479
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Human-p6-twisting-P6 Twist-p5p6p7-twist-FullBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 30.40996
-  tps: 47.27981
+  dps: 29.55784
+  tps: 46.42769
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Human-p6-twisting-P6 Twist-p5p6p7-twist-FullBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 102.30228
-  tps: 131.50648
+  dps: 99.42839
+  tps: 128.63259
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Human-p6-twisting-P6 Twist-p5p6p7-twist-NoBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 13.72308
-  tps: 340.05018
+  dps: 13.30487
+  tps: 339.63198
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Human-p6-twisting-P6 Twist-p5p6p7-twist-NoBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 13.72308
-  tps: 30.03944
+  dps: 13.30487
+  tps: 29.62123
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-Settings-Human-p6-twisting-P6 Twist-p5p6p7-twist-NoBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 36.79388
-  tps: 64.92617
+  dps: 35.6642
+  tps: 63.79649
  }
 }
 dps_results: {
  key: "TestRetribution-Phase6-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6548.40516
-  tps: 6596.31628
+  dps: 6517.42952
+  tps: 6565.34064
   dtps: 2.05858
  }
 }

--- a/sim/paladin/retribution/TestSealStacking.results
+++ b/sim/paladin/retribution/TestSealStacking.results
@@ -6,7 +6,7 @@ character_stats_results: {
   final_stats: 596.4475
   final_stats: 172.04
   final_stats: 199.2375
-  final_stats: 216
+  final_stats: 180
   final_stats: 0
   final_stats: 10
   final_stats: 0
@@ -15,7 +15,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 49.6
   final_stats: 4
-  final_stats: 40.37307
+  final_stats: 39.37307
   final_stats: 0
   final_stats: 0
   final_stats: 2695.782
@@ -50,12 +50,12 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestSealStacking-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 3.12288
-  weights: 2.65026
+  weights: 3.11208
+  weights: 2.20037
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.52673
+  weights: 0.52299
   weights: 0
   weights: 0
   weights: 0
@@ -63,13 +63,13 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 8.49367
-  weights: 0.94172
+  weights: 9.65927
+  weights: 0.85506
   weights: 0
   weights: 0
-  weights: 1.12213
+  weights: 1.11825
   weights: 0
-  weights: 35.20872
+  weights: 37.26971
   weights: 0
   weights: 0
   weights: 0
@@ -99,133 +99,133 @@ stat_weights_results: {
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-AllItems-EmeraldEncrustedBattleplate"
  value: {
-  dps: 1730.5273
-  tps: 1769.44432
+  dps: 1722.18228
+  tps: 1761.0993
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-AllItems-Knight-Lieutenant'sImbuedPlate"
  value: {
-  dps: 1744.39943
-  tps: 1784.05372
+  dps: 1736.00386
+  tps: 1775.65815
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-AllItems-Knight-Lieutenant'sLamellarPlate"
  value: {
-  dps: 1818.60656
-  tps: 1858.36235
+  dps: 1810.67474
+  tps: 1850.43052
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-AllItems-ObsessedProphet'sPlate"
  value: {
-  dps: 2954.37557
-  tps: 3008.81224
+  dps: 2941.00463
+  tps: 2995.4413
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-AllItems-SoulforgeArmor"
  value: {
-  dps: 1559.68508
-  tps: 1598.02393
+  dps: 1552.83735
+  tps: 1591.1762
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4772.06838
-  tps: 4819.65134
+  dps: 4749.28092
+  tps: 4797.90102
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Dwarf-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 4979.58378
-  tps: 5648.28194
+  dps: 4912.28705
+  tps: 5580.98521
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Dwarf-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1739.66458
-  tps: 1773.13073
+  dps: 1726.94144
+  tps: 1760.40759
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Dwarf-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1837.53949
-  tps: 1877.82252
+  dps: 1823.83517
+  tps: 1864.1182
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Dwarf-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 1245.34484
-  tps: 1619.03875
+  dps: 1219.71082
+  tps: 1593.40473
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Dwarf-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 526.77242
-  tps: 545.47651
+  dps: 521.31379
+  tps: 540.01787
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Dwarf-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 790.67853
-  tps: 815.55812
+  dps: 781.92873
+  tps: 806.80832
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Human-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 5034.25872
-  tps: 5705.36505
+  dps: 4967.31024
+  tps: 5638.41656
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Human-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 1755.53536
-  tps: 1789.10316
+  dps: 1742.71086
+  tps: 1776.27866
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Human-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 1850.06091
-  tps: 1890.44759
+  dps: 1836.16355
+  tps: 1876.55023
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Human-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-NoBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 1287.02616
-  tps: 1661.96382
+  dps: 1260.77787
+  tps: 1635.71553
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Human-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-NoBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 536.61869
-  tps: 555.34606
+  dps: 530.806
+  tps: 549.53336
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-Settings-Human-p5-seal-stacking-P5 Seal Stacking-p5-seal-stacking-6CF-2DR-NoBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 791.98425
-  tps: 816.87755
+  dps: 783.3041
+  tps: 808.1974
  }
 }
 dps_results: {
  key: "TestSealStacking-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3865.28576
-  tps: 3914.71013
+  dps: 3818.36237
+  tps: 3868.46291
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -55,7 +55,7 @@ character_stats_results: {
   final_stats: 244.2
   final_stats: 204.6
   final_stats: 133.1
-  final_stats: 249
+  final_stats: 233
   final_stats: 0
   final_stats: 10
   final_stats: 0
@@ -347,7 +347,7 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.18725
+  weights: 1.16036
   weights: 0
   weights: 0.85597
   weights: 0
@@ -357,8 +357,8 @@ stat_weights_results: {
   weights: 0.59081
   weights: 0
   weights: 0
-  weights: 7.83941
-  weights: 3.33782
+  weights: 7.66939
+  weights: 3.2505
   weights: 0
   weights: 0
   weights: 0
@@ -687,99 +687,99 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 610.52814
-  tps: 507.54154
+  dps: 596.8784
+  tps: 497.07063
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 691.17965
-  tps: 1124.45856
+  dps: 675.49938
+  tps: 1112.48687
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 575.94795
-  tps: 477.84398
+  dps: 562.8556
+  tps: 467.76657
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 620.59897
-  tps: 520.72303
+  dps: 606.42653
+  tps: 509.545
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 375.41478
-  tps: 734.57762
+  dps: 366.35122
+  tps: 727.76184
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 322.04138
-  tps: 269.82936
+  dps: 314.27602
+  tps: 263.95909
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Orc-phase_2-Adaptive-phase_2-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 431.90689
-  tps: 366.562
+  dps: 421.52456
+  tps: 358.38493
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 708.85127
-  tps: 1148.38284
+  dps: 692.71271
+  tps: 1136.05147
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 578.32679
-  tps: 480.80038
+  dps: 565.12554
+  tps: 470.63351
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 647.83791
-  tps: 554.40316
+  dps: 633.04939
+  tps: 542.52707
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 380.76122
-  tps: 746.87708
+  dps: 371.56154
+  tps: 739.93947
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 320.98293
-  tps: 270.13266
+  dps: 313.21441
+  tps: 264.23652
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-Settings-Troll-phase_2-Adaptive-phase_2-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 452.41316
-  tps: 389.58561
+  dps: 441.52557
+  tps: 380.89925
  }
 }
 dps_results: {
  key: "TestElemental-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 606.53313
-  tps: 508.03979
+  dps: 592.96275
+  tps: 497.55617
  }
 }
 dps_results: {

--- a/sim/warrior/dps_warrior/TestTwoHandedWarrior.results
+++ b/sim/warrior/dps_warrior/TestTwoHandedWarrior.results
@@ -69,7 +69,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2793.78
   final_stats: 5
-  final_stats: 53.071
+  final_stats: 51.071
   final_stats: 0
   final_stats: 0
   final_stats: 0
@@ -118,7 +118,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 2860.79
   final_stats: 6
-  final_stats: 57.24875
+  final_stats: 55.24875
   final_stats: 2
   final_stats: 0
   final_stats: 5
@@ -148,8 +148,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-StatWeights-Default"
  value: {
-  weights: 1.1267
-  weights: 0.82184
+  weights: 1.12677
+  weights: 0.82161
   weights: 0
   weights: 0
   weights: 0
@@ -165,9 +165,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.48743
-  weights: 15.47283
-  weights: 11.09794
+  weights: 0.48756
+  weights: 15.4724
+  weights: 11.09655
   weights: 0
   weights: 0
   weights: 0
@@ -197,8 +197,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 3.20864
-  weights: 2.6689
+  weights: 3.46648
+  weights: 1.19662
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +214,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.00157
+  weights: 1.01569
   weights: 0
-  weights: 27.15425
+  weights: 23.34931
   weights: 0
   weights: 0
   weights: 0
@@ -246,8 +246,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-StatWeights-Default"
  value: {
-  weights: 2.50694
-  weights: 2.63588
+  weights: 2.60117
+  weights: 2.39623
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.21737
+  weights: 0.59859
   weights: 0
-  weights: 40.74009
+  weights: 42.13555
   weights: 0
   weights: 0
   weights: 0
@@ -295,379 +295,379 @@ stat_weights_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-AllItems-BattlegearofHeroism"
  value: {
-  dps: 808.93741
-  tps: 696.29102
+  dps: 808.85416
+  tps: 696.22442
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1179.73535
-  tps: 1007.32871
+  dps: 1179.65355
+  tps: 1007.26328
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 317.197
-  tps: 427.68028
+  dps: 316.93504
+  tps: 427.47071
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 87.14375
-  tps: 80.19988
+  dps: 87.12956
+  tps: 80.18852
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 159.72349
-  tps: 142.90374
+  dps: 159.68893
+  tps: 142.87609
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 147.18635
-  tps: 269.03107
+  dps: 147.01634
+  tps: 268.89507
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 41.11445
-  tps: 42.07683
+  dps: 41.10585
+  tps: 42.06996
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Human-phase_3_2h-Arms-phase_3_arms-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 80.73417
-  tps: 77.56827
+  dps: 80.70606
+  tps: 77.54578
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 357.92327
-  tps: 466.07829
+  dps: 357.63585
+  tps: 465.84835
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 94.83365
-  tps: 86.65447
+  dps: 94.81873
+  tps: 86.64253
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 170.0386
-  tps: 151.32621
+  dps: 170.00403
+  tps: 151.29856
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 165.77014
-  tps: 286.483
+  dps: 165.59484
+  tps: 286.34276
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 44.30859
-  tps: 44.77845
+  dps: 44.29999
+  tps: 44.77157
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-Settings-Orc-phase_3_2h-Arms-phase_3_arms-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 85.87681
-  tps: 81.68032
+  dps: 85.84869
+  tps: 81.65783
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1096.62723
-  tps: 941.2903
+  dps: 1096.55209
+  tps: 941.23019
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
-  dps: 2720.42797
-  tps: 2258.84387
+  dps: 2654.00327
+  tps: 2204.28529
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 1656.93555
-  tps: 1403.01423
+  dps: 1620.80039
+  tps: 1373.24192
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
-  dps: 1993.81836
-  tps: 1677.33027
+  dps: 1940.78962
+  tps: 1632.6628
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
-  dps: 1956.09328
-  tps: 1645.44747
+  dps: 1910.89046
+  tps: 1606.72066
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
-  dps: 1993.81836
-  tps: 1677.33027
+  dps: 1940.78962
+  tps: 1632.6628
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
-  dps: 2927.42797
-  tps: 2428.88546
+  dps: 2872.05462
+  tps: 2383.12965
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4486.69802
-  tps: 3400.38726
+  dps: 4438.56314
+  tps: 3363.40268
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t1-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 988.35034
-  tps: 746.17588
+  dps: 984.13694
+  tps: 743.06746
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t1-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 970.02693
-  tps: 638.57917
+  dps: 965.81353
+  tps: 635.47075
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t1-Arms-phase_5_2h-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1281.55243
-  tps: 855.3845
+  dps: 1278.69611
+  tps: 853.38507
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t1-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 455.70525
-  tps: 398.91275
+  dps: 448.67654
+  tps: 394.11999
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t1-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 444.54525
-  tps: 296.65326
+  dps: 437.68154
+  tps: 291.976
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t1-Arms-phase_5_2h-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 589.24172
-  tps: 397.86936
+  dps: 583.58328
+  tps: 394.14978
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t2-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 712.97846
-  tps: 582.79272
+  dps: 706.1213
+  tps: 578.7235
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t2-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 701.25903
-  tps: 480.40207
+  dps: 694.40187
+  tps: 476.24924
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t2-Arms-phase_5_2h-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1086.28185
-  tps: 774.79894
+  dps: 1076.08717
+  tps: 767.10428
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t2-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 309.57948
-  tps: 308.82086
+  dps: 308.72837
+  tps: 308.48368
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t2-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 301.84948
-  tps: 209.31881
+  dps: 300.64587
+  tps: 208.71738
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Human-phase_5_2h_t2-Arms-phase_5_2h-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 477.9104
-  tps: 342.82269
+  dps: 475.37069
+  tps: 341.10996
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t1-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1017.99028
-  tps: 768.64415
+  dps: 1013.49858
+  tps: 765.21328
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t1-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1000.432
-  tps: 661.58242
+  dps: 995.9403
+  tps: 658.15155
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t1-Arms-phase_5_2h-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1378.69477
-  tps: 924.43354
+  dps: 1373.79714
+  tps: 920.93898
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t1-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 470.53642
-  tps: 409.44715
+  dps: 466.24142
+  tps: 406.56803
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t1-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 459.69142
-  tps: 307.38742
+  dps: 455.39642
+  tps: 304.5083
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t1-Arms-phase_5_2h-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 632.914
-  tps: 428.51322
+  dps: 628.00763
+  tps: 425.41736
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t2-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 738.50902
-  tps: 602.762
+  dps: 721.90108
+  tps: 591.22317
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t2-Arms-phase_5_2h-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 727.01039
-  tps: 500.45565
+  dps: 710.68869
+  tps: 489.09127
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t2-Arms-phase_5_2h-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1174.61054
-  tps: 841.48453
+  dps: 1165.53766
+  tps: 834.26623
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t2-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 310.70715
-  tps: 310.94434
+  dps: 307.2907
+  tps: 308.81025
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t2-Arms-phase_5_2h-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 303.13215
-  tps: 211.63377
+  dps: 299.5332
+  tps: 209.3281
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-Settings-Orc-phase_5_2h_t2-Arms-phase_5_2h-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 505.7426
-  tps: 366.03056
+  dps: 503.91915
+  tps: 364.71692
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3687.79396
-  tps: 2775.66168
+  dps: 3652.28249
+  tps: 2748.34794
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-AllItems-BanishedMartyr'sFullPlate"
  value: {
-  dps: 3329.74744
-  tps: 2628.5065
+  dps: 3277.98989
+  tps: 2587.38454
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-AllItems-BattlegearofHeroism"
  value: {
-  dps: 1609.68108
-  tps: 1336.96516
+  dps: 1575.75344
+  tps: 1309.6997
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-AllItems-BloodGuard'sPlate"
  value: {
-  dps: 2020.14121
-  tps: 1670.38272
+  dps: 1968.03528
+  tps: 1628.14821
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-AllItems-EmeraldDreamPlate"
  value: {
-  dps: 1999.15987
-  tps: 1653.82917
+  dps: 1947.2581
+  tps: 1611.71291
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-AllItems-Knight-Lieutenant'sPlate"
  value: {
-  dps: 2020.14121
-  tps: 1670.38272
+  dps: 1968.03528
+  tps: 1628.14821
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-AllItems-WailingBerserker'sPlateArmor"
  value: {
-  dps: 3562.89893
-  tps: 2814.21198
+  dps: 3498.45586
+  tps: 2763.15662
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-Average-Default"
  value: {
-  dps: 5876.962
-  tps: 4641.95555
+  dps: 5794.98349
+  tps: 4576.21514
  }
 }
 dps_results: {
@@ -694,22 +694,22 @@ dps_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-Settings-Human-phase_6_2h-Arms-phase_6_2h-NoBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 176.74228
-  tps: 218.9675
+  dps: 173.99625
+  tps: 216.92845
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-Settings-Human-phase_6_2h-Arms-phase_6_2h-NoBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 173.00724
-  tps: 126.87885
+  dps: 170.26121
+  tps: 124.8398
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-Settings-Human-phase_6_2h-Arms-phase_6_2h-NoBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 295.32671
-  tps: 219.25592
+  dps: 289.5494
+  tps: 214.7626
  }
 }
 dps_results: {
@@ -736,28 +736,28 @@ dps_results: {
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-Settings-Orc-phase_6_2h-Arms-phase_6_2h-NoBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 189.70443
-  tps: 228.69274
+  dps: 187.01682
+  tps: 226.67956
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-Settings-Orc-phase_6_2h-Arms-phase_6_2h-NoBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 185.69451
-  tps: 136.3842
+  dps: 183.0069
+  tps: 134.37101
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-Settings-Orc-phase_6_2h-Arms-phase_6_2h-NoBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 258.31943
-  tps: 197.9068
+  dps: 253.76091
+  tps: 194.33358
  }
 }
 dps_results: {
  key: "TestTwoHandedWarrior-Phase6-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5229.29769
-  tps: 4116.74232
+  dps: 5179.91605
+  tps: 4076.60454
  }
 }


### PR DESCRIPTION
Off-hand imbues were always applying if selected in a saved setting, even if that saved setting was applied while wielding a two-handed weapon.
the `equipment.OffHand()` func always returns an item, albeit an empty one with ID 0. The check in the `applyWeaponImbueConsumes()` func was checking if this was null, which never happened.