### PR TITLE
[Paladin] Fix some set bonuses that were overwriting others

### DIFF
--- a/sim/paladin/holy_shield.go
+++ b/sim/paladin/holy_shield.go
@@ -57,7 +57,7 @@ func (paladin *Paladin) registerHolyShield() {
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 				// Spell damage from Holy Shield can crit, but does not miss.
-				spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMagicCrit)
+				spell.CalcAndDealDamage(sim, target, paladin.getHolyShieldDamage(sim, damage), spell.OutcomeMagicCrit)
 			},
 		})
 
@@ -78,7 +78,9 @@ func (paladin *Paladin) registerHolyShield() {
 			OnSpellHitTaken: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if result.DidBlock() {
 					paladin.holyShieldProc[i].Cast(sim, spell.Unit)
-					aura.RemoveStack(sim)
+					if aura.MaxStacks > 0 {
+						aura.RemoveStack(sim)
+					}
 				}
 			},
 		})
@@ -114,4 +116,14 @@ func (paladin *Paladin) registerHolyShield() {
 			},
 		})
 	}
+}
+
+func (paladin *Paladin) getHolyShieldDamage(sim *core.Simulation, baseDamage float64) float64 {
+	damage := baseDamage
+
+	if paladin.holyShieldExtraDamage != nil {
+		damage += paladin.holyShieldExtraDamage(sim, paladin)
+	}
+
+	return damage
 }

--- a/sim/paladin/item_sets_pve_phase_7.go
+++ b/sim/paladin/item_sets_pve_phase_7.go
@@ -154,7 +154,7 @@ func (paladin *Paladin) applyNaxxramasProtection2PBonus() {
 		ActionID:   core.ActionID{SpellID: PaladinT3Prot2P},
 		Label:      label,
 		BuildPhase: core.CharacterBuildPhaseBuffs,
-	}).AttachStatsBuff(bonusStats))
+	}).AttachBuildPhaseStatsBuff(bonusStats))
 }
 
 // Reduces the cooldown on your Divine Protection ability by 3 min and reduces the cooldown on your Avenging Wrath ability by 2 min.

--- a/sim/paladin/item_sets_pve_phase_8.go
+++ b/sim/paladin/item_sets_pve_phase_8.go
@@ -253,7 +253,7 @@ func (paladin *Paladin) applyScarletEnclaveProtection6PBonus() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			blockValue := paladin.GetStat(stats.BlockValue)
+			blockValue := paladin.BlockValue()
 			healAmount := blockValue * 0.5
 			spell.CalcAndDealHealing(sim, target, healAmount, spell.OutcomeHealingCrit)
 		},

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -100,8 +100,9 @@ type Paladin struct {
 	sealOfMartyrdom     *core.Spell
 
 	// Set bonus specific
-	holyPowerAura    *core.Aura
-	onHolyPowerSpent func(sim *core.Simulation, holyPower int32)
+	holyPowerAura         *core.Aura
+	onHolyPowerSpent      func(sim *core.Simulation, holyPower int32)
+	holyShieldExtraDamage func(sim *core.Simulation, paladin *Paladin) float64
 
 	enableMultiJudge    bool
 	lingerDuration      time.Duration

--- a/ui/protection_paladin/inputs.ts
+++ b/ui/protection_paladin/inputs.ts
@@ -1,7 +1,7 @@
 import * as InputHelpers from '../core/components/input_helpers.js';
 import { Player } from '../core/player.js';
 import { ItemSlot, Spec } from '../core/proto/common.js';
-import { PaladinRune, PaladinSeal, PaladinAura, Blessings } from '../core/proto/paladin.js';
+import { Blessings,PaladinAura, PaladinRune, PaladinSeal } from '../core/proto/paladin.js';
 import { ActionId } from '../core/proto_utils/action_id.js';
 import { TypedEvent } from '../core/typed_event.js';
 // Configuration for spec-specific UI elements on the settings tab.

--- a/ui/protection_paladin/presets.ts
+++ b/ui/protection_paladin/presets.ts
@@ -8,7 +8,6 @@ import {
 	Conjured,
 	Consumes,
 	Debuffs,
-	EnchantedSigil,
 	Explosive,
 	FirePowerBuff,
 	Flask,

--- a/ui/protection_paladin/sim.ts
+++ b/ui/protection_paladin/sim.ts
@@ -1,4 +1,3 @@
-import * as BuffDebuffInputs from '../core/components/inputs/buffs_debuffs';
 import * as OtherInputs from '../core/components/other_inputs.js';
 import { Phase } from '../core/constants/other.js';
 import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.js';
@@ -13,12 +12,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 	cssClass: 'protection-paladin-sim-ui',
 	cssScheme: 'paladin',
 	// List any known bugs / issues here and they'll be shown on the site.
-	knownIssues: [
-		`Judgement of the Crusader is currently not implemented; users can manually award themselves the relevant spellpower amount
-		for a dps gain that will be slightly inflated given JotC does not benefit from source damage modifiers.`,
-		`Be aware that not all item and weapon enchants are currently implemented in the sim, which make some notable Retribution
-		weapons like Pendulum of Doom and The Jackhammer undervalued.`,
-	],
+	knownIssues: [],
 	warnings: [
 		(simUI: IndividualSimUI<Spec.SpecProtectionPaladin>) => {
 			return {


### PR DESCRIPTION
* T1 6pc Prot was overwriting all other set bonuses affecting Holy Shield (like T2 2pc/4pc)
* T2 2pc was adding 40% extra block instead of 10% on top of the already existing 30%
* Fixed Scarlet Enclave Prot 6pc to use correct func for getting block value
* Moved all old set bonuses to use auras with attached spell mods
  * Using build phase where appropriate (flat stats etc)