### PR TITLE
Rogue talent fixes

### DIFF
--- a/sim/rogue/_shiv.go
+++ b/sim/rogue/_shiv.go
@@ -21,14 +21,15 @@ func (rogue *Rogue) registerShivSpell() {
 
 	// Shiv /might/ scale with BonusWeaponDamage, if it's using https://www.wowhead.com/classic/spell=424800/shiv
 	rogue.Shiv = rogue.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: int32(proto.RogueRune_RuneShiv)},
-		SpellSchool: core.SpellSchoolPhysical,
-		DefenseType: core.DefenseTypeMelee,
-		ProcMask:    core.ProcMaskMeleeOHSpecial,
-		Flags:       rogue.builderFlags(),
+		ActionID:       core.ActionID{SpellID: int32(proto.RogueRune_RuneShiv)},
+		ClassSpellMask: ClassSpellMask_RogueShiv,
+		SpellSchool:    core.SpellSchoolPhysical,
+		DefenseType:    core.DefenseTypeMelee,
+		ProcMask:       core.ProcMaskMeleeOHSpecial,
+		Flags:          rogue.builderFlags(),
 
 		EnergyCost: core.EnergyCostOptions{
-			Cost:   baseCost - []float64{0, 3, 5}[rogue.Talents.ImprovedSinisterStrike],
+			Cost:   baseCost,
 			Refund: 0.8,
 		},
 		Cast: core.CastConfig{
@@ -40,7 +41,7 @@ func (rogue *Rogue) registerShivSpell() {
 
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier: []float64{1, 1.02, 1.04, 1.06}[rogue.Talents.Aggression] * rogue.dwsMultiplier(),
+		DamageMultiplier: 1 * rogue.dwsMultiplier(),
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/rogue/ambush.go
+++ b/sim/rogue/ambush.go
@@ -25,8 +25,6 @@ func (rogue *Rogue) registerAmbushSpell() {
 	// waylay := rogue.HasRune(proto.RogueRune_RuneWaylay)
 	hasCutthroatRune := rogue.HasRune(proto.RogueRune_RuneCutthroat)
 
-	damageMultiplier := 2.5 * []float64{1, 1.04, 1.08, 1.12, 1.16, 1.2}[rogue.Talents.Opportunity]
-
 	rogue.Ambush = rogue.RegisterSpell(core.SpellConfig{
 		ClassSpellMask: ClassSpellMask_RogueAmbush,
 		ActionID:       core.ActionID{SpellID: spellID},
@@ -56,7 +54,7 @@ func (rogue *Rogue) registerAmbushSpell() {
 		},
 
 		BonusCritRating:  15 * core.CritRatingPerCritChance * float64(rogue.Talents.ImprovedAmbush),
-		DamageMultiplier: damageMultiplier,
+		DamageMultiplier: 2.5,
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
 

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -25,8 +25,6 @@ func (rogue *Rogue) registerBackstabSpell() {
 	// waylay := rogue.HasRune(proto.RogueRune_RuneWaylay)
 	hasCutthroatRune := rogue.HasRune(proto.RogueRune_RuneCutthroat)
 
-	damageMultiplier := 1.5 * []float64{1, 1.04, 1.08, 1.12, 1.16, 1.2}[rogue.Talents.Opportunity]
-
 	rogue.Backstab = rogue.RegisterSpell(core.SpellConfig{
 		ClassSpellMask: ClassSpellMask_RogueBackstab,
 		ActionID:       core.ActionID{SpellID: spellID},
@@ -52,11 +50,9 @@ func (rogue *Rogue) registerBackstabSpell() {
 			return hasCutthroatRune || !rogue.PseudoStats.InFrontOfTarget
 		},
 
-		BonusCritRating: 10 * core.CritRatingPerCritChance * float64(rogue.Talents.ImprovedBackstab),
-
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier: damageMultiplier,
+		DamageMultiplier: 1.5,
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
 

--- a/sim/rogue/crimson_tempest.go
+++ b/sim/rogue/crimson_tempest.go
@@ -19,7 +19,7 @@ func (rogue *Rogue) makeCrimsonTempestHitSpell() *core.Spell {
 		ProcMask:    procMask,
 		Flags:       core.SpellFlagMeleeMetrics | SpellFlagCarnage,
 
-		DamageMultiplier: []float64{1, 1.1, 1.2, 1.3}[rogue.Talents.SerratedBlades],
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/rogue/dps_rogue/TestAssassination.results
+++ b/sim/rogue/dps_rogue/TestAssassination.results
@@ -246,8 +246,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestAssassination-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 0.34691
-  weights: 0.55775
+  weights: 0.34654
+  weights: 0.55738
   weights: 0
   weights: 0
   weights: 0
@@ -263,9 +263,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.27424
-  weights: 13.16868
-  weights: 2.57765
+  weights: 0.27395
+  weights: 13.16879
+  weights: 2.57083
   weights: 0
   weights: 0
   weights: 0
@@ -519,98 +519,98 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 911.93624
-  tps: 647.47473
+  dps: 910.72581
+  tps: 646.61532
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Human-p5_backstab-No Poisons-P5_Assassination_Backstab-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 192.30395
-  tps: 136.53581
+  dps: 191.0047
+  tps: 135.61333
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Human-p5_backstab-No Poisons-P5_Assassination_Backstab-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 175.94258
-  tps: 124.91923
+  dps: 174.64333
+  tps: 123.99676
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Human-p5_backstab-No Poisons-P5_Assassination_Backstab-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 373.67409
-  tps: 265.30861
+  dps: 367.17781
+  tps: 260.69625
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Human-p5_backstab-No Poisons-P5_Assassination_Backstab-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 87.13977
-  tps: 61.86924
+  dps: 86.58309
+  tps: 61.47399
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Human-p5_backstab-No Poisons-P5_Assassination_Backstab-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 77.85727
-  tps: 55.27866
+  dps: 77.30059
+  tps: 54.88342
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Human-p5_backstab-No Poisons-P5_Assassination_Backstab-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 165.84464
-  tps: 117.7497
+  dps: 163.06121
+  tps: 115.77346
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Orc-p5_backstab-No Poisons-P5_Assassination_Backstab-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 197.34631
-  tps: 140.11588
+  dps: 195.94945
+  tps: 139.12411
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Orc-p5_backstab-No Poisons-P5_Assassination_Backstab-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 180.98494
-  tps: 128.4993
+  dps: 179.58808
+  tps: 127.50754
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Orc-p5_backstab-No Poisons-P5_Assassination_Backstab-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 394.31
-  tps: 279.9601
+  dps: 387.32572
+  tps: 275.00126
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Orc-p5_backstab-No Poisons-P5_Assassination_Backstab-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 89.10867
-  tps: 63.26716
+  dps: 88.514
+  tps: 62.84494
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Orc-p5_backstab-No Poisons-P5_Assassination_Backstab-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 79.82617
-  tps: 56.67658
+  dps: 79.2315
+  tps: 56.25436
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-Settings-Orc-p5_backstab-No Poisons-P5_Assassination_Backstab-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 173.7295
-  tps: 123.34795
+  dps: 170.75614
+  tps: 121.23686
  }
 }
 dps_results: {
  key: "TestAssassination-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 714.46481
-  tps: 507.27001
+  dps: 713.16622
+  tps: 506.34802
  }
 }

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -197,8 +197,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestCombat-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.37601
-  weights: 0.60813
+  weights: 0.36208
+  weights: 0.58239
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +214,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.34183
-  weights: 4.04906
-  weights: 3.74848
+  weights: 0.32916
+  weights: 4.04689
+  weights: 3.84447
   weights: 0
   weights: 0
   weights: 0
@@ -407,99 +407,99 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 543.26531
-  tps: 385.71837
+  dps: 518.67143
+  tps: 368.25671
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 211.62717
-  tps: 150.25529
+  dps: 183.38645
+  tps: 130.20438
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 183.84937
-  tps: 130.53305
+  dps: 159.95187
+  tps: 113.56583
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 242.39578
-  tps: 172.10101
+  dps: 214.75339
+  tps: 152.4749
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 116.87244
-  tps: 82.97943
+  dps: 100.40319
+  tps: 71.28626
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 101.85627
-  tps: 72.31795
+  dps: 88.09567
+  tps: 62.54793
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 134.80195
-  tps: 95.70938
+  dps: 117.53174
+  tps: 83.44754
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 211.25637
-  tps: 149.99203
+  dps: 183.47789
+  tps: 130.2693
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 182.05478
-  tps: 129.25889
+  dps: 158.82555
+  tps: 112.76614
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 238.35292
-  tps: 169.23057
+  dps: 209.77806
+  tps: 148.94242
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 120.3131
-  tps: 85.4223
+  dps: 103.64373
+  tps: 73.58705
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 103.97833
-  tps: 73.82461
+  dps: 90.26451
+  tps: 64.0878
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 135.80227
-  tps: 96.41961
+  dps: 118.23808
+  tps: 83.94904
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 518.35971
-  tps: 368.0354
+  dps: 494.42214
+  tps: 351.03972
  }
 }
 dps_results: {

--- a/sim/rogue/dps_rogue/TestCombat.results
+++ b/sim/rogue/dps_rogue/TestCombat.results
@@ -197,8 +197,8 @@ stat_weights_results: {
 stat_weights_results: {
  key: "TestCombat-Phase2-Lvl40-StatWeights-Default"
  value: {
-  weights: 0.36208
-  weights: 0.58239
+  weights: 0.37601
+  weights: 0.60813
   weights: 0
   weights: 0
   weights: 0
@@ -214,9 +214,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.32916
-  weights: 4.04689
-  weights: 3.84447
+  weights: 0.34183
+  weights: 4.04906
+  weights: 3.74848
   weights: 0
   weights: 0
   weights: 0
@@ -407,99 +407,99 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 518.67143
-  tps: 368.25671
+  dps: 543.26531
+  tps: 385.71837
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 183.38645
-  tps: 130.20438
+  dps: 211.62717
+  tps: 150.25529
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 159.95187
-  tps: 113.56583
+  dps: 183.84937
+  tps: 130.53305
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 214.75339
-  tps: 152.4749
+  dps: 242.39578
+  tps: 172.10101
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 100.40319
-  tps: 71.28626
+  dps: 116.87244
+  tps: 82.97943
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 88.09567
-  tps: 62.54793
+  dps: 101.85627
+  tps: 72.31795
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Human-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 117.53174
-  tps: 83.44754
+  dps: 134.80195
+  tps: 95.70938
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 183.47789
-  tps: 130.2693
+  dps: 211.25637
+  tps: 149.99203
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 158.82555
-  tps: 112.76614
+  dps: 182.05478
+  tps: 129.25889
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 209.77806
-  tps: 148.94242
+  dps: 238.35292
+  tps: 169.23057
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 103.64373
-  tps: 73.58705
+  dps: 120.3131
+  tps: 85.4223
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 90.26451
-  tps: 64.0878
+  dps: 103.97833
+  tps: 73.82461
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-Settings-Orc-p2_daggers-No Poisons-mutilate-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 118.23808
-  tps: 83.94904
+  dps: 135.80227
+  tps: 96.41961
  }
 }
 dps_results: {
  key: "TestCombat-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 494.42214
-  tps: 351.03972
+  dps: 518.35971
+  tps: 368.0354
  }
 }
 dps_results: {

--- a/sim/rogue/envenom.go
+++ b/sim/rogue/envenom.go
@@ -57,9 +57,8 @@ func (rogue *Rogue) registerEnvenom() {
 			return false
 		},
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
-		BonusCoefficient: 0,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.BreakStealth(sim)

--- a/sim/rogue/eviscerate.go
+++ b/sim/rogue/eviscerate.go
@@ -64,9 +64,9 @@ func (rogue *Rogue) registerEviscerate() {
 			return rogue.ComboPoints() > 0
 		},
 
-		DamageMultiplierAdditivePct: []int64{0, 5, 10, 15}[rogue.Talents.ImprovedEviscerate] + []int64{0, 2, 4, 6}[rogue.Talents.Aggression],
-		ThreatMultiplier:            1,
-		BonusCoefficient:            1,
+		DamageMultiplier: 1,
+		ThreatMultiplier: 1,
+		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.BreakStealth(sim)

--- a/sim/rogue/garrote.go
+++ b/sim/rogue/garrote.go
@@ -49,8 +49,7 @@ func (rogue *Rogue) registerGarrote() {
 			return hasCutthroatRune || !rogue.PseudoStats.InFrontOfTarget
 		},
 
-		DamageMultiplier: 1 +
-			0.04*float64(rogue.Talents.Opportunity),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/rogue/main_gauche.go
+++ b/sim/rogue/main_gauche.go
@@ -83,7 +83,7 @@ func (rogue *Rogue) registerMainGaucheSpell() {
 		Flags:          rogue.builderFlags(),
 
 		EnergyCost: core.EnergyCostOptions{
-			Cost:   []float64{15, 12, 10}[rogue.Talents.ImprovedSinisterStrike],
+			Cost:   15,
 			Refund: 0.8,
 		},
 
@@ -100,7 +100,7 @@ func (rogue *Rogue) registerMainGaucheSpell() {
 
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier: []float64{1, 1.02, 1.04, 1.06}[rogue.Talents.Aggression],
+		DamageMultiplier: 1,
 		ThreatMultiplier: 3,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/rogue/mutilate.go
+++ b/sim/rogue/mutilate.go
@@ -29,13 +29,9 @@ func (rogue *Rogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		ProcMask:       procMask,
 		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell | SpellFlagBuilder | SpellFlagColdBlooded | SpellFlagCarnage,
 
-		BonusCritRating: 10 * core.CritRatingPerCritChance * float64(rogue.Talents.ImprovedBackstab),
-
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier: 1 *
-			core.TernaryFloat64(isMH, 1, rogue.dwsMultiplier()) *
-			[]float64{1, 1.04, 1.08, 1.12, 1.16, 1.2}[rogue.Talents.Opportunity],
+		DamageMultiplier: 1 * core.TernaryFloat64(isMH, 1, rogue.dwsMultiplier()),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
 

--- a/sim/rogue/poisoned_knife.go
+++ b/sim/rogue/poisoned_knife.go
@@ -26,7 +26,7 @@ func (rogue *Rogue) registerPoisonedKnife() {
 		Flags:          rogue.builderFlags(),
 
 		EnergyCost: core.EnergyCostOptions{
-			Cost:   []float64{25, 22, 20}[rogue.Talents.ImprovedSinisterStrike],
+			Cost:   25,
 			Refund: 0.8,
 		},
 		Cast: core.CastConfig{
@@ -46,7 +46,7 @@ func (rogue *Rogue) registerPoisonedKnife() {
 
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier: []float64{1, 1.02, 1.04, 1.06}[rogue.Talents.Aggression] * rogue.dwsMultiplier(),
+		DamageMultiplier: 1 * rogue.dwsMultiplier(),
 		ThreatMultiplier: core.TernaryFloat64(hasJustAFleshWound, 1.5, 1),
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -51,24 +51,20 @@ const (
 )
 
 func (rogue *Rogue) GetInstantPoisonProcChance() float64 {
-	return (0.2+rogue.improvedPoisons())*(1+rogue.instantPoisonProcChanceBonus) + rogue.additivePoisonBonusChance
+	return (0.2+rogue.improvedPoisonsBonusProcChance())*(1+rogue.instantPoisonProcChanceBonus) + rogue.additivePoisonBonusChance
 }
 
 // Used for all 30% proc poisons (Sebacious and others)
 func (rogue *Rogue) GetDeadlyPoisonProcChance() float64 {
-	return 0.3 + rogue.improvedPoisons() + rogue.additivePoisonBonusChance
+	return 0.3 + rogue.improvedPoisonsBonusProcChance() + rogue.additivePoisonBonusChance
 }
 
 func (rogue *Rogue) GetWoundPoisonProcChance() float64 {
-	return 0.3 + rogue.improvedPoisons() + rogue.additivePoisonBonusChance
+	return 0.3 + rogue.improvedPoisonsBonusProcChance() + rogue.additivePoisonBonusChance
 }
 
-func (rogue *Rogue) improvedPoisons() float64 {
-	return []float64{0, 0.02, 0.04, 0.06, 0.08, 0.1}[rogue.Talents.ImprovedPoisons]
-}
-
-func (rogue *Rogue) getPoisonDamageMultiplier() float64 {
-	return []float64{1, 1.04, 1.08, 1.12, 1.16, 1.2}[rogue.Talents.VilePoisons]
+func (rogue *Rogue) improvedPoisonsBonusProcChance() float64 {
+	return 0.02 * float64(rogue.Talents.ImprovedPoisons)
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -365,7 +361,7 @@ func (rogue *Rogue) registerDeadlyPoisonSpell() {
 		ProcMask:       core.ProcMaskSpellDamageProc,
 		Flags:          core.SpellFlagPoison | core.SpellFlagPassiveSpell | SpellFlagRoguePoison | SpellFlagCarnage,
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{
@@ -448,7 +444,7 @@ func (rogue *Rogue) registerOccultPoisonSpell() {
 		ProcMask:       core.ProcMaskSpellDamageProc,
 		Flags:          SpellFlagCarnage | core.SpellFlagPoison | SpellFlagRoguePoison,
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{
@@ -575,7 +571,7 @@ func (rogue *Rogue) makeInstantPoison(procSource PoisonProcSource) *core.Spell {
 		ProcMask:       core.ProcMaskSpellDamageProc,
 		Flags:          core.SpellFlagPoison | core.SpellFlagPassiveSpell | SpellFlagDeadlyBrewed | SpellFlagCarnage | SpellFlagRoguePoison,
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
@@ -661,7 +657,7 @@ func (rogue *Rogue) makeWoundPoison(procSource PoisonProcSource) *core.Spell {
 		ProcMask:    core.ProcMaskSpellDamageProc,
 		Flags:       core.SpellFlagPoison | core.SpellFlagPassiveSpell | SpellFlagDeadlyBrewed | SpellFlagRoguePoison,
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
@@ -691,7 +687,6 @@ func (rogue *Rogue) makeWoundPoison(procSource PoisonProcSource) *core.Spell {
 }
 
 func (rogue *Rogue) makeSebaciousPoison(procSource PoisonProcSource) *core.Spell {
-
 	return rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 439500, Tag: int32(procSource)},
 		SpellSchool: core.SpellSchoolNature,
@@ -699,7 +694,7 @@ func (rogue *Rogue) makeSebaciousPoison(procSource PoisonProcSource) *core.Spell
 		ProcMask:    core.ProcMaskSpellDamageProc,
 		Flags:       core.SpellFlagPoison | core.SpellFlagPassiveSpell | SpellFlagDeadlyBrewed | SpellFlagRoguePoison,
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
@@ -717,7 +712,6 @@ func (rogue *Rogue) makeSebaciousPoison(procSource PoisonProcSource) *core.Spell
 }
 
 func (rogue *Rogue) makeAtrophicPoison(procSource PoisonProcSource) *core.Spell {
-
 	return rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 439473, Tag: int32(procSource)},
 		SpellSchool: core.SpellSchoolNature,
@@ -725,7 +719,7 @@ func (rogue *Rogue) makeAtrophicPoison(procSource PoisonProcSource) *core.Spell 
 		ProcMask:    core.ProcMaskSpellDamageProc,
 		Flags:       core.SpellFlagPoison | core.SpellFlagPassiveSpell | SpellFlagDeadlyBrewed | SpellFlagRoguePoison,
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),
@@ -743,7 +737,6 @@ func (rogue *Rogue) makeAtrophicPoison(procSource PoisonProcSource) *core.Spell 
 }
 
 func (rogue *Rogue) makeNumbingPoison(procSource PoisonProcSource) *core.Spell {
-
 	return rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 439472, Tag: int32(procSource)},
 		SpellSchool: core.SpellSchoolNature,
@@ -751,7 +744,7 @@ func (rogue *Rogue) makeNumbingPoison(procSource PoisonProcSource) *core.Spell {
 		ProcMask:    core.ProcMaskSpellDamageProc,
 		Flags:       core.SpellFlagPoison | core.SpellFlagPassiveSpell | SpellFlagDeadlyBrewed | SpellFlagRoguePoison,
 
-		DamageMultiplier: rogue.getPoisonDamageMultiplier(),
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		BonusHitRating: core.TernaryFloat64(procSource == ShivProc, 100*core.SpellHitRatingPerHitChance, 0),

--- a/sim/rogue/quick_draw.go
+++ b/sim/rogue/quick_draw.go
@@ -24,17 +24,18 @@ func (rogue *Rogue) registerQuickDrawSpell() {
 	// Quick Draw applies a 50% slow, but bosses are immune
 
 	rogue.QuickDraw = rogue.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: int32(proto.RogueRune_RuneQuickDraw)},
-		SpellSchool: core.SpellSchoolPhysical,
-		DefenseType: core.DefenseTypeRanged,
-		ProcMask:    core.ProcMaskRangedSpecial,
-		Flags:       rogue.builderFlags(),
-		CastType:    proto.CastType_CastTypeRanged,
+		ActionID:       core.ActionID{SpellID: int32(proto.RogueRune_RuneQuickDraw)},
+		ClassSpellMask: ClassSpellMask_RogueQuickdraw,
+		SpellSchool:    core.SpellSchoolPhysical,
+		DefenseType:    core.DefenseTypeRanged,
+		ProcMask:       core.ProcMaskRangedSpecial,
+		Flags:          rogue.builderFlags(),
+		CastType:       proto.CastType_CastTypeRanged,
 
 		MissileSpeed: 40,
 
 		EnergyCost: core.EnergyCostOptions{
-			Cost:   []float64{25, 22, 20}[rogue.Talents.ImprovedSinisterStrike],
+			Cost:   25,
 			Refund: 0,
 		},
 		Cast: core.CastConfig{
@@ -55,7 +56,7 @@ func (rogue *Rogue) registerQuickDrawSpell() {
 
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier: []float64{1, 1.02, 1.04, 1.06}[rogue.Talents.Aggression],
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
 

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -26,11 +26,14 @@ const (
 	ClassSpellMask_RogueBetweentheEyes
 	ClassSpellMask_RogueBladeDance
 	ClassSpellMask_RogueBladeFlurry
+	SpellClassMask_RogueBlunderbuss
 	ClassSpellMask_RogueCrimsonTempest
 	ClassSpellMask_RogueDeadlyPoisonTick
 	ClassSpellMask_RogueEnvenom
+	SpellClassMask_RogueEvasion
 	ClassSpellMask_RogueEviscerate
 	ClassSpellMask_RogueExposeArmor
+	SpellClassMask_RogueFanOfKnives
 	ClassSpellMask_RogueGarrote
 	ClassSpellMask_RogueGhostlyStrike
 	ClassSpellMask_RogueHemorrhage
@@ -39,14 +42,25 @@ const (
 	ClassSpellMask_RogueMutilate
 	ClassSpellMask_RogueOccultPoisonTick
 	ClassSpellMask_RoguePoisonedKnife
+	ClassSpellMask_RogueQuickdraw
 	ClassSpellMask_RogueRupture
 	ClassSpellMask_RogueSaberSlash
 	ClassSpellMask_RogueShadowStrike
+	ClassSpellMask_RogueShiv
 	ClassSpellMask_RogueSinisterStrike
 	ClassSpellMask_RogueSliceAndDice
-	SpellClassMask_RogueFanOfKnives
-	SpellClassMask_RogueBlunderbuss
-	SpellClassMask_RogueEvasion
+
+	// Sinister Strike and spells that benefit from effects that benefit it
+	ClassSpellMask_RogueSinisterStrikeDependent = ClassSpellMask_RogueSinisterStrike | ClassSpellMask_RogueSaberSlash | ClassSpellMask_RogueQuickdraw |
+		ClassSpellMask_RoguePoisonedKnife | ClassSpellMask_RogueShiv | ClassSpellMask_RogueMainGauche
+
+	// Backstab and spells that benefit from effects that benefit it
+	ClassSpellMask_RogueBackstabDependent = ClassSpellMask_RogueBackstab | ClassSpellMask_RogueMutilate
+
+	// Rupture and spells that benefit from effects that benefit it
+	ClassSpellMask_RogueRuptureDependent = ClassSpellMask_RogueRupture | ClassSpellMask_RogueCrimsonTempest
+
+	ClassSpellMask_RoguePoisonDependent = ClassSpellMask_RogueInstantPoison | ClassSpellMask_RogueDeadlyPoisonTick | ClassSpellMask_RogueOccultPoisonTick | ClassSpellMask_RogueEnvenom
 )
 
 var TalentTreeSizes = [3]int{15, 19, 17}

--- a/sim/rogue/rupture.go
+++ b/sim/rogue/rupture.go
@@ -40,7 +40,7 @@ func (rogue *Rogue) registerRupture() {
 			return rogue.ComboPoints() > 0
 		},
 
-		DamageMultiplier: []float64{1, 1.1, 1.2, 1.3}[rogue.Talents.SerratedBlades],
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/rogue/saber_slash.go
+++ b/sim/rogue/saber_slash.go
@@ -20,7 +20,7 @@ func (rogue *Rogue) registerSaberSlashSpell() {
 		ProcMask:       core.ProcMaskMeleeMHSpecial,
 		Flags:          rogue.builderFlags(),
 		EnergyCost: core.EnergyCostOptions{
-			Cost:   []float64{45, 42, 40}[rogue.Talents.ImprovedSinisterStrike],
+			Cost:   45,
 			Refund: 0.8,
 		},
 
@@ -63,10 +63,9 @@ func (rogue *Rogue) registerSaberSlashSpell() {
 
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier:                  1,
-		ImpactDamageMultiplierAdditivePct: []int64{0, 2, 4, 6}[rogue.Talents.Aggression],
-		ThreatMultiplier:                  1,
-		BonusCoefficient:                  1,
+		DamageMultiplier: 1,
+		ThreatMultiplier: 1,
+		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			rogue.BreakStealth(sim)

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -30,7 +30,7 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 		Flags:          rogue.builderFlags(),
 
 		EnergyCost: core.EnergyCostOptions{
-			Cost:   []float64{45, 42, 40}[rogue.Talents.ImprovedSinisterStrike],
+			Cost:   45,
 			Refund: 0.8,
 		},
 		Cast: core.CastConfig{
@@ -42,7 +42,7 @@ func (rogue *Rogue) registerSinisterStrikeSpell() {
 
 		CritDamageBonus: rogue.lethality(),
 
-		DamageMultiplier: []float64{1, 1.02, 1.04, 1.06}[rogue.Talents.Aggression],
+		DamageMultiplier: 1,
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
 

--- a/sim/rogue/slice_and_dice.go
+++ b/sim/rogue/slice_and_dice.go
@@ -23,7 +23,7 @@ func (rogue *Rogue) registerSliceAndDice() {
 
 	actionID := core.ActionID{SpellID: spellID}
 
-	durationMultiplier := []float64{1, 1.15, 1.3, 1.45}[rogue.Talents.ImprovedSliceAndDice]
+	durationMultiplier := 1 + 0.15*float64(rogue.Talents.ImprovedSliceAndDice)
 
 	rogue.sliceAndDiceDurations = [6]time.Duration{
 		0,

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -103,6 +103,9 @@ func (rogue *Rogue) applySerratedBlades() {
 		return
 	}
 
+	// TODO: Test the Armor reduction amount
+	rogue.AddStat(stats.ArmorPenetration, float64(5/3*rogue.Talents.SerratedBlades*rogue.Level))
+
 	rogue.AddStaticMod(core.SpellModConfig{
 		ClassMask: ClassSpellMask_RogueRuptureDependent,
 		Kind:      core.SpellMod_PeriodicDamageDone_Flat,

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -10,20 +10,25 @@ import (
 )
 
 func (rogue *Rogue) ApplyTalents() {
+	rogue.applyImprovedSinisterStrike()
+	rogue.applyImprovedBackstab()
+	rogue.applyImprovedEviscerate()
 	rogue.applyRuthlessness()
 	rogue.applyMurder()
+	rogue.applyVilePoisons()
 	rogue.applyRelentlessStrikes()
 	rogue.applySealFate()
 	rogue.applyWeaponSpecializations()
 	rogue.applyWeaponExpertise()
 	rogue.applyInitiative()
+	rogue.applyAggression()
+	rogue.applyOpportunity()
+	rogue.applySerratedBlades()
 
 	rogue.AddStat(stats.Dodge, 1*float64(rogue.Talents.LightningReflexes))
 	rogue.AddStat(stats.Parry, 1*float64(rogue.Talents.Deflection))
 	rogue.AddStat(stats.MeleeCrit, 1*float64(rogue.Talents.Malice))
 	rogue.AddStat(stats.MeleeHit, 1*float64(rogue.Talents.Precision))
-	// TODO: Test the Armor reduction amount
-	rogue.AddStat(stats.ArmorPenetration, float64(5/3*rogue.Talents.SerratedBlades*rogue.Level))
 	rogue.AutoAttacks.OHConfig().DamageMultiplier *= rogue.dwsMultiplier()
 
 	if rogue.Talents.Deadliness > 0 {
@@ -37,6 +42,72 @@ func (rogue *Rogue) ApplyTalents() {
 	rogue.registerPremeditation()
 	rogue.registerGhostlyStrikeSpell()
 	rogue.applyRiposte()
+}
+
+func (rogue *Rogue) applyImprovedEviscerate() {
+	if rogue.Talents.ImprovedEviscerate == 0 {
+		return
+	}
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RogueEviscerate,
+		Kind:      core.SpellMod_DamageDone_Flat,
+		IntValue:  5 * int64(rogue.Talents.ImprovedEviscerate),
+	})
+}
+
+func (rogue *Rogue) applyImprovedSinisterStrike() {
+	if rogue.Talents.ImprovedSinisterStrike == 0 {
+		return
+	}
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RogueSinisterStrikeDependent,
+		Kind:      core.SpellMod_PowerCost_Flat,
+		IntValue:  -[]int64{0, 3, 5}[rogue.Talents.ImprovedSinisterStrike],
+	})
+}
+
+func (rogue *Rogue) applyImprovedBackstab() {
+	if rogue.Talents.ImprovedBackstab == 0 {
+		return
+	}
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RogueBackstabDependent,
+		Kind:      core.SpellMod_BonusCrit_Flat,
+		IntValue:  10 * int64(rogue.Talents.ImprovedBackstab),
+	})
+}
+
+func (rogue *Rogue) applyOpportunity() {
+	if rogue.Talents.Opportunity == 0 {
+		return
+	}
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RogueBackstabDependent | ClassSpellMask_RogueAmbush | ClassSpellMask_RogueMutilate,
+		Kind:      core.SpellMod_ImpactDamageDone_Flat,
+		IntValue:  4 * int64(rogue.Talents.Opportunity),
+	})
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RogueGarrote,
+		Kind:      core.SpellMod_PeriodicDamageDone_Flat,
+		IntValue:  4 * int64(rogue.Talents.Opportunity),
+	})
+}
+
+func (rogue *Rogue) applySerratedBlades() {
+	if rogue.Talents.SerratedBlades == 0 {
+		return
+	}
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RogueRuptureDependent,
+		Kind:      core.SpellMod_PeriodicDamageDone_Flat,
+		IntValue:  10 * int64(rogue.Talents.SerratedBlades),
+	})
 }
 
 // dwsMultiplier returns the offhand damage multiplier
@@ -85,6 +156,30 @@ func (rogue *Rogue) applyMurder() {
 			}
 		})
 	}
+}
+
+func (rogue *Rogue) applyVilePoisons() {
+	if rogue.Talents.VilePoisons == 0 {
+		return
+	}
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RoguePoisonDependent,
+		Kind:      core.SpellMod_DamageDone_Flat,
+		IntValue:  4 * int64(rogue.Talents.VilePoisons),
+	})
+}
+
+func (rogue *Rogue) applyAggression() {
+	if rogue.Talents.Aggression == 0 {
+		return
+	}
+
+	rogue.AddStaticMod(core.SpellModConfig{
+		ClassMask: ClassSpellMask_RogueSinisterStrikeDependent,
+		Kind:      core.SpellMod_ImpactDamageDone_Flat,
+		IntValue:  2 * int64(rogue.Talents.Aggression),
+	})
 }
 
 func (rogue *Rogue) applyRelentlessStrikes() {

--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -74,9 +74,9 @@ func (rogue *Rogue) applyImprovedBackstab() {
 	}
 
 	rogue.AddStaticMod(core.SpellModConfig{
-		ClassMask: ClassSpellMask_RogueBackstabDependent,
-		Kind:      core.SpellMod_BonusCrit_Flat,
-		IntValue:  10 * int64(rogue.Talents.ImprovedBackstab),
+		ClassMask:  ClassSpellMask_RogueBackstabDependent,
+		Kind:       core.SpellMod_BonusCrit_Flat,
+		FloatValue: 10 * float64(rogue.Talents.ImprovedBackstab),
 	})
 }
 

--- a/sim/rogue/tank_rogue/TestTank.results
+++ b/sim/rogue/tank_rogue/TestTank.results
@@ -50,8 +50,8 @@ character_stats_results: {
 stat_weights_results: {
  key: "TestTank-Phase5-Lvl60-StatWeights-Default"
  value: {
-  weights: 0.66249
-  weights: 0.91304
+  weights: 0.66129
+  weights: 0.90956
   weights: 0
   weights: 0
   weights: 0
@@ -67,9 +67,9 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.52371
-  weights: 15.44381
-  weights: 4.29331
+  weights: 0.52276
+  weights: 15.39888
+  weights: 4.197
   weights: 0
   weights: 0
   weights: 0
@@ -99,8 +99,8 @@ stat_weights_results: {
 dps_results: {
  key: "TestTank-Phase5-Lvl60-AllItems-BloodCorruptedLeathers"
  value: {
-  dps: 1677.347
-  tps: 1276.00825
+  dps: 1669.47238
+  tps: 1270.41728
  }
 }
 dps_results: {
@@ -113,98 +113,98 @@ dps_results: {
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 1708.05196
-  tps: 4065.51169
+  dps: 1701.51689
+  tps: 4051.89465
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Human-p5_saber-Basic-P5_Saber-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1515.37032
-  tps: 5771.05603
+  dps: 1507.32641
+  tps: 5754.60654
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Human-p5_saber-Basic-P5_Saber-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1054.53994
-  tps: 2831.60016
+  dps: 1047.85035
+  tps: 2817.66207
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Human-p5_saber-Basic-P5_Saber-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1103.64545
-  tps: 2835.92329
+  dps: 1096.29575
+  tps: 2821.06566
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Human-p5_saber-Basic-P5_Saber-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 590.33693
-  tps: 2245.57374
+  dps: 589.01477
+  tps: 2242.48579
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Human-p5_saber-Basic-P5_Saber-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 413.3724
-  tps: 1144.37304
+  dps: 412.20731
+  tps: 1141.574
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Human-p5_saber-Basic-P5_Saber-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 431.78543
-  tps: 1131.63421
+  dps: 430.29859
+  tps: 1128.3707
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Orc-p5_saber-Basic-P5_Saber-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1551.924
-  tps: 5885.39949
+  dps: 1544.38004
+  tps: 5869.87824
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Orc-p5_saber-Basic-P5_Saber-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1067.0647
-  tps: 2853.39895
+  dps: 1060.43174
+  tps: 2839.60431
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Orc-p5_saber-Basic-P5_Saber-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1169.38586
-  tps: 2970.41767
+  dps: 1162.12281
+  tps: 2955.6731
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Orc-p5_saber-Basic-P5_Saber-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 611.77209
-  tps: 2288.42377
+  dps: 610.42373
+  tps: 2285.28238
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Orc-p5_saber-Basic-P5_Saber-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 425.65201
-  tps: 1163.37279
+  dps: 424.67038
+  tps: 1160.94847
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-Settings-Orc-p5_saber-Basic-P5_Saber-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 462.9301
-  tps: 1196.4922
+  dps: 461.23876
+  tps: 1192.86251
  }
 }
 dps_results: {
  key: "TestTank-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1710.12312
-  tps: 4082.30315
+  dps: 1703.62544
+  tps: 4068.76327
  }
 }


### PR DESCRIPTION
Talents affected:
- [x] Improved Sinister Strike
- [x] Improved Backstab
- [x] Improved Eviscerate
- [x] Vile Poisons
- [x] Aggression
- [x] Opportunity
- [x] Serrated Blades