### PR TITLE
update pet haste inheritance rules

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -885,6 +885,16 @@ func applyPetBuffEffects(petAgent PetAgent, playerFaction proto.Faction, raidBuf
 	individualBuffs.SlipkiksSavvy = false
 	individualBuffs.SparkOfInspiration = false
 
+	// Hunter and Shaman pets don't double dip from the Melee Speed increase of Warchief's Blessing
+	if ownerClass := petAgent.GetPet().Owner.Class; individualBuffs.WarchiefsBlessing && (ownerClass == proto.Class_ClassHunter || ownerClass == proto.Class_ClassShaman) {
+		petAgent.GetCharacter().RegisterAura(Aura{
+			Label: "Warchief's Blessing Pet Override",
+			OnInit: func(aura *Aura, sim *Simulation) {
+				aura.Unit.GetAura("Warchief's Blessing").OnReset = nil
+			},
+		})
+	}
+
 	applyBuffEffects(petAgent, playerFaction, raidBuffs, partyBuffs, individualBuffs)
 }
 
@@ -2367,10 +2377,10 @@ func ApplyWarchiefsBlessing(unit *Unit, category string) {
 			{stats.MP5, 10, false},
 		},
 		ExtraOnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.PseudoStats.MeleeSpeedMultiplier *= 1.15
+			aura.Unit.MultiplyMeleeSpeed(sim, 1.15)
 		},
 		ExtraOnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.PseudoStats.MeleeSpeedMultiplier /= 1.15
+			aura.Unit.MultiplyMeleeSpeed(sim, 1/1.15)
 		},
 	})
 }
@@ -2389,10 +2399,10 @@ func ApplyMightOfStormwind(unit *Unit, category string) {
 			{stats.MP5, 10, false},
 		},
 		ExtraOnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.PseudoStats.MeleeSpeedMultiplier *= 1.15
+			aura.Unit.MultiplyMeleeSpeed(sim, 1.15)
 		},
 		ExtraOnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.PseudoStats.MeleeSpeedMultiplier /= 1.15
+			aura.Unit.MultiplyMeleeSpeed(sim, 1/1.15)
 		},
 	})
 }
@@ -2545,12 +2555,10 @@ func ApplySparkOfInspiration(unit *Unit) {
 			{stats.SpellPower, 42, false},
 		},
 		ExtraOnGain: func(aura *Aura, sim *Simulation) {
-			aura.Unit.PseudoStats.MeleeSpeedMultiplier *= 1.1
-			aura.Unit.PseudoStats.RangedSpeedMultiplier *= 1.1
+			aura.Unit.MultiplyAttackSpeed(sim, 1.10)
 		},
 		ExtraOnExpire: func(aura *Aura, sim *Simulation) {
-			aura.Unit.PseudoStats.MeleeSpeedMultiplier /= 1.1
-			aura.Unit.PseudoStats.RangedSpeedMultiplier /= 1.1
+			aura.Unit.MultiplyAttackSpeed(sim, 1/1.10)
 		},
 	})
 }

--- a/sim/hunter/pet.go
+++ b/sim/hunter/pet.go
@@ -165,7 +165,8 @@ func (hunter *Hunter) NewHunterPet() *HunterPet {
 	}
 
 	hp.ApplyOnPetEnable(func(sim *core.Simulation) {
-		hp.EnableDynamicAttackSpeed(sim)
+		// Hunter pets only inherit the owner's melee speed
+		hp.EnableDynamicMeleeSpeedInheritance(sim)
 	})
 
 	core.ApplyPetConsumeEffects(&hp.Character, hunter.Consumes)

--- a/sim/priest/eye_of_the_void.go
+++ b/sim/priest/eye_of_the_void.go
@@ -135,6 +135,11 @@ func (priest *Priest) NewEyeOfTheVoid() *EyeOfTheVoid {
 	// Mage spell crit scaling for imp
 	eyePet.AddStatDependency(stats.Intellect, stats.SpellCrit, core.CritPerIntAtLevel[proto.Class_ClassMage][int(eyePet.Level)]*core.SpellCritRatingPerCritChance)
 
+	eyePet.ApplyOnPetEnable(func(sim *core.Simulation) {
+		// Priest pets only inherit the owner's cast speed
+		eyePet.EnableDynamicCastSpeedInheritance(sim)
+	})
+
 	eyePet.ShadowBolt = eyePet.GetOrRegisterSpell(eyePet.newShadowBoltSpellConfig(priest))
 
 	priest.AddPet(eyePet)

--- a/sim/priest/homunculi.go
+++ b/sim/priest/homunculi.go
@@ -96,6 +96,11 @@ func (priest *Priest) NewHomunculus(idx int32, npcID int32) *Homunculus {
 		AutoSwingMelee: true,
 	})
 
+	homunculus.ApplyOnPetEnable(func(sim *core.Simulation) {
+		// Priest pets only inherit the owner's cast speed
+		homunculus.EnableDynamicCastSpeedInheritance(sim)
+	})
+
 	// Homunculus aren't very bright and often sit in front of targets
 	homunculus.PseudoStats.InFrontOfTarget = true
 

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -298,18 +298,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.19529
+  weights: 0.15362
   weights: 0
-  weights: 0.37098
-  weights: 0
-  weights: 0
+  weights: 0.37282
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.22206
   weights: 0
   weights: 0
-  weights: 0.48054
+  weights: 0.22298
+  weights: 0
+  weights: 0
+  weights: 0.48621
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.06617
+  weights: -0.01293
   weights: 0
-  weights: 0.8012
-  weights: 0
-  weights: 0
+  weights: 0.8097
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.8012
   weights: 0
   weights: 0
-  weights: 1.90899
+  weights: 0.8097
+  weights: 0
+  weights: 0
+  weights: 1.90994
   weights: 0
   weights: 0
   weights: 0
@@ -396,18 +396,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.37744
+  weights: 0.35512
   weights: 0
-  weights: 1.10913
-  weights: 0
-  weights: 0
+  weights: 1.11079
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.10913
   weights: 0
-  weights: 0.57275
-  weights: 8.23992
+  weights: 0
+  weights: 1.11079
+  weights: 0
+  weights: 0.55054
+  weights: 8.24548
   weights: 0
   weights: 0
   weights: 0
@@ -445,18 +445,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.3525
+  weights: 0.35047
   weights: 0
-  weights: 2.00162
-  weights: 0
-  weights: 0
+  weights: 2.01258
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.00162
   weights: 0
   weights: 0
-  weights: 23.88033
+  weights: 2.01258
+  weights: 0
+  weights: 0
+  weights: 23.985
   weights: 0
   weights: 0
   weights: 0
@@ -494,18 +494,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.42881
+  weights: 0.46307
   weights: 0
-  weights: 1.95592
-  weights: 0
-  weights: 0
+  weights: 1.96729
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.95592
+  weights: 0
+  weights: 0
+  weights: 1.96729
   weights: 0
   weights: 0.00072
-  weights: 30.25079
+  weights: 30.36133
   weights: 0
   weights: 0
   weights: 0
@@ -543,18 +543,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.50897
+  weights: 0.52477
   weights: 0
-  weights: 2.671
-  weights: 0
-  weights: 0
+  weights: 2.68378
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.671
+  weights: 0
+  weights: 0
+  weights: 2.68378
   weights: 0
   weights: 0.00284
-  weights: 29.56988
+  weights: 29.60325
   weights: 0
   weights: 0
   weights: 0
@@ -596,8 +596,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Average-Default"
  value: {
-  dps: 119.71838
-  tps: 104.37365
+  dps: 119.84094
+  tps: 104.37284
  }
 }
 dps_results: {
@@ -645,50 +645,50 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 119.97619
-  tps: 192.81284
+  dps: 119.95241
+  tps: 192.81814
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 119.97619
-  tps: 104.47119
+  dps: 119.95241
+  tps: 104.47649
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-FullBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 177.90598
+  dps: 178.16604
   tps: 166.74238
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongMultiTarget"
  value: {
-  dps: 82.30657
+  dps: 82.71865
   tps: 155.6262
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-LongSingleTarget"
  value: {
-  dps: 82.30657
+  dps: 82.71865
   tps: 73.6068
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-Settings-Troll-phase_1-Basic-phase_1-NoBuffs-P1-Consumes-ShortSingleTarget"
  value: {
-  dps: 130.51607
+  dps: 131.09835
   tps: 122.63917
  }
 }
 dps_results: {
  key: "TestShadow-Phase1-Lvl25-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 119.97619
-  tps: 104.47119
+  dps: 119.95241
+  tps: 104.47649
  }
 }
 dps_results: {
@@ -701,21 +701,21 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 618.99476
-  tps: 494.08536
+  dps: 621.53723
+  tps: 494.08408
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 620.75453
+  dps: 623.17314
   tps: 783.56855
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-NightElf-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 620.75453
+  dps: 623.17314
   tps: 495.40097
  }
 }
@@ -750,50 +750,50 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 620.54622
-  tps: 781.06273
+  dps: 623.55746
+  tps: 780.99855
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 620.54622
-  tps: 495.42405
+  dps: 623.55746
+  tps: 495.35987
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 597.35839
+  dps: 598.55687
   tps: 483.96878
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 405.24011
+  dps: 405.71373
   tps: 523.33977
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 405.24011
+  dps: 405.71373
   tps: 321.06264
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-Settings-Troll-phase_2-Basic-phase_2-NoBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 465.35137
+  dps: 465.91133
   tps: 372.09172
  }
 }
 dps_results: {
  key: "TestShadow-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 620.54622
-  tps: 495.42405
+  dps: 623.55746
+  tps: 495.35987
  }
 }
 dps_results: {
@@ -807,9 +807,9 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1282.87783
-  tps: 1035.02995
-  hps: 11.44624
+  dps: 1283.35761
+  tps: 1035.0356
+  hps: 11.44626
  }
 }
 dps_results: {
@@ -863,15 +863,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1696.21479
-  tps: 1739.89031
+  dps: 1696.87414
+  tps: 1740.03744
   hps: 10.74615
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 1282.5481
+  dps: 1282.62865
   tps: 1035.33935
   hps: 11.91653
  }
@@ -879,7 +879,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 1308.37068
+  dps: 1307.99994
   tps: 994.19458
   hps: 12.59676
  }
@@ -887,15 +887,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 808.10909
-  tps: 887.97494
+  dps: 809.15646
+  tps: 888.05177
   hps: 6.08192
  }
 }
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 691.06406
+  dps: 691.88274
   tps: 549.14267
   hps: 7.35667
  }
@@ -903,7 +903,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-Settings-Troll-phase_3-Basic-phase_3-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 879.78862
+  dps: 880.32441
   tps: 672.23639
   hps: 10.06708
  }
@@ -911,7 +911,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1282.5481
+  dps: 1282.62865
   tps: 1035.33935
   hps: 11.91653
  }
@@ -989,22 +989,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3547.01502
-  tps: 3298.54314
+  dps: 3556.58823
+  tps: 3298.53345
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4025.65652
-  tps: 4308.66737
+  dps: 4032.92611
+  tps: 4306.2449
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3524.3305
-  tps: 3271.449
+  dps: 3529.86299
+  tps: 3271.66782
  }
 }
 dps_results: {
@@ -1017,14 +1017,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1785.72848
-  tps: 2020.90012
+  dps: 1786.75711
+  tps: 2021.3947
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-NightElf-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1919.83885
+  dps: 1919.41795
   tps: 1773.72973
  }
 }
@@ -1038,50 +1038,50 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4041.45436
-  tps: 4332.75004
+  dps: 4046.09639
+  tps: 4332.67808
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3523.37395
-  tps: 3271.10927
+  dps: 3526.82843
+  tps: 3270.73843
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3427.66569
-  tps: 3037.7152
+  dps: 3415.55328
+  tps: 3036.74389
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1783.75801
-  tps: 2018.5536
+  dps: 1785.66409
+  tps: 2020.02369
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 1909.13692
+  dps: 1909.61989
   tps: 1763.98751
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-Settings-Troll-phase_4-Basic-phase_4-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 1873.68418
+  dps: 1872.56767
   tps: 1647.6211
  }
 }
 dps_results: {
  key: "TestShadow-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3523.37395
-  tps: 3271.10927
+  dps: 3526.82843
+  tps: 3270.73843
  }
 }
 dps_results: {
@@ -1157,22 +1157,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 3945.19843
-  tps: 3653.74556
+  dps: 3955.78337
+  tps: 3653.77039
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4211.53964
-  tps: 4438.67622
+  dps: 4219.1094
+  tps: 4437.66869
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3921.79153
-  tps: 3628.46179
+  dps: 3929.18667
+  tps: 3628.70241
  }
 }
 dps_results: {
@@ -1206,15 +1206,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 5067.92051
-  tps: 5151.60349
+  dps: 5079.22126
+  tps: 5152.90897
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-NightElf-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3982.5518
-  tps: 3688.81825
+  dps: 3989.27161
+  tps: 3689.0677
  }
 }
 dps_results: {
@@ -1248,182 +1248,182 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4191.63089
-  tps: 4434.41766
+  dps: 4199.9236
+  tps: 4433.94073
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3915.01541
-  tps: 3622.97849
+  dps: 3925.29434
+  tps: 3623.02524
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3715.83555
-  tps: 3259.95248
+  dps: 3711.65024
+  tps: 3260.33325
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2015.91863
-  tps: 2247.46919
+  dps: 2016.75405
+  tps: 2248.70151
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2097.36676
+  dps: 2099.63573
   tps: 1925.88682
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t1-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 2027.1705
+  dps: 2023.81532
   tps: 1764.882
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 5038.15139
-  tps: 5134.62826
+  dps: 5055.00191
+  tps: 5138.52228
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3979.9537
-  tps: 3686.76236
+  dps: 3990.31985
+  tps: 3687.12373
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3813.86194
+  dps: 3806.91166
   tps: 3357.80414
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2665.58727
-  tps: 2909.77889
+  dps: 2663.74489
+  tps: 2907.26695
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2219.24117
+  dps: 2220.63565
   tps: 2045.06124
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-Settings-Troll-phase_5_t2-Basic-phase_5-NoBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 2147.23735
+  dps: 2142.13768
   tps: 1880.07279
  }
 }
 dps_results: {
  key: "TestShadow-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3915.01541
-  tps: 3622.97849
+  dps: 3925.29434
+  tps: 3623.02524
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-BenevolentProphet'sVestments"
  value: {
-  dps: 2919.56423
-  tps: 2778.24759
+  dps: 2919.08085
+  tps: 2778.00229
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1601.20431
-  tps: 1509.49927
+  dps: 1601.20502
+  tps: 1509.19836
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-BloodGuard'sSatin"
  value: {
-  dps: 1484.12979
-  tps: 1399.76923
+  dps: 1484.09966
+  tps: 1399.4857
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1593.71944
-  tps: 1502.44295
+  dps: 1593.72022
+  tps: 1502.14353
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-EmeraldWovenGarb"
  value: {
-  dps: 1483.26106
-  tps: 1399.02618
+  dps: 1483.23093
+  tps: 1398.7429
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 1128.81557
-  tps: 1057.56411
+  dps: 1128.84174
+  tps: 1057.3393
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1601.20431
-  tps: 1509.49927
+  dps: 1601.20502
+  tps: 1509.19836
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-KnightLieutenant'sSatin"
  value: {
-  dps: 1484.12979
-  tps: 1399.76923
+  dps: 1484.09966
+  tps: 1399.4857
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 3079.95407
-  tps: 2929.66274
+  dps: 3079.29724
+  tps: 2929.31168
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-AllItems-VestmentsoftheVirtuous"
  value: {
-  dps: 1122.17865
-  tps: 1051.98678
+  dps: 1122.22118
+  tps: 1051.76683
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Average-Default"
  value: {
-  dps: 5437.51102
-  tps: 5070.70229
+  dps: 5451.5681
+  tps: 5071.84574
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-NightElf-phase_6-Basic-phase_6-FullBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 5410.68905
+  dps: 5422.63625
   tps: 5558.98875
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-NightElf-phase_6-Basic-phase_6-FullBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 5410.68905
+  dps: 5422.63625
   tps: 5042.58554
  }
 }
@@ -1458,49 +1458,49 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-Troll-phase_6-Basic-phase_6-FullBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 5408.6693
-  tps: 5568.4971
+  dps: 5422.74178
+  tps: 5567.77463
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-Troll-phase_6-Basic-phase_6-FullBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 5408.6693
-  tps: 5041.21304
+  dps: 5422.74178
+  tps: 5043.41862
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-Troll-phase_6-Basic-phase_6-FullBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 5196.23025
-  tps: 4635.03042
+  dps: 5206.96361
+  tps: 4646.05829
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-Troll-phase_6-Basic-phase_6-NoBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 3015.71327
-  tps: 3331.08089
+  dps: 3015.94785
+  tps: 3331.96147
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-Troll-phase_6-Basic-phase_6-NoBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 3015.71327
-  tps: 2793.75046
+  dps: 3015.94785
+  tps: 2793.79449
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-Settings-Troll-phase_6-Basic-phase_6-NoBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 2960.97112
-  tps: 2621.23501
+  dps: 2960.81351
+  tps: 2621.45516
  }
 }
 dps_results: {
  key: "TestShadow-Phase6-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5408.6693
-  tps: 5041.21304
+  dps: 5422.74178
+  tps: 5043.41862
  }
 }

--- a/sim/priest/shadowfiend.go
+++ b/sim/priest/shadowfiend.go
@@ -166,6 +166,11 @@ func (priest *Priest) NewShadowfiend() *Shadowfiend {
 		AutoSwingMelee: true,
 	})
 
+	shadowfiend.ApplyOnPetEnable(func(sim *core.Simulation) {
+		// Priest pets only inherit the owner's cast speed
+		shadowfiend.EnableDynamicCastSpeedInheritance(sim)
+	})
+
 	priest.AddPet(shadowfiend)
 
 	return shadowfiend

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1537,15 +1537,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-Settings-Troll-phase_4_dw-Sync Auto-phase_4-NoBuffs-P4-Consumes WF/WF-LongMultiTarget"
  value: {
-  dps: 2346.08726
-  tps: 2091.65566
+  dps: 2344.06917
+  tps: 2090.97452
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-Settings-Troll-phase_4_dw-Sync Auto-phase_4-NoBuffs-P4-Consumes WF/WF-LongSingleTarget"
  value: {
-  dps: 1609.39541
-  tps: 1142.51474
+  dps: 1609.40025
+  tps: 1142.9795
  }
 }
 dps_results: {
@@ -1582,15 +1582,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-Settings-Troll-phase_4_dw-Sync Delay OH-phase_4-NoBuffs-P4-Consumes WF/WF-LongMultiTarget"
  value: {
-  dps: 2368.26933
-  tps: 2104.09474
+  dps: 2371.33392
+  tps: 2105.93221
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase4-Lvl60-Settings-Troll-phase_4_dw-Sync Delay OH-phase_4-NoBuffs-P4-Consumes WF/WF-LongSingleTarget"
  value: {
-  dps: 1637.16641
-  tps: 1161.09895
+  dps: 1637.67153
+  tps: 1161.48596
  }
 }
 dps_results: {
@@ -1985,8 +1985,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase5-Lvl60-Settings-Troll-phase_5_dw-Sync Auto-phase_5-NoBuffs-P4-Consumes WF/WF-LongMultiTarget"
  value: {
-  dps: 2736.73101
-  tps: 2443.74409
+  dps: 2737.13834
+  tps: 2443.87086
  }
 }
 dps_results: {
@@ -2433,15 +2433,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase6-Lvl60-Settings-Troll-phase_6_dw-Sync Auto-phase_6-NoBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 2977.8607
-  tps: 2565.417
+  dps: 2978.14773
+  tps: 2565.73785
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase6-Lvl60-Settings-Troll-phase_6_dw-Sync Auto-phase_6-NoBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 2158.8815
-  tps: 1514.06587
+  dps: 2159.28202
+  tps: 1513.87874
  }
 }
 dps_results: {
@@ -2478,15 +2478,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Phase6-Lvl60-Settings-Troll-phase_6_dw-Sync Delay OH-phase_6-NoBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 2968.15347
-  tps: 2558.87427
+  dps: 2968.61507
+  tps: 2562.18779
  }
 }
 dps_results: {
  key: "TestEnhancement-Phase6-Lvl60-Settings-Troll-phase_6_dw-Sync Delay OH-phase_6-NoBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 2165.15477
-  tps: 1517.62636
+  dps: 2166.44045
+  tps: 1518.73749
  }
 }
 dps_results: {

--- a/sim/shaman/spirit_wolves.go
+++ b/sim/shaman/spirit_wolves.go
@@ -48,7 +48,8 @@ func (shaman *Shaman) NewSpiritWolves() *SpiritWolves {
 	wolves.AddStatDependency(stats.Agility, stats.AttackPower, 0.2)
 
 	wolves.ApplyOnPetEnable(func(sim *core.Simulation) {
-		wolves.EnableDynamicAttackSpeed(sim)
+		// Shaman pets inherit the highest of the owner's melee and cast speed
+		wolves.EnableDynamicAttackSpeedInheritance(sim)
 	})
 
 	// Warrior crit scaling

--- a/sim/shaman/warden/TestWardenShaman.results
+++ b/sim/shaman/warden/TestWardenShaman.results
@@ -241,15 +241,15 @@ dps_results: {
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-Settings-Troll-phase_4_enh_tank-Default-phase_4_enh_tank-NoBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 1176.66905
-  tps: 2708.38474
+  dps: 1175.84557
+  tps: 2710.5505
  }
 }
 dps_results: {
  key: "TestWardenShaman-Phase4-Lvl60-Settings-Troll-phase_4_enh_tank-Default-phase_4_enh_tank-NoBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 554.8214
-  tps: 836.96732
+  dps: 553.99344
+  tps: 836.22295
  }
 }
 dps_results: {

--- a/sim/warlock/dps/TestAffliction.results
+++ b/sim/warlock/dps/TestAffliction.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.33205
+  weights: -0.11218
   weights: 0
-  weights: 0.86775
-  weights: 0
-  weights: 0
+  weights: 0.21741
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.73935
-  weights: 2.07457
+  weights: 0
+  weights: 0
+  weights: 2.5316
+  weights: 1.96592
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.70993
+  weights: -0.19645
   weights: 0
-  weights: 2.37589
-  weights: 0
-  weights: 0
+  weights: 1.69015
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 14.67163
-  weights: 26.13997
+  weights: 0
+  weights: 0
+  weights: 12.28883
+  weights: 24.30545
   weights: 0
   weights: 0
   weights: 0
@@ -396,18 +396,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.90815
+  weights: 2.99709
   weights: 0
-  weights: 3.53413
-  weights: 0
-  weights: 0
+  weights: 4.00519
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 27.46767
+  weights: 0
+  weights: 0
+  weights: 26.11808
   weights: 0
   weights: 0
   weights: 0
@@ -445,18 +445,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 2.70748
+  weights: -2.07165
   weights: 0
-  weights: 2.91221
-  weights: 0
-  weights: 0
+  weights: 4.01553
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 33.80653
-  weights: 22.06194
+  weights: 0
+  weights: 0
+  weights: 42.42862
+  weights: 21.03499
   weights: 0
   weights: 0
   weights: 0
@@ -491,41 +491,41 @@ stat_weights_results: {
 dps_results: {
  key: "TestAffliction-Phase2-Lvl40-AllItems-DeathmistRaiment"
  value: {
-  dps: 211.00812
-  tps: 164.09196
-  hps: 105.54882
+  dps: 205.16844
+  tps: 163.67752
+  hps: 105.27057
  }
 }
 dps_results: {
  key: "TestAffliction-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 677.69754
-  tps: 647.39003
-  hps: 244.44219
+  dps: 670.73148
+  tps: 645.9979
+  hps: 243.8318
  }
 }
 dps_results: {
  key: "TestAffliction-Phase2-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 678.31076
-  tps: 1326.1689
-  hps: 245.86764
+  dps: 666.32951
+  tps: 1318.45459
+  hps: 244.35161
  }
 }
 dps_results: {
  key: "TestAffliction-Phase2-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 678.31076
-  tps: 649.16533
-  hps: 245.86764
+  dps: 666.32951
+  tps: 641.47109
+  hps: 244.35161
  }
 }
 dps_results: {
  key: "TestAffliction-Phase2-Lvl40-Settings-Orc-shadow-Affliction Warlock-affliction-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 647.09136
-  tps: 607.76837
-  hps: 204.6234
+  dps: 647.20994
+  tps: 611.09795
+  hps: 203.64578
  }
 }
 dps_results: {
@@ -555,9 +555,9 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 678.31076
-  tps: 649.16533
-  hps: 245.86764
+  dps: 666.32951
+  tps: 641.47109
+  hps: 244.35161
  }
 }
 dps_results: {
@@ -635,105 +635,105 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 986.94816
-  tps: 743.15637
-  hps: 247.73837
+  dps: 971.58524
+  tps: 756.32563
+  hps: 250.68546
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 670.46474
-  tps: 428.92938
-  hps: 257.23701
+  dps: 651.74927
+  tps: 439.08027
+  hps: 258.69906
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 987.64953
-  tps: 744.14371
-  hps: 247.91342
+  dps: 969.85094
+  tps: 755.44288
+  hps: 250.35325
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 3688.13587
-  tps: 3456.59233
-  hps: 746.15675
+  dps: 3684.00078
+  tps: 3485.66796
+  hps: 757.00916
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 664.64835
-  tps: 433.56794
-  hps: 255.72609
+  dps: 636.97432
+  tps: 433.60673
+  hps: 258.53434
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 3669.80937
-  tps: 3442.55731
-  hps: 759.02323
+  dps: 3616.67221
+  tps: 3421.59251
+  hps: 756.90081
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 986.94816
-  tps: 743.15637
-  hps: 247.73837
+  dps: 971.58524
+  tps: 756.32563
+  hps: 250.68546
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1795.15688
-  tps: 1536.33213
-  hps: 365.16153
+  dps: 1742.74298
+  tps: 1515.01958
+  hps: 369.41423
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1760.29199
-  tps: 1498.90543
-  hps: 363.20051
+  dps: 1730.25223
+  tps: 1500.34482
+  hps: 368.23007
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3692.83567
-  tps: 3462.11139
-  hps: 755.21891
+  dps: 3657.48756
+  tps: 3459.86505
+  hps: 755.09917
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3685.13196
-  tps: 4860.04104
-  hps: 757.19649
+  dps: 3621.69155
+  tps: 4827.9843
+  hps: 759.95107
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3685.13196
-  tps: 3456.5664
-  hps: 757.19649
+  dps: 3621.69155
+  tps: 3424.66127
+  hps: 759.95107
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3480.0818
-  tps: 3217.77344
-  hps: 713.82342
+  dps: 3477.26199
+  tps: 3249.45258
+  hps: 710.63384
  }
 }
 dps_results: {
@@ -763,121 +763,121 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3685.13196
-  tps: 3456.5664
-  hps: 757.19649
+  dps: 3621.69155
+  tps: 3424.66127
+  hps: 759.95107
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1077.79119
-  tps: 735.12655
-  hps: 249.91937
+  dps: 1064.85647
+  tps: 745.49127
+  hps: 250.7903
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 704.33026
-  tps: 432.68036
-  hps: 241.55144
+  dps: 685.2798
+  tps: 436.93618
+  hps: 241.14543
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1078.69966
-  tps: 736.2918
-  hps: 248.7995
+  dps: 1061.09504
+  tps: 742.8117
+  hps: 250.94912
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 3984.99173
-  tps: 3031.50763
-  hps: 796.75093
+  dps: 3922.94196
+  tps: 3010.8452
+  hps: 789.58297
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 698.38069
-  tps: 436.676
-  hps: 235.92004
+  dps: 676.73026
+  tps: 439.53503
+  hps: 236.05049
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 4120.73044
-  tps: 3136.9652
-  hps: 844.88193
+  dps: 4086.49697
+  tps: 3140.26278
+  hps: 829.64715
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1077.79119
-  tps: 735.12655
-  hps: 249.91937
+  dps: 1064.85647
+  tps: 745.49127
+  hps: 250.7903
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1967.83553
-  tps: 1443.52255
-  hps: 351.62604
+  dps: 1913.57689
+  tps: 1422.32428
+  hps: 356.93301
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1938.67052
-  tps: 1423.34946
-  hps: 362.29442
+  dps: 1902.28043
+  tps: 1415.99573
+  hps: 362.68626
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 3982.47214
-  tps: 3031.35354
-  hps: 796.75093
+  dps: 3920.90761
+  tps: 3010.68986
+  hps: 789.58297
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4170.41106
-  tps: 3171.86391
-  hps: 841.29847
+  dps: 4135.58047
+  tps: 3174.62325
+  hps: 841.93478
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 4159.40929
-  tps: 4157.70855
-  hps: 844.24279
+  dps: 4107.48522
+  tps: 4146.95396
+  hps: 827.18311
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 4159.40929
-  tps: 3167.56699
-  hps: 844.24279
+  dps: 4107.48522
+  tps: 3155.95018
+  hps: 827.18311
  }
 }
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 4180.90388
-  tps: 3314.50845
-  hps: 793.73002
+  dps: 4144.35398
+  tps: 3317.12835
+  hps: 796.71248
  }
 }
 dps_results: {
@@ -907,121 +907,121 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4159.40929
-  tps: 3167.56699
-  hps: 844.24279
+  dps: 4107.48522
+  tps: 3155.95018
+  hps: 827.18311
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 792.3914
-  tps: 699.79321
-  hps: 225.53141
+  dps: 784.75729
+  tps: 700.71628
+  hps: 223.37744
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 357.84146
-  tps: 264.73313
-  hps: 232.14767
+  dps: 349.29065
+  tps: 262.18121
+  hps: 230.92592
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 790.2903
-  tps: 698.55725
-  hps: 224.16838
+  dps: 774.23208
+  tps: 694.04414
+  hps: 224.13409
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 4156.97969
-  tps: 3995.52654
-  hps: 965.14668
+  dps: 4154.21289
+  tps: 4007.98978
+  hps: 951.6409
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 352.05496
-  tps: 271.64652
-  hps: 227.7777
+  dps: 342.32886
+  tps: 273.59917
+  hps: 227.5924
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 4182.91097
-  tps: 4018.03096
-  hps: 973.33567
+  dps: 4212.44224
+  tps: 4061.03901
+  hps: 978.34361
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 792.3914
-  tps: 699.79321
-  hps: 225.53141
+  dps: 784.75729
+  tps: 700.71628
+  hps: 223.37744
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1128.07695
-  tps: 1022.29035
-  hps: 283.3948
+  dps: 1121.10108
+  tps: 1022.82931
+  hps: 280.07303
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1115.37078
-  tps: 1012.74351
-  hps: 287.39413
+  dps: 1099.58442
+  tps: 1008.46441
+  hps: 280.72367
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 4191.38473
-  tps: 4030.50772
-  hps: 977.03324
+  dps: 4162.83051
+  tps: 4019.42477
+  hps: 946.01464
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-Average-Default"
  value: {
-  dps: 4253.70677
-  tps: 4090.60769
-  hps: 973.10732
+  dps: 4240.28537
+  tps: 4092.93272
+  hps: 973.35796
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 4230.10071
-  tps: 5385.94142
-  hps: 962.15168
+  dps: 4274.0024
+  tps: 5445.41869
+  hps: 978.39905
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 4230.10071
-  tps: 4067.52762
-  hps: 962.15168
+  dps: 4274.0024
+  tps: 4123.43755
+  hps: 978.39905
  }
 }
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-Settings-Orc-affliction-Affliction Warlock-affliction-FullBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 4006.21702
-  tps: 3764.82212
-  hps: 867.03855
+  dps: 4002.15671
+  tps: 3783.10887
+  hps: 867.69645
  }
 }
 dps_results: {
@@ -1051,8 +1051,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase6-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4230.10071
-  tps: 4067.52762
-  hps: 962.15168
+  dps: 4274.0024
+  tps: 4123.43755
+  hps: 978.39905
  }
 }

--- a/sim/warlock/dps/TestDemonology.results
+++ b/sim/warlock/dps/TestDemonology.results
@@ -200,18 +200,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.223
+  weights: -0.60676
   weights: 0
-  weights: 2.26935
-  weights: 0
-  weights: 0
+  weights: 3.01266
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 23.73488
+  weights: 0
+  weights: 0
+  weights: 22.49366
   weights: 0
   weights: 0
   weights: 0
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -1.496
+  weights: 3.23557
   weights: 0
-  weights: 2.42425
-  weights: 0
-  weights: 0
+  weights: 3.52515
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 23.54802
+  weights: 0
+  weights: 0
+  weights: 23.22396
   weights: 0
   weights: 0
   weights: 0
@@ -358,8 +358,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 2630.32827
-  tps: 1047.52674
+  dps: 2490.17904
+  tps: 1042.81942
  }
 }
 dps_results: {
@@ -372,15 +372,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 2627.96199
-  tps: 1046.47449
+  dps: 2485.47576
+  tps: 1041.0194
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 4685.88981
-  tps: 2594.15068
+  dps: 4514.1813
+  tps: 2565.43393
  }
 }
 dps_results: {
@@ -393,57 +393,57 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 2630.32827
-  tps: 1047.52674
+  dps: 2490.17904
+  tps: 1042.81942
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 3352.77841
-  tps: 1459.54273
+  dps: 3191.63527
+  tps: 1456.46443
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 3316.23047
-  tps: 1449.45585
+  dps: 3146.37137
+  tps: 1440.4161
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 4685.88981
-  tps: 2594.15068
+  dps: 4514.1813
+  tps: 2565.43393
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4950.77478
-  tps: 2662.07868
+  dps: 4779.50957
+  tps: 2649.73203
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-Settings-Orc-demonology-Demonology Warlock-demonology-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 5476.49189
-  tps: 3548.24225
+  dps: 5284.49092
+  tps: 3510.45044
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-Settings-Orc-demonology-Demonology Warlock-demonology-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 4946.09718
-  tps: 2650.21986
+  dps: 4761.06978
+  tps: 2630.92014
  }
 }
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-Settings-Orc-demonology-Demonology Warlock-demonology-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 5591.75684
-  tps: 2819.69417
+  dps: 5411.95997
+  tps: 2812.9348
  }
 }
 dps_results: {
@@ -470,15 +470,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4946.09718
-  tps: 2650.21986
+  dps: 4761.06978
+  tps: 2630.92014
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 2415.36786
-  tps: 1322.46149
+  dps: 2308.39421
+  tps: 1324.91565
  }
 }
 dps_results: {
@@ -491,16 +491,16 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 2412.65551
-  tps: 1320.74722
+  dps: 2301.78626
+  tps: 1318.4426
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 4737.06768
-  tps: 3581.41779
-  hps: 944.23175
+  dps: 4575.42083
+  tps: 3526.12342
+  hps: 932.75348
  }
 }
 dps_results: {
@@ -513,62 +513,62 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 2415.36786
-  tps: 1322.46149
+  dps: 2308.39421
+  tps: 1324.91565
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 3035.67814
-  tps: 1884.63302
+  dps: 2899.14041
+  tps: 1868.06872
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 2992.56379
-  tps: 1860.07476
+  dps: 2878.75467
+  tps: 1859.5913
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 4727.93545
-  tps: 3574.37661
-  hps: 934.9159
+  dps: 4588.10496
+  tps: 3540.57592
+  hps: 934.97938
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-Average-Default"
  value: {
-  dps: 4916.35101
-  tps: 3680.1816
-  hps: 943.79282
+  dps: 4782.03513
+  tps: 3662.38284
+  hps: 941.139
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-Settings-Orc-demonology-Demonology Warlock-demonology-FullBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 5258.47595
-  tps: 4999.8664
-  hps: 951.69804
+  dps: 5150.77264
+  tps: 4993.99384
+  hps: 956.446
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-Settings-Orc-demonology-Demonology Warlock-demonology-FullBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 4890.36063
-  tps: 3647.98868
-  hps: 956.00269
+  dps: 4755.36978
+  tps: 3633.00302
+  hps: 943.23212
  }
 }
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-Settings-Orc-demonology-Demonology Warlock-demonology-FullBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 5258.33525
-  tps: 3686.33297
-  hps: 843.71918
+  dps: 5087.51652
+  tps: 3645.53168
+  hps: 828.16641
  }
 }
 dps_results: {
@@ -598,8 +598,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase6-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4890.36063
-  tps: 3647.98868
-  hps: 956.00269
+  dps: 4755.36978
+  tps: 3633.00302
+  hps: 943.23212
  }
 }

--- a/sim/warlock/dps/TestDestruction.results
+++ b/sim/warlock/dps/TestDestruction.results
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.38829
+  weights: 0.90596
   weights: 0
-  weights: 0.80116
-  weights: 0
-  weights: 0
+  weights: 1.39655
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.53814
-  weights: 5.94564
+  weights: 0
+  weights: 0
+  weights: 6.13822
+  weights: 6.07612
   weights: 0
   weights: 0
   weights: 0
@@ -445,18 +445,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.679
+  weights: 0.42845
   weights: 0
-  weights: 1.99875
-  weights: 0
-  weights: 0
+  weights: 0.95453
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 22.22906
+  weights: 0
+  weights: 0
+  weights: 22.28147
   weights: 0
   weights: 0
   weights: 0
@@ -494,18 +494,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -2.32697
+  weights: -0.88296
   weights: 0
-  weights: 0.18271
-  weights: 0
-  weights: 0
+  weights: 2.03937
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 26.33258
+  weights: 0
+  weights: 0
+  weights: 26.38447
   weights: 0
   weights: 0
   weights: 0
@@ -543,18 +543,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -3.21285
+  weights: 4.46972
   weights: 0
-  weights: 4.86326
-  weights: 0
-  weights: 0
+  weights: 6.507
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.17924
-  weights: 34.75731
+  weights: 0
+  weights: 0
+  weights: 0.07559
+  weights: 33.00134
   weights: 0
   weights: 0
   weights: 0
@@ -652,36 +652,36 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-AllItems-DeathmistRaiment"
  value: {
-  dps: 119.50322
-  tps: 63.16873
+  dps: 111.5936
+  tps: 64.12061
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 796.36459
-  tps: 697.42609
+  dps: 792.6509
+  tps: 697.47729
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 786.75981
-  tps: 1025.07067
+  dps: 789.55475
+  tps: 1032.25613
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 786.75981
-  tps: 687.78619
+  dps: 789.55475
+  tps: 695.1284
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Settings-Orc-fire.imp-Destruction Warlock-fire.imp-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 852.24581
-  tps: 742.26325
+  dps: 840.7862
+  tps: 740.80946
  }
 }
 dps_results: {
@@ -708,8 +708,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 786.75981
-  tps: 687.78619
+  dps: 789.55475
+  tps: 695.1284
  }
 }
 dps_results: {
@@ -778,99 +778,99 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 2032.1735
-  tps: 1752.14135
+  dps: 2019.20976
+  tps: 1775.76267
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 549.25503
-  tps: 244.17264
+  dps: 516.57073
+  tps: 245.27658
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 2037.61557
-  tps: 1760.02443
+  dps: 2007.52122
+  tps: 1766.23282
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 3815.17744
-  tps: 3221.82135
+  dps: 3635.52836
+  tps: 3183.86592
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 535.56325
-  tps: 244.7044
+  dps: 505.22127
+  tps: 246.04901
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 3880.30487
-  tps: 3270.60876
+  dps: 3761.67454
+  tps: 3301.27239
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 2032.1735
-  tps: 1752.14135
+  dps: 2019.20976
+  tps: 1775.76267
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 2917.4802
-  tps: 2485.72518
+  dps: 2830.35999
+  tps: 2514.8264
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 2859.34212
-  tps: 2447.38
+  dps: 2751.62263
+  tps: 2447.72011
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 3787.15754
-  tps: 3206.58924
+  dps: 3676.36715
+  tps: 3231.17673
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 3941.8097
-  tps: 3330.31982
+  dps: 3796.2235
+  tps: 3332.25074
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 3900.88906
-  tps: 4337.04727
+  dps: 3776.41518
+  tps: 4350.62157
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 3900.88906
-  tps: 3295.50438
+  dps: 3776.41518
+  tps: 3313.92672
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 3961.52654
-  tps: 3449.60259
+  dps: 3850.2393
+  tps: 3410.725
  }
 }
 dps_results: {
@@ -897,106 +897,106 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 3900.88906
-  tps: 3295.50438
+  dps: 3776.41518
+  tps: 3313.92672
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 2056.26441
-  tps: 1733.0933
+  dps: 2024.15187
+  tps: 1733.88764
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 780.46389
-  tps: 492.85859
+  dps: 782.49534
+  tps: 504.15343
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 2071.7663
-  tps: 1749.53958
+  dps: 2028.22645
+  tps: 1736.01238
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 4482.15793
-  tps: 3607.33458
+  dps: 4131.21094
+  tps: 3578.47317
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 776.01217
-  tps: 502.27895
+  dps: 749.02882
+  tps: 494.12188
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 4573.72096
-  tps: 3735.6514
+  dps: 4259.7957
+  tps: 3705.25178
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 2056.26441
-  tps: 1733.0933
+  dps: 2024.15187
+  tps: 1733.88764
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 3110.26051
-  tps: 2576.36791
+  dps: 2941.43348
+  tps: 2563.95115
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 3084.23154
-  tps: 2549.8466
+  dps: 2912.90773
+  tps: 2542.39722
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 4412.10932
-  tps: 3574.83639
+  dps: 4139.06918
+  tps: 3599.31325
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-Average-Default"
  value: {
-  dps: 4611.80106
-  tps: 3767.25395
+  dps: 4322.42927
+  tps: 3764.15325
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P5-Consumes-LongMultiTarget"
  value: {
-  dps: 4603.02747
-  tps: 4749.28072
+  dps: 4293.26253
+  tps: 4726.53645
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P5-Consumes-LongSingleTarget"
  value: {
-  dps: 4603.02747
-  tps: 3756.10688
+  dps: 4293.26253
+  tps: 3734.44886
  }
 }
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P5-Consumes-ShortSingleTarget"
  value: {
-  dps: 4739.00673
-  tps: 4078.56941
+  dps: 4511.99588
+  tps: 3966.28075
  }
 }
 dps_results: {
@@ -1023,106 +1023,106 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase5-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 4603.02747
-  tps: 3756.10688
+  dps: 4293.26253
+  tps: 3734.44886
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 2100.69678
-  tps: 1748.36725
+  dps: 2084.98973
+  tps: 1755.13364
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 490.78776
-  tps: 226.27504
+  dps: 483.96587
+  tps: 224.04655
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 2100.71662
-  tps: 1746.66934
+  dps: 2079.84092
+  tps: 1751.00205
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 5503.31347
-  tps: 4560.07762
+  dps: 5289.95517
+  tps: 4564.06349
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 473.04127
-  tps: 222.92664
+  dps: 450.4084
+  tps: 226.18732
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 5503.77308
-  tps: 4571.67617
+  dps: 5257.68076
+  tps: 4540.76889
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 2100.69678
-  tps: 1748.36725
+  dps: 2084.98973
+  tps: 1755.13364
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 3357.15984
-  tps: 2790.17243
+  dps: 3315.47776
+  tps: 2855.27
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 3343.82365
-  tps: 2782.58604
+  dps: 3227.36265
+  tps: 2771.45022
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 5500.03668
-  tps: 4575.65453
+  dps: 5269.63251
+  tps: 4549.8866
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-Average-Default"
  value: {
-  dps: 5570.49154
-  tps: 4632.58784
+  dps: 5359.35288
+  tps: 4632.44351
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P6-Consumes-LongMultiTarget"
  value: {
-  dps: 5522.78336
-  tps: 5527.63721
+  dps: 5292.07497
+  tps: 5499.29494
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P6-Consumes-LongSingleTarget"
  value: {
-  dps: 5522.78336
-  tps: 4598.00114
+  dps: 5292.07497
+  tps: 4572.44436
  }
 }
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-Settings-Orc-destruction-Destruction Warlock-destruction-FullBuffs-P6-Consumes-ShortSingleTarget"
  value: {
-  dps: 5980.571
-  tps: 5106.34504
+  dps: 5846.60454
+  tps: 5031.4093
  }
 }
 dps_results: {
@@ -1149,7 +1149,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase6-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 5522.78336
-  tps: 4598.00114
+  dps: 5292.07497
+  tps: 4572.44436
  }
 }

--- a/sim/warlock/pet.go
+++ b/sim/warlock/pet.go
@@ -127,7 +127,8 @@ func (warlock *Warlock) makePet(cfg PetConfig, enabledOnStart bool) *WarlockPet 
 	}
 
 	wp.ApplyOnPetEnable(func(sim *core.Simulation) {
-		wp.EnableDynamicAttackSpeed(sim)
+		// Warlock pets only inherit the owner's cast speed
+		wp.EnableDynamicCastSpeedInheritance(sim)
 	})
 
 	// Having either the Fire or Shadow ring rune grants the pet 6% spell hit, 4.8% physical hit, and 0.5% expertise

--- a/sim/warlock/tank/TestAffliction.results
+++ b/sim/warlock/tank/TestAffliction.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.23231
+  weights: 0.30236
   weights: 0
-  weights: 1.1305
-  weights: 0
-  weights: 0
+  weights: 1.11411
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 9.68916
-  weights: 11.93938
+  weights: 0
+  weights: 0
+  weights: 9.92084
+  weights: 11.33017
   weights: 0
   weights: 0
   weights: 0
@@ -271,114 +271,114 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1487.20757
-  tps: 1655.0832
-  hps: 6.8015
+  dps: 1448.04064
+  tps: 1645.4881
+  hps: 6.82183
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 1330.15679
-  tps: 1450.82009
-  hps: 6.1915
+  dps: 1293.29056
+  tps: 1443.22107
+  hps: 6.24233
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1479.42951
-  tps: 1640.86342
-  hps: 6.82183
+  dps: 1451.80607
+  tps: 1646.51042
+  hps: 6.8625
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2026.03226
-  tps: 3928.56383
-  hps: 445.15374
+  dps: 1975.11946
+  tps: 3908.50329
+  hps: 445.41302
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 1281.45189
-  tps: 1390.7883
-  hps: 6.56767
+  dps: 1244.19841
+  tps: 1378.88158
+  hps: 6.57783
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 2006.10739
-  tps: 3905.1119
-  hps: 444.98709
+  dps: 1964.65869
+  tps: 3904.74775
+  hps: 438.09117
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1487.20757
-  tps: 1655.0832
-  hps: 6.8015
+  dps: 1448.04064
+  tps: 1645.4881
+  hps: 6.82183
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1666.48848
-  tps: 3236.99663
-  hps: 15.83967
+  dps: 1625.07239
+  tps: 3213.06391
+  hps: 15.78883
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1646.57043
-  tps: 3197.40315
+  dps: 1613.2416
+  tps: 3208.76985
   hps: 15.84983
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2023.57029
-  tps: 3928.56383
-  hps: 445.15374
+  dps: 1973.25544
+  tps: 3908.50329
+  hps: 445.41302
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2071.65469
-  tps: 4016.82456
-  dtps: 399.54674
-  hps: 478.02532
+  dps: 2032.58703
+  tps: 4015.33702
+  dtps: 399.00981
+  hps: 477.37596
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Settings-Orc-p4_destro_aff_tank-Affliction Warlock-p4_destro_aff_tank-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4126.4075
-  tps: 12222.52834
-  hps: 465.14022
+  dps: 4087.59769
+  tps: 12207.59114
+  hps: 474.17872
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Settings-Orc-p4_destro_aff_tank-Affliction Warlock-p4_destro_aff_tank-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2023.57029
-  tps: 3928.56383
-  hps: 445.15374
+  dps: 1973.25544
+  tps: 3908.50329
+  hps: 445.41302
  }
 }
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-Settings-Orc-p4_destro_aff_tank-Affliction Warlock-p4_destro_aff_tank-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 2057.04673
-  tps: 3988.5036
-  hps: 456.33242
+  dps: 1999.03412
+  tps: 3928.70617
+  hps: 453.03387
  }
 }
 dps_results: {
@@ -408,9 +408,9 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2029.90564
-  tps: 3936.81488
-  dtps: 425.90745
-  hps: 474.24511
+  dps: 1994.79248
+  tps: 3954.84408
+  dtps: 428.20465
+  hps: 471.69119
  }
 }

--- a/sim/warlock/tank/TestDemonology.results
+++ b/sim/warlock/tank/TestDemonology.results
@@ -151,18 +151,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.46033
+  weights: 0.4349
   weights: 0
-  weights: 1.09943
-  weights: 0
-  weights: 0
+  weights: 1.07689
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 15.09324
-  weights: 10.15815
+  weights: 0
+  weights: 0
+  weights: 16.40921
+  weights: 8.37339
   weights: 0
   weights: 0
   weights: 0
@@ -271,9 +271,9 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1252.52444
-  tps: 422.452
-  hps: 231.02779
+  dps: 1164.14907
+  tps: 422.96451
+  hps: 230.69013
  }
 }
 dps_results: {
@@ -287,17 +287,17 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1247.80275
-  tps: 419.1134
-  hps: 230.14525
+  dps: 1159.32029
+  tps: 420.32789
+  hps: 230.28552
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2305.61841
-  tps: 4542.76065
-  hps: 418.95856
+  dps: 2233.5074
+  tps: 4536.90365
+  hps: 416.63776
  }
 }
 dps_results: {
@@ -311,74 +311,74 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 2404.14257
-  tps: 4511.05095
-  hps: 412.11189
+  dps: 2302.87975
+  tps: 4492.58066
+  hps: 403.90798
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1252.52444
-  tps: 422.452
-  hps: 231.02779
+  dps: 1164.14907
+  tps: 422.96451
+  hps: 230.69013
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1339.27745
-  tps: 1351.34947
-  hps: 225.22469
+  dps: 1251.23166
+  tps: 1349.67805
+  hps: 226.12336
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1314.04877
-  tps: 1341.27694
-  hps: 226.03505
+  dps: 1231.95246
+  tps: 1329.01054
+  hps: 226.39441
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2305.61841
-  tps: 4542.76065
-  hps: 418.95856
+  dps: 2233.5074
+  tps: 4536.90365
+  hps: 416.63776
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2314.90449
-  tps: 4494.79397
-  dtps: 409.07491
-  hps: 440.2654
+  dps: 2230.56259
+  tps: 4494.04921
+  dtps: 408.95309
+  hps: 440.45923
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 2974.82072
-  tps: 9266.34017
-  hps: 433.77628
+  dps: 2886.64489
+  tps: 9237.88508
+  hps: 429.03289
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2305.61841
-  tps: 4542.76065
-  hps: 418.95856
+  dps: 2233.5074
+  tps: 4536.90365
+  hps: 416.63776
  }
 }
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-Settings-Orc-p4_demo_tank-Demonology Warlock-p4_demo_tank-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 2312.05863
-  tps: 4565.98501
-  hps: 432.52936
+  dps: 2230.56289
+  tps: 4564.48983
+  hps: 431.91936
  }
 }
 dps_results: {
@@ -408,9 +408,9 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2281.73268
-  tps: 4424.77029
-  dtps: 434.42128
-  hps: 442.61574
+  dps: 2197.07772
+  tps: 4408.7811
+  dtps: 428.84321
+  hps: 440.50779
  }
 }

--- a/sim/warlock/tank/TestDestruction.results
+++ b/sim/warlock/tank/TestDestruction.results
@@ -249,18 +249,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: -0.13615
+  weights: 0.05081
   weights: 0
-  weights: 0.59268
-  weights: 0
-  weights: 0
+  weights: 0.51327
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.35562
-  weights: 3.16233
+  weights: 0
+  weights: 0
+  weights: 5.38431
+  weights: 2.96193
   weights: 0
   weights: 0
   weights: 0
@@ -298,18 +298,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.38519
+  weights: -0.16702
   weights: 0
-  weights: 1.22367
-  weights: 0
-  weights: 0
+  weights: 0.54125
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 6.97874
+  weights: 0
+  weights: 0
+  weights: 7.08342
   weights: 0
   weights: 0
   weights: 0
@@ -347,18 +347,18 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 0.11864
+  weights: 0.28227
   weights: 0
-  weights: 1.16807
-  weights: 0
-  weights: 0
+  weights: 1.15531
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 11.73467
-  weights: 11.13194
+  weights: 0
+  weights: 0
+  weights: 9.21118
+  weights: 11.61439
   weights: 0
   weights: 0
   weights: 0
@@ -458,41 +458,41 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-AllItems-DeathmistRaiment"
  value: {
-  dps: 145.67456
-  tps: 87.19163
+  dps: 140.06507
+  tps: 88.21642
   hps: 10.64767
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Average-Default"
  value: {
-  dps: 465.45287
-  tps: 1270.14683
-  dtps: 920.50831
-  hps: 8.44917
+  dps: 457.85171
+  tps: 1267.2021
+  dtps: 920.53732
+  hps: 8.44876
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-P2-Consumes-LongMultiTarget"
  value: {
-  dps: 486.03666
-  tps: 1945.31615
+  dps: 480.04771
+  tps: 1945.18471
   hps: 8.67
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-P2-Consumes-LongSingleTarget"
  value: {
-  dps: 473.16441
-  tps: 1313.25617
+  dps: 465.41982
+  tps: 1308.6604
   hps: 8.67
  }
 }
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-Settings-Orc-p2.destro.tank-Destruction Warlock-p2.destro.tank-FullBuffs-P2-Consumes-ShortSingleTarget"
  value: {
-  dps: 484.57995
-  tps: 1338.96764
+  dps: 472.55526
+  tps: 1319.2248
   hps: 8.5
  }
 }
@@ -520,10 +520,10 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase2-Lvl40-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 453.4149
-  tps: 1236.50069
-  dtps: 945.73811
-  hps: 7.72367
+  dps: 448.72946
+  tps: 1244.22045
+  dtps: 945.00754
+  hps: 7.72933
  }
 }
 dps_results: {
@@ -537,180 +537,180 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Average-Default"
  value: {
-  dps: 1297.25164
-  tps: 2619.58511
-  dtps: 859.69881
-  hps: 277.1825
+  dps: 1295.43723
+  tps: 2618.44755
+  dtps: 859.87162
+  hps: 277.02374
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 2044.93546
-  tps: 5767.08735
-  hps: 282.93039
+  dps: 2031.02259
+  tps: 5730.86107
+  hps: 283.35357
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 1304.95204
-  tps: 2654.28402
-  hps: 281.95489
+  dps: 1292.78916
+  tps: 2621.88345
+  hps: 278.33429
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-FullBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 1297.17006
-  tps: 2601.44898
-  hps: 275.59784
+  dps: 1303.26655
+  tps: 2616.60082
+  hps: 276.31232
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-P3-Consumes-LongMultiTarget"
  value: {
-  dps: 1276.22134
-  tps: 4331.5536
-  hps: 159.937
+  dps: 1274.74053
+  tps: 4337.86232
+  hps: 160.1294
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-P3-Consumes-LongSingleTarget"
  value: {
-  dps: 735.04954
-  tps: 1485.99417
-  hps: 160.30629
+  dps: 736.87349
+  tps: 1490.14363
+  hps: 161.22194
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-Settings-Orc-p3.destro.tank-Destruction Warlock-p3.destro.tank-NoBuffs-P3-Consumes-ShortSingleTarget"
  value: {
-  dps: 723.20916
-  tps: 1480.71338
-  hps: 157.82981
+  dps: 727.23411
+  tps: 1479.12509
+  hps: 158.32239
  }
 }
 dps_results: {
  key: "TestDestruction-Phase3-Lvl50-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1288.07173
-  tps: 2603.90728
-  dtps: 881.42623
-  hps: 277.31759
+  dps: 1281.74267
+  tps: 2588.91171
+  dtps: 882.81029
+  hps: 277.09203
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-BloodGuard'sDreadweave"
  value: {
-  dps: 1564.46436
-  tps: 1838.1692
-  hps: 6.0085
+  dps: 1536.34198
+  tps: 1843.84712
+  hps: 6.039
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-DeathmistRaiment"
  value: {
-  dps: 1386.47232
-  tps: 1603.18372
-  hps: 5.49
+  dps: 1336.7905
+  tps: 1576.82149
+  hps: 5.46967
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-EmeraldEnchantedVestments"
  value: {
-  dps: 1552.49746
-  tps: 1821.28888
-  hps: 6.05933
+  dps: 1527.47437
+  tps: 1831.14345
+  hps: 6.0695
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-InfernalPactEssence-216509"
  value: {
-  dps: 2045.95537
-  tps: 4141.71146
-  hps: 420.29019
+  dps: 2006.49352
+  tps: 4152.87617
+  hps: 417.79058
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-IronweaveBattlesuit"
  value: {
-  dps: 1319.34144
-  tps: 1510.90851
-  hps: 5.7645
+  dps: 1288.47712
+  tps: 1513.21053
+  hps: 5.77467
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Kezan'sUnstoppableTaint-231346"
  value: {
-  dps: 2030.86866
-  tps: 4119.43589
-  hps: 409.79523
+  dps: 1980.07067
+  tps: 4084.50126
+  hps: 409.18349
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
  value: {
-  dps: 1564.46436
-  tps: 1838.1692
-  hps: 6.0085
+  dps: 1536.34198
+  tps: 1843.84712
+  hps: 6.039
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-MalevolentProphet'sVestments"
  value: {
-  dps: 1715.10237
-  tps: 3472.61804
-  hps: 15.75833
+  dps: 1675.09589
+  tps: 3478.47129
+  hps: 15.78883
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-NightmareProphet'sGarb"
  value: {
-  dps: 1694.66641
-  tps: 3463.25781
-  hps: 15.84983
+  dps: 1662.56219
+  tps: 3456.53565
+  hps: 15.83967
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-AllItems-ZilaGular-223214"
  value: {
-  dps: 2043.77175
-  tps: 4141.71146
-  hps: 420.29019
+  dps: 2004.41836
+  tps: 4152.87617
+  hps: 417.79058
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 2098.89729
-  tps: 4246.81723
-  dtps: 396.97296
-  hps: 448.2405
+  dps: 2062.55072
+  tps: 4253.12669
+  dtps: 398.24616
+  hps: 448.07149
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Settings-Orc-p4_destro_aff_tank-Destruction Warlock-p4_destro_aff_tank-FullBuffs-P4-Consumes-LongMultiTarget"
  value: {
-  dps: 4245.95975
-  tps: 12485.61959
-  hps: 437.17783
+  dps: 4205.32429
+  tps: 12449.06039
+  hps: 442.18821
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Settings-Orc-p4_destro_aff_tank-Destruction Warlock-p4_destro_aff_tank-FullBuffs-P4-Consumes-LongSingleTarget"
  value: {
-  dps: 2043.77175
-  tps: 4141.71146
-  hps: 420.29019
+  dps: 2004.41836
+  tps: 4152.87617
+  hps: 417.79058
  }
 }
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-Settings-Orc-p4_destro_aff_tank-Destruction Warlock-p4_destro_aff_tank-FullBuffs-P4-Consumes-ShortSingleTarget"
  value: {
-  dps: 2090.94645
-  tps: 4237.0089
-  hps: 425.66398
+  dps: 2034.76224
+  tps: 4188.82593
+  hps: 433.6479
  }
 }
 dps_results: {
@@ -740,9 +740,9 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 2050.44492
-  tps: 4143.15168
-  dtps: 425.41373
-  hps: 442.83801
+  dps: 2030.88681
+  tps: 4206.07131
+  dtps: 424.90798
+  hps: 442.70781
  }
 }


### PR DESCRIPTION
We updated class pet attack and cast speed scaling based on new information from the Classic team. The following rules apply:
- Hunter
  - All pets scale their Melee and Cast Speeds off of your Melee Speed
  - They also do not "double dip" from the 15% Melee Speed from Warchief's Blessing / Might of Stormwind
- Priest
  - Homunculi, Shadowfiend, and Eye of the Void scale their Melee and Castoff of your Cast Speed
- Shamans
  - Spirit Wolves scale their Melee Speed off of the higherof your Melee Attack and Cast Speeds
  - They also do not "double dip" from the 15% Melee Speed from Warchief's Blessing / Might of Stormwind
- Warlock
  - All pets scale their Melee and Cast Speeds off of your Cast Speed