### PR TITLE
Update the value of the 6p coreforge rogue tank set bonus

### DIFF
--- a/sim/rogue/item_sets_phase_4.go
+++ b/sim/rogue/item_sets_phase_4.go
@@ -247,7 +247,7 @@ func (rogue *Rogue) applyT1Tank4PBonus() {
 	})
 }
 
-// Your finishing moves have a 20% chance per combo point to make you take 50% less Physical damage from the next melee attack that hits you within 10 sec.
+// Your finishing moves have a 20% chance per combo point to make you take 20% less Physical damage from the next melee attack that hits you within 10 sec.
 func (rogue *Rogue) applyT1Tank6PBonus() {
 	label := "S03 - Item - T1 - Rogue - Tank 6P Bonus"
 	if rogue.HasAura(label) {
@@ -255,7 +255,7 @@ func (rogue *Rogue) applyT1Tank6PBonus() {
 	}
 
 	buffLabel := fmt.Sprintf("Resilient (%s)", label)
-	damageTakenMultiplier := 0.5
+	damageTakenMultiplier := 0.8
 
 	buffAura := rogue.RegisterAura(core.Aura{
 		ActionID: core.ActionID{SpellID: 457469},


### PR DESCRIPTION
Implementing the latest value for 6p CF tank tier. https://github.com/wowsims/sod/issues/1328

Old damage reduction: 50%
New damage reduction: 20%