### PR TITLE
The check for Draught of the Sands used to be contained in an else/if…

### DIFF
--- a/sim/rogue/talents.go
+++ b/sim/rogue/talents.go
@@ -132,7 +132,7 @@ func (rogue *Rogue) applyRuthlessness() {
 	})
 }
 
-// Murder talent
+// Murder talent / Draught of the Sands (these can stack)
 func (rogue *Rogue) applyMurder() {
 	murderMobTypes := []proto.MobType{proto.MobType_MobTypeHumanoid, proto.MobType_MobTypeGiant, proto.MobType_MobTypeBeast, proto.MobType_MobTypeDragonkin}
 	murderTargets := core.FilterSlice(rogue.Env.Encounter.Targets, func(t *core.Target) bool { return slices.Contains(murderMobTypes, t.MobType) })
@@ -148,7 +148,9 @@ func (rogue *Rogue) applyMurder() {
 				}
 			}
 		})
-	} else if rogue.Consumes.MiscConsumes != nil && rogue.Consumes.MiscConsumes.DraughtOfTheSands {
+	}
+
+	if rogue.Consumes.MiscConsumes != nil && rogue.Consumes.MiscConsumes.DraughtOfTheSands {
 		rogue.Env.RegisterPostFinalizeEffect(func() {
 			multiplier := 1.02
 			for _, t := range rogue.Env.Encounter.Targets {


### PR DESCRIPTION
… statement after checking for the Murder talent. This means if Murder was selected as a talent then the check for Daught of the Sands would never occur. I moved the check for Draught to its own if statement as the talent and consumable can stack in game and the sim should reflect that.