### PR TITLE
Add ability to disable stats for stat weight calculation

### DIFF
--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -326,6 +326,10 @@ message SavedGearSet {
 	UnitStats bonus_stats_stats = 3;
 }
 
+message SavedStatWeightSettings {
+	UnitStats excluded_from_calc = 1;
+}
+
 // Local storage data for other settings.
 message SavedSettings {
 	RaidBuffs raid_buffs = 1;

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -627,7 +627,7 @@ class EpWeightsMenu extends BaseModal {
 		} else {
 			updateStatEntry(stat.getPseudoStat(), this.swSettings.excludedFromCalc.pseudoStats);
 		}
-		window.localStorage.setItem(this.swSettingsStorageKey, JSON.stringify(this.swSettings).toString());
+		window.localStorage.setItem(this.swSettingsStorageKey, SavedStatWeightSettings.toJsonString(this.swSettings));
 	}
 
 	private setSimProgress(progress: ProgressMetrics) {

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -675,8 +675,8 @@ class EpWeightsMenu extends BaseModal {
 			<td class="current-ep"></td>
 		`;
 
-		const includeToggleCell = row.querySelector('.swcalc-include-toggle') as HTMLElement;
 		if (this.isEpStat(stat)) {
+			const includeToggleCell = row.querySelector('.swcalc-include-toggle') as HTMLElement;
 			const cb = document.createElement('input');
 			cb.type = 'checkbox';
 			if (stat.isStat() && this.epReferenceStat == stat.getStat()) {

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -659,7 +659,8 @@ class EpWeightsMenu extends BaseModal {
 
 	private makeTableRow(stat: UnitStat): HTMLElement {
 		const row = document.createElement('tr');
-		const result = this.simUI.prevEpSimResult;
+		const statIsCalculated = !(stat.isStat() ? this.isStatExcludedFromCalc(stat.getStat()) : this.isPseudostatExcludedFromCalc(stat.getPseudoStat()));
+		const result = statIsCalculated ? this.simUI.prevEpSimResult : null;
 		const epRatios = this.simUI.player.getEpRatios();
 		const rowTotalEp = scaledEpValue(stat, epRatios, result);
 		row.innerHTML = `
@@ -682,7 +683,7 @@ class EpWeightsMenu extends BaseModal {
 				cb.checked = true;
 				cb.disabled = true;
 			} else {
-				cb.checked = !(stat.isStat() ? this.isStatExcludedFromCalc(stat.getStat()) : this.isPseudostatExcludedFromCalc(stat.getPseudoStat()));
+				cb.checked = statIsCalculated;
 				cb.addEventListener('change', () => this.setStatExcluded(stat, !cb.checked));
 			}
 			includeToggleCell.appendChild(cb);

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -402,17 +402,7 @@ class EpWeightsMenu extends BaseModal {
 			});
 
 			button.addEventListener('click', _event => {
-				const newWeights = weightsFunc();
-				if (newWeights && this.swSettings.excludedFromCalc) {
-					const oldWeights = this.simUI.player.getEpWeights();
-					for (const stat of this.swSettings.excludedFromCalc.stats) {
-						newWeights.stats[stat] = oldWeights.getStat(stat);
-					}
-					for (const pseudoStat of this.swSettings.excludedFromCalc.pseudoStats) {
-						newWeights.pseudoStats[pseudoStat] = oldWeights.getPseudoStat(pseudoStat);
-					}
-				}
-				this.simUI.player.setEpWeights(TypedEvent.nextEventID(), Stats.fromProto(newWeights));
+				this.setEpWeightsWithoutExcluded(Stats.fromProto(weightsFunc()));
 				this.updateTable();
 			});
 		};
@@ -550,7 +540,7 @@ class EpWeightsMenu extends BaseModal {
 				const scaledTmiEp = Stats.fromProto(results.tmi!.epValues).scale(epRatios[4]);
 				const scaledPDeathEp = Stats.fromProto(results.pDeath!.epValues).scale(epRatios[5]);
 				const newEp = scaledDpsEp.add(scaledHpsEp).add(scaledTpsEp).add(scaledDtpsEp).add(scaledTmiEp).add(scaledPDeathEp);
-				this.simUI.player.setEpWeights(TypedEvent.nextEventID(), newEp);
+				this.setEpWeightsWithoutExcluded(newEp);
 			} else {
 				const scaledDpsWeights = Stats.fromProto(results.dps!.weights).scale(epRatios[0]);
 				const scaledHpsWeights = Stats.fromProto(results.hps!.weights).scale(epRatios[1]);
@@ -564,10 +554,27 @@ class EpWeightsMenu extends BaseModal {
 					.add(scaledDtpsWeights)
 					.add(scaledTmiWeights)
 					.add(scaledPDeathWeights);
-				this.simUI.player.setEpWeights(TypedEvent.nextEventID(), newWeights);
+				this.setEpWeightsWithoutExcluded(newWeights);
 			}
 			this.updateTable();
 		});
+	}
+
+	/**
+	 * Set new ep weights while leaving excluded stats at their old value.
+	 * @param newWeights
+	 */
+	private setEpWeightsWithoutExcluded(newWeights: Stats) {
+		if (this.swSettings.excludedFromCalc) {
+			const oldWeights = this.simUI.player.getEpWeights();
+			for (const stat of this.swSettings.excludedFromCalc.stats) {
+				newWeights.setStat(stat, oldWeights.getStat(stat));
+			}
+			for (const pseudoStat of this.swSettings.excludedFromCalc.pseudoStats) {
+				newWeights.setPseudostat(pseudoStat, oldWeights.getPseudoStat(pseudoStat));
+			}
+		}
+		this.simUI.player.setEpWeights(TypedEvent.nextEventID(), newWeights);
 	}
 
 	/**

--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -568,10 +568,10 @@ class EpWeightsMenu extends BaseModal {
 		if (this.swSettings.excludedFromCalc) {
 			const oldWeights = this.simUI.player.getEpWeights();
 			for (const stat of this.swSettings.excludedFromCalc.stats) {
-				newWeights.setStat(stat, oldWeights.getStat(stat));
+				newWeights = newWeights.withStat(stat, oldWeights.getStat(stat));
 			}
 			for (const pseudoStat of this.swSettings.excludedFromCalc.pseudoStats) {
-				newWeights.setPseudostat(pseudoStat, oldWeights.getPseudoStat(pseudoStat));
+				newWeights = newWeights.withPseudoStat(pseudoStat, oldWeights.getPseudoStat(pseudoStat));
 			}
 		}
 		this.simUI.player.setEpWeights(TypedEvent.nextEventID(), newWeights);

--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -171,6 +171,14 @@ export class Stats {
 		);
 	}
 
+	setStat(stat: Stat, value: number) {
+		this.stats[stat] = value;
+	}
+
+	setPseudostat(stat: PseudoStat, value: number) {
+		this.pseudoStats[stat] = value;
+	}
+
 	computeEP(epWeights: Stats): number {
 		let total = 0;
 		this.stats.forEach((stat, idx) => {

--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -171,14 +171,6 @@ export class Stats {
 		);
 	}
 
-	setStat(stat: Stat, value: number) {
-		this.stats[stat] = value;
-	}
-
-	setPseudostat(stat: PseudoStat, value: number) {
-		this.pseudoStats[stat] = value;
-	}
-
 	computeEP(epWeights: Stats): number {
 		let total = 0;
 		this.stats.forEach((stat, idx) => {


### PR DESCRIPTION
Adds a checkbox column to the table in the stat weight modal to toggle whether stats should be included in the stat weight sim. Feature was requested in https://github.com/wowsims/sod/issues/1333
Disabling them also excludes stats from the EP copy and EP ratios functions. In that case the old values will be kept.

Settings are saved as an independent local storage entry per spec. Don't think it's something you'd want to export and share, so I didn't put it in the sim settings.

![grafik](https://github.com/user-attachments/assets/23885f98-5ef1-4d2c-b2e9-b2c3110a34f5)
