### PR TITLE
HUNTER - FIXED Pet's Flanking Strike not benefitting from Mortal Shots talent or Deadly Striker tier bonus

### DIFF
--- a/sim/hunter/flanking_strike.go
+++ b/sim/hunter/flanking_strike.go
@@ -42,6 +42,7 @@ func (hunter *Hunter) registerFlankingStrikeSpell() {
 			ProcMask:       core.ProcMaskMeleeMHSpecial,
 			Flags:          core.SpellFlagMeleeMetrics,
 
+			CritDamageBonus:  hunter.mortalShots(),
 			DamageMultiplier: 1,
 			BonusCoefficient: 1,
 

--- a/sim/hunter/item_sets_pve_phase_6.go
+++ b/sim/hunter/item_sets_pve_phase_6.go
@@ -61,6 +61,15 @@ func (hunter *Hunter) applyTAQMelee4PBonus() {
 		ClassMask: ClassSpellMask_HunterMongooseBite | ClassSpellMask_HunterStrikes,
 		IntValue:  20,
 	}))
+
+	// This also applies to the pet's Flanking Strike
+	core.MakePermanent(hunter.pet.RegisterAura(core.Aura{
+		Label: label,
+	}).AttachSpellMod(core.SpellModConfig{
+		Kind:      core.SpellMod_ImpactDamageDone_Flat,
+		ClassMask: ClassSpellMask_HunterPetFlankingStrike,
+		IntValue:  20,
+	}))
 }
 
 var StrikersPursuit = core.NewItemSet(core.ItemSet{

--- a/sim/hunter/item_sets_pve_phase_7.go
+++ b/sim/hunter/item_sets_pve_phase_7.go
@@ -69,7 +69,7 @@ func (hunter *Hunter) applyNaxxramasMelee4PBonus() {
 	}))
 }
 
-// You gain 4% increased damage done to Undead for 30 sec each time you hit an Undead enemy with a melee attack, stacking up to 10 times.
+// You gain 2% increased damage and critical damage done to Undead for 30 sec each time you hit an Undead enemy with a melee attack, stacking up to 12 times. Stacks are lost upon performing a ranged attack.
 func (hunter *Hunter) applyNaxxramasMelee6PBonus() {
 	label := "S03 - Item - Naxxramas - Hunter - Melee 6P Bonus"
 	if hunter.HasAura(label) {
@@ -183,7 +183,7 @@ func (hunter *Hunter) applyNaxxramasRanged4PBonus() {
 	})
 }
 
-// You gain 2% increased critical strike chance for 30 sec each time you hit an Undead enemy with a ranged attack, stacking up to 15 times.
+// You gain 2% increased damage and critical damage done to Undead for 30 sec each time you hit an Undead enemy with a ranged attack, stacking up to 7 times.
 func (hunter *Hunter) applyNaxxramasRanged6PBonus() {
 	label := "S03 - Item - Naxxramas - Hunter - Ranged 6P Bonus"
 	if hunter.HasAura(label) {


### PR DESCRIPTION
Tested by Kawney that mortal shots and TAQ 4p melee bonus do affect the pet's flanking strike spell.
https://www.wowhead.com/classic-ptr/spell=415326/flanking-strike#modified-by

We believe that Clever Strikes does not ever effect the pet's flanking strike since the buff is consumed by the player's flanking strike first.