### PR TITLE
Add: shadow_priest Phase 7 + 8

### DIFF
--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -292,6 +292,104 @@ character_stats_results: {
   final_stats: 0
  }
 }
+character_stats_results: {
+ key: "TestShadow-Phase7-Lvl60-CharacterStats-Default"
+ value: {
+  final_stats: 83.49
+  final_stats: 88.55
+  final_stats: 747.01412
+  final_stats: 490.82
+  final_stats: 285.89
+  final_stats: 829
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 553
+  final_stats: 53.25
+  final_stats: 0
+  final_stats: 54.04578
+  final_stats: 0
+  final_stats: 0
+  final_stats: 453.49
+  final_stats: 0
+  final_stats: 34
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 8458.3
+  final_stats: 0
+  final_stats: 0
+  final_stats: 986.1
+  final_stats: 380
+  final_stats: 0
+  final_stats: 5
+  final_stats: 0
+  final_stats: 3
+  final_stats: 5
+  final_stats: 0
+  final_stats: 9107.14125
+  final_stats: 27
+  final_stats: 60
+  final_stats: 27
+  final_stats: 42
+  final_stats: 80
+  final_stats: 384
+  final_stats: 132
+  final_stats: 71
+  final_stats: 0
+ }
+}
+character_stats_results: {
+ key: "TestShadow-Phase8-Lvl60-CharacterStats-Default"
+ value: {
+  final_stats: 83.49
+  final_stats: 88.55
+  final_stats: 815.09643
+  final_stats: 500.94
+  final_stats: 255.53
+  final_stats: 924
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 591
+  final_stats: 53.25
+  final_stats: 0
+  final_stats: 50.21579
+  final_stats: 0
+  final_stats: 0
+  final_stats: 453.49
+  final_stats: 0
+  final_stats: 30
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 8610.1
+  final_stats: 0
+  final_stats: 0
+  final_stats: 1059.1
+  final_stats: 380
+  final_stats: 0
+  final_stats: 5
+  final_stats: 0
+  final_stats: 3
+  final_stats: 5
+  final_stats: 0
+  final_stats: 9787.96425
+  final_stats: 27
+  final_stats: 60
+  final_stats: 27
+  final_stats: 42
+  final_stats: 80
+  final_stats: 384
+  final_stats: 125
+  final_stats: 70
+  final_stats: 0
+ }
+}
 stat_weights_results: {
  key: "TestShadow-Phase1-Lvl25-StatWeights-Default"
  value: {
@@ -555,6 +653,104 @@ stat_weights_results: {
   weights: 0
   weights: 0.00284
   weights: 29.60325
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+ }
+}
+stat_weights_results: {
+ key: "TestShadow-Phase7-Lvl60-StatWeights-Default"
+ value: {
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0.90189
+  weights: 0
+  weights: 2.79027
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 2.79027
+  weights: 0
+  weights: 25.87801
+  weights: 33.71776
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+ }
+}
+stat_weights_results: {
+ key: "TestShadow-Phase8-Lvl60-StatWeights-Default"
+ value: {
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 1.20555
+  weights: 0
+  weights: 3.93674
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 0
+  weights: 3.93674
+  weights: 0
+  weights: 30.99382
+  weights: 57.09528
   weights: 0
   weights: 0
   weights: 0
@@ -1502,5 +1698,257 @@ dps_results: {
  value: {
   dps: 5422.74178
   tps: 5043.41862
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-BenevolentProphet'sVestments"
+ value: {
+  dps: 2707.6975
+  tps: 1636.55742
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-BloodGuard'sDreadweave"
+ value: {
+  dps: 1917.52046
+  tps: 1166.19293
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-BloodGuard'sSatin"
+ value: {
+  dps: 1800.23135
+  tps: 1097.18375
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-EmeraldEnchantedVestments"
+ value: {
+  dps: 1909.12144
+  tps: 1161.2284
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-EmeraldWovenGarb"
+ value: {
+  dps: 1798.21169
+  tps: 1095.98497
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-IronweaveBattlesuit"
+ value: {
+  dps: 1316.89973
+  tps: 804.7599
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
+ value: {
+  dps: 1917.52046
+  tps: 1166.19293
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-KnightLieutenant'sSatin"
+ value: {
+  dps: 1800.23135
+  tps: 1097.18375
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-MalevolentProphet'sVestments"
+ value: {
+  dps: 2856.97655
+  tps: 1725.30082
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-AllItems-VestmentsoftheVirtuous"
+ value: {
+  dps: 1347.34429
+  tps: 827.04834
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-Average-Default"
+ value: {
+  dps: 6910.89224
+  tps: 4057.99567
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-Settings-Undead-phase_7-phase_7-phase_7-FullBuffs-phase_7-LongMultiTarget"
+ value: {
+  dps: 6917.6384
+  tps: 4645.75899
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-Settings-Undead-phase_7-phase_7-phase_7-FullBuffs-phase_7-LongSingleTarget"
+ value: {
+  dps: 6917.6384
+  tps: 4063.65544
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-Settings-Undead-phase_7-phase_7-phase_7-FullBuffs-phase_7-ShortSingleTarget"
+ value: {
+  dps: 6698.6826
+  tps: 3785.97927
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-Settings-Undead-phase_7-phase_7-phase_7-NoBuffs-phase_7-LongMultiTarget"
+ value: {
+  dps: 3606.40557
+  tps: 2697.78221
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-Settings-Undead-phase_7-phase_7-phase_7-NoBuffs-phase_7-LongSingleTarget"
+ value: {
+  dps: 3606.40557
+  tps: 2112.64088
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-Settings-Undead-phase_7-phase_7-phase_7-NoBuffs-phase_7-ShortSingleTarget"
+ value: {
+  dps: 3562.07078
+  tps: 2001.43623
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase7-Lvl60-SwitchInFrontOfTarget-Default"
+ value: {
+  dps: 6917.6384
+  tps: 4063.65544
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-BenevolentProphet'sVestments"
+ value: {
+  dps: 3002.29623
+  tps: 1218.964
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-BloodGuard'sDreadweave"
+ value: {
+  dps: 2186.65789
+  tps: 1329.45277
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-BloodGuard'sSatin"
+ value: {
+  dps: 2053.26772
+  tps: 1248.37273
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-EmeraldEnchantedVestments"
+ value: {
+  dps: 2177.91184
+  tps: 1324.25527
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-EmeraldWovenGarb"
+ value: {
+  dps: 2051.23597
+  tps: 1248.23956
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-IronweaveBattlesuit"
+ value: {
+  dps: 1431.72271
+  tps: 876.12469
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-Knight-Lieutenant'sDreadweave"
+ value: {
+  dps: 2186.65789
+  tps: 1329.45277
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-KnightLieutenant'sSatin"
+ value: {
+  dps: 2053.26772
+  tps: 1248.37273
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-MalevolentProphet'sVestments"
+ value: {
+  dps: 3153.28317
+  tps: 1292.57284
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-AllItems-VestmentsoftheVirtuous"
+ value: {
+  dps: 1424.64147
+  tps: 870.70114
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-Average-Default"
+ value: {
+  dps: 10476.73933
+  tps: 4411.91521
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-Settings-Undead-phase_8-phase_8-phase_8-FullBuffs-phase_8-LongMultiTarget"
+ value: {
+  dps: 10410.65966
+  tps: 4742.3694
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-Settings-Undead-phase_8-phase_8-phase_8-FullBuffs-phase_8-LongSingleTarget"
+ value: {
+  dps: 10410.65966
+  tps: 4372.07771
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-Settings-Undead-phase_8-phase_8-phase_8-FullBuffs-phase_8-ShortSingleTarget"
+ value: {
+  dps: 9794.2497
+  tps: 3878.29642
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-Settings-Undead-phase_8-phase_8-phase_8-NoBuffs-phase_8-LongMultiTarget"
+ value: {
+  dps: 5229.56853
+  tps: 2426.48711
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-Settings-Undead-phase_8-phase_8-phase_8-NoBuffs-phase_8-LongSingleTarget"
+ value: {
+  dps: 5229.56853
+  tps: 2039.63076
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-Settings-Undead-phase_8-phase_8-phase_8-NoBuffs-phase_8-ShortSingleTarget"
+ value: {
+  dps: 5037.32236
+  tps: 1857.12331
+ }
+}
+dps_results: {
+ key: "TestShadow-Phase8-Lvl60-SwitchInFrontOfTarget-Default"
+ value: {
+  dps: 10410.65966
+  tps: 4372.07771
  }
 }

--- a/sim/priest/shadow/shadow_priest_test.go
+++ b/sim/priest/shadow/shadow_priest_test.go
@@ -128,6 +128,8 @@ func TestShadow(t *testing.T) {
 			EPReferenceStat: proto.Stat_StatSpellPower,
 			StatsToWeigh:    Stats,
 		},
+		core.GetTestBuildFromJSON(proto.Class_ClassPriest, 7, 60, "../../../ui/shadow_priest/builds", "phase_7", ItemFilters, proto.Stat_StatSpellPower, Stats),
+		core.GetTestBuildFromJSON(proto.Class_ClassPriest, 8, 60, "../../../ui/shadow_priest/builds", "phase_8", ItemFilters, proto.Stat_StatSpellPower, Stats),
 	}))
 }
 

--- a/ui/shadow_priest/builds/phase_7.build.json
+++ b/ui/shadow_priest/builds/phase_7.build.json
@@ -1,0 +1,194 @@
+{
+  "raidBuffs": {
+    "giftOfTheWild": "TristateEffectImproved",
+    "powerWordFortitude": "TristateEffectImproved",
+    "bloodPact": "TristateEffectRegular",
+    "arcaneBrilliance": true,
+    "divineSpirit": true,
+    "moonkinAura": true,
+    "manaSpringTotem": "TristateEffectImproved",
+    "fireResistanceTotem": true,
+    "demonicPact": 150,
+    "aspectOfTheLion": true,
+    "atieshSpellCritBuff": true,
+    "atieshSpellPowerBuff": true
+  },
+  "debuffs": {
+    "markOfChaos": true,
+    "occultPoison": true,
+    "wintersChill": true,
+    "improvedShadowBolt": true,
+    "improvedScorch": true,
+    "shadowWeaving": true,
+    "stormstrike": true
+  },
+  "partyBuffs": {
+  },
+  "player": {
+    "name": "Player",
+    "race": "RaceUndead",
+    "level": 60,
+    "class": "ClassPriest",
+    "equipment": {
+      "items": [
+        {"id":236279,"enchant":7623,"rune":413251},
+        {"id":236345},
+        {"id":236108,"enchant":7883,"rune":1220128},
+        {"id":236307,"enchant":804,"rune":402668},
+        {"id":233395,"enchant":7648,"rune":425198},
+        {"id":236106,"enchant":7665,"rune":431670},
+        {"id":236111,"enchant":2614,"rune":401955},
+        {"id":236107,"rune":431655},
+        {"id":236109,"enchant":7623,"rune":402799},
+        {"id":233392,"enchant":7648,"rune":425204},
+        {"id":236112,"rune":442897},
+        {"id":233431,"rune":442898},
+        {"id":236331},
+        {"id":231509},
+        {"id":236399,"enchant":7662},
+        {},
+        {"id":235894}
+      ]
+    },
+    "consumes": {
+      "flask": "FlaskOfAncientKnowledge",
+      "food": "FoodDarkclawBisque",
+      "manaRegenElixir": "MagebloodPotion",
+      "spellPowerBuff": "ElixirOfTheMageLord",
+      "shadowPowerBuff": "ElixirOfShadowPower",
+      "mainHandImbue": "EnchantedRepellent",
+      "defaultPotion": "MajorManaPotion",
+      "defaultConjured": "ConjuredDemonicRune",
+      "enchantedSigil": "WrathOfTheStormSigil",
+      "mildlyIrradiatedRejuvPot": true,
+      "miscConsumes": {
+        "elixirOfCoalescedRegret": true,
+        "greaterMarkOfTheDawn": true
+      },
+      "sealOfTheDawn": "SealOfTheDawnDamageR7",
+      "zanzaBuff": "CerebralCortexCompound",
+      "healthElixir": "ElixirOfFortitude"
+    },
+    "bonusStats": {
+      "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      "pseudoStats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+    },
+    "itemSwap": {
+      "items": [
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        }
+      ],
+      "prepullBonusStats": {
+        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+        "pseudoStats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+      }
+    },
+    "buffs": {
+      "rallyingCryOfTheDragonslayer": true,
+      "valorOfAzeroth": true,
+      "saygesFortune": "SaygesDamage",
+      "spiritOfZandalar": true,
+      "songflowerSerenade": true,
+      "warchiefsBlessing": true,
+      "moldarsMoxie": true,
+      "slipkiksSavvy": true
+    },
+    "talentsString": "5052001--5032505103501251",
+    "profession1": "Alchemy",
+    "profession2": "Enchanting",
+    "cooldowns": {
+    },
+    "rotation": {
+      "type": "TypeAPL",
+      "prepullActions": [
+        {"action":{"castSpell":{"spellId":{"spellId":15473}}},"doAtValue":{"const":{"val":"-10s"}}},
+        {"action":{"castSpell":{"spellId":{"spellId":402799}}},"doAtValue":{"const":{"val":"-5s"}}},
+        {"action":{"castSpell":{"spellId":{"itemId":234080}}},"doAtValue":{"const":{"val":"-1.3"}},"hide":true},
+        {"action":{"castSpell":{"spellId":{"spellId":431655}}},"doAtValue":{"const":{"val":"-2.8s"}},"hide":true},
+        {"action":{"castSpell":{"spellId":{"itemId":215162}}},"doAtValue":{"const":{"val":"0"}},"hide":true},
+        {"action":{"castSpell":{"spellId":{"spellId":402668}}},"doAtValue":{"const":{"val":"-1.3s"}},"hide":true}
+      ],
+      "priorityList": [
+        {"action":{"autocastOtherCooldowns":{}}},
+        {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":425204}}}}},"castSpell":{"spellId":{"spellId":425204}}}},
+        {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":10894,"rank":8}}}}},"castSpell":{"spellId":{"spellId":10894,"rank":8}}}},
+        {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":402668}}}}},"castSpell":{"spellId":{"spellId":402668}}}},
+        {"action":{"castSpell":{"spellId":{"itemId":231509}}}},
+        {"hide":true,"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":19280,"rank":6}}}}},"castSpell":{"spellId":{"spellId":19280,"rank":6}}}},
+        {"action":{"condition":{"spellIsReady":{"spellId":{"spellId":10947,"rank":9}}},"castSpell":{"spellId":{"spellId":10947,"rank":9}}}},
+        {"hide":true,"action":{"castSpell":{"spellId":{"spellId":402799}}}},
+        {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"itemId":231509}}}}},"castSpell":{"spellId":{"spellId":401977}}}},
+        {"action":{"condition":{"cmp":{"op":"OpGe","lhs":{"spellTimeToReady":{"spellId":{"spellId":10947,"rank":9}}},"rhs":{"const":{"val":"1.5"}}}},"channelSpell":{"spellId":{"spellId":18807,"rank":6},"interruptIf":{"cmp":{"op":"OpEq","lhs":{"spellChanneledTicks":{"spellId":{"spellId":18807,"rank":6}}},"rhs":{"const":{"val":"1"}}}},"allowRecast":true}}},
+        {"hide":true,"action":{"castSpell":{"spellId":{"spellId":401955}}}},
+        {"action":{"channelSpell":{"spellId":{"spellId":18807,"rank":6},"interruptIf":{"cmp":{"op":"OpEq","lhs":{"spellChanneledTicks":{"spellId":{"spellId":18807,"rank":6}}},"rhs":{"const":{"val":"1"}}}},"allowRecast":true}}},
+        {"hide":true,"action":{"castSpell":{"spellId":{"spellId":431655}}}}
+      ]
+    },
+    "reactionTimeMs": 200,
+    "channelClipDelayMs": 100,
+    "distanceFromTarget": 30,
+    "isbUsingShadowflame": true,
+    "isbSbFrequency": 1.25,
+    "isbCrit": 62,
+    "isbWarlocks": 1,
+    "healingModel": {
+    },
+    "shadowPriest": {
+      "options": {
+        "armor": "InnerFire"
+      }
+    }
+  },
+  "encounter": {
+    "duration": 60,
+    "durationVariation": 15,
+    "executeProportion20": 0.15,
+    "executeProportion25": 0.2,
+    "executeProportion35": 0.3,
+    "targets": [
+      {
+        "id": 213336,
+        "name": "Level 60",
+        "level": 63,
+        "mobType": "MobTypeUndead",
+        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,805,0,0,0,0,0,0,0,0,3731,0,0,0,0,0,0,0,127393,0,0,0,0,0,0,0,0,0],
+        "minBaseDamage": 3000,
+        "damageSpread": 0.3333,
+        "swingSpeed": 2,
+        "parryHaste": true
+      }
+    ]
+  }
+}

--- a/ui/shadow_priest/builds/phase_8.build.json
+++ b/ui/shadow_priest/builds/phase_8.build.json
@@ -1,0 +1,190 @@
+{
+  "raidBuffs": {
+    "giftOfTheWild": "TristateEffectImproved",
+    "powerWordFortitude": "TristateEffectImproved",
+    "bloodPact": "TristateEffectRegular",
+    "arcaneBrilliance": true,
+    "divineSpirit": true,
+    "moonkinAura": true,
+    "manaSpringTotem": "TristateEffectImproved",
+    "fireResistanceTotem": true,
+    "demonicPact": 160,
+    "aspectOfTheLion": true,
+    "atieshSpellCritBuff": true,
+    "atieshSpellPowerBuff": true
+  },
+  "debuffs": {
+    "markOfChaos": true,
+    "occultPoison": true,
+    "wintersChill": true,
+    "improvedShadowBolt": true,
+    "improvedScorch": true,
+    "shadowWeaving": true,
+    "stormstrike": true
+  },
+  "partyBuffs": {
+  },
+  "player": {
+    "name": "Player",
+    "race": "RaceUndead",
+    "level": 60,
+    "class": "ClassPriest",
+    "equipment": {
+      "items": [
+        {"id":239575,"enchant":7623,"rune":413251},
+        {"id":241072},
+        {"id":239581,"enchant":7883,"rune":1220128},
+        {"id":241025,"enchant":804,"rune":402668},
+        {"id":233395,"enchant":7648,"rune":425198},
+        {"id":239583,"enchant":7665,"rune":431670},
+        {"id":239574,"enchant":2614,"rune":401955},
+        {"id":239582,"rune":431655},
+        {"id":239577,"enchant":7623,"rune":402799},
+        {"id":233392,"enchant":7648,"rune":425204},
+        {"id":236112,"rune":442897},
+        {"id":233431,"rune":442898},
+        {"id":236331},
+        {"id":231509},
+        {"id":241001,"enchant":2504},
+        {"id":241020,"enchant":7659},
+        {"id":241004}
+      ]
+    },
+    "consumes": {
+      "flask": "FlaskOfAncientKnowledge",
+      "food": "FoodSunriseOmelette",
+      "manaRegenElixir": "MagebloodPotion",
+      "spellPowerBuff": "ElixirOfTheMageLord",
+      "shadowPowerBuff": "ElixirOfShadowPower",
+      "mainHandImbue": "EnchantedRepellent",
+      "defaultPotion": "MajorManaPotion",
+      "defaultConjured": "ConjuredDemonicRune",
+      "enchantedSigil": "WrathOfTheStormSigil",
+      "mildlyIrradiatedRejuvPot": true,
+      "miscConsumes": {
+        "elixirOfCoalescedRegret": true,
+        "greaterMarkOfTheDawn": true
+      },
+      "zanzaBuff": "CerebralCortexCompound",
+      "healthElixir": "ElixirOfFortitude"
+    },
+    "bonusStats": {
+      "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+      "pseudoStats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+    },
+    "itemSwap": {
+      "items": [
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        },
+        {
+        }
+      ],
+      "prepullBonusStats": {
+        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+        "pseudoStats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+      }
+    },
+    "buffs": {
+      "rallyingCryOfTheDragonslayer": true,
+      "valorOfAzeroth": true,
+      "saygesFortune": "SaygesDamage",
+      "spiritOfZandalar": true,
+      "songflowerSerenade": true,
+      "warchiefsBlessing": true,
+      "moldarsMoxie": true,
+      "slipkiksSavvy": true
+    },
+    "talentsString": "5052001--5032505103501251",
+    "profession1": "Alchemy",
+    "profession2": "Enchanting",
+    "cooldowns": {
+    },
+    "rotation": {
+      "type": "TypeAPL",
+      "prepullActions": [
+        {"action":{"castSpell":{"spellId":{"spellId":15473}}},"doAtValue":{"const":{"val":"-10s"}}},
+        {"action":{"castSpell":{"spellId":{"spellId":402799}}},"doAtValue":{"const":{"val":"-5s"}}},
+        {"action":{"castSpell":{"spellId":{"itemId":234080}}},"doAtValue":{"const":{"val":"-1.3"}},"hide":true},
+        {"action":{"castSpell":{"spellId":{"spellId":431655}}},"doAtValue":{"const":{"val":"-2.8s"}},"hide":true},
+        {"action":{"castSpell":{"spellId":{"spellId":402668}}},"doAtValue":{"const":{"val":"-1.3s"}},"hide":true}
+      ],
+      "priorityList": [
+        {"action":{"autocastOtherCooldowns":{}}},
+        {"hide":true,"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"itemId":241241}}},"rhs":{"const":{"val":"2"}}}},"castSpell":{"spellId":{"itemId":241241}}}},
+        {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":425204}}}}},"castSpell":{"spellId":{"spellId":425204}}}},
+        {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":10894,"rank":8}}}}},"castSpell":{"spellId":{"spellId":10894,"rank":8}}}},
+        {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":402668}}}}},"castSpell":{"spellId":{"spellId":402668}}}},
+        {"action":{"castSpell":{"spellId":{"itemId":231509}}}},
+        {"hide":true,"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":19280,"rank":6}}}}},"castSpell":{"spellId":{"spellId":19280,"rank":6}}}},
+        {"action":{"condition":{"spellIsReady":{"spellId":{"spellId":10947,"rank":9}}},"castSpell":{"spellId":{"spellId":10947,"rank":9}}}},
+        {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":456549}}},"castSpell":{"spellId":{"spellId":18807,"rank":6}}}},
+        {"action":{"condition":{"not":{"val":{"auraIsActive":{"auraId":{"itemId":231509}}}}},"castSpell":{"spellId":{"spellId":401977}}}},
+        {"action":{"channelSpell":{"spellId":{"spellId":18807,"rank":6},"interruptIf":{"cmp":{"op":"OpEq","lhs":{"spellChanneledTicks":{"spellId":{"spellId":18807,"rank":6}}},"rhs":{"const":{"val":"3"}}}},"allowRecast":true}}},
+        {"hide":true,"action":{"condition":{"cmp":{"op":"OpGe","lhs":{"spellTimeToReady":{"spellId":{"spellId":10947,"rank":9}}},"rhs":{"const":{"val":"1.5"}}}},"channelSpell":{"spellId":{"spellId":18807,"rank":6},"interruptIf":{"cmp":{"op":"OpEq","lhs":{"spellChanneledTicks":{"spellId":{"spellId":18807,"rank":6}}},"rhs":{"const":{"val":"3"}}}},"allowRecast":true}}}
+      ]
+    },
+    "reactionTimeMs": 200,
+    "channelClipDelayMs": 100,
+    "distanceFromTarget": 30,
+    "isbUsingShadowflame": true,
+    "isbSbFrequency": 1.25,
+    "isbCrit": 62,
+    "isbWarlocks": 1,
+    "healingModel": {
+    },
+    "shadowPriest": {
+      "options": {
+        "armor": "InnerFire"
+      }
+    }
+  },
+  "encounter": {
+    "duration": 120,
+    "durationVariation": 15,
+    "executeProportion20": 0.15,
+    "executeProportion25": 0.2,
+    "executeProportion35": 0.3,
+    "targets": [
+      {
+        "id": 213336,
+        "name": "Level 60",
+        "level": 63,
+        "stats": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,805,0,0,0,0,0,0,0,0,3731,0,0,0,0,0,0,0,127393,0,0,0,0,0,0,0,0,0],
+        "minBaseDamage": 3000,
+        "damageSpread": 0.3333,
+        "swingSpeed": 2,
+        "parryHaste": true
+      }
+    ]
+  }
+}

--- a/ui/shadow_priest/presets.ts
+++ b/ui/shadow_priest/presets.ts
@@ -1,26 +1,6 @@
 import { Phase } from '../core/constants/other.js';
 import * as PresetUtils from '../core/preset_utils.js';
 import { Spec } from '../core/proto/common';
-import {
-	Conjured,
-	Consumes,
-	Debuffs,
-	EnchantedSigil,
-	Flask,
-	Food,
-	IndividualBuffs,
-	ManaRegenElixir,
-	Potions,
-	Profession,
-	RaidBuffs,
-	SaygesFortune,
-	ShadowPowerBuff,
-	SpellPowerBuff,
-	TristateEffect,
-	WeaponImbue,
-	ZanzaBuff,
-} from '../core/proto/common.js';
-import { ShadowPriest_Options as Options } from '../core/proto/priest.js';
 import { SavedTalents } from '../core/proto/ui.js';
 // APLs
 import Phase1APL from './apls/phase_1.apl.json';
@@ -44,6 +24,10 @@ import Phase6Gear from './gear_sets/phase_6.gear.json';
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
+
+///////////////////////////////////////////////////////////////////////////
+//                                 Build Presets
+///////////////////////////////////////////////////////////////////////////
 
 export const PresetBuildPhase7 = PresetUtils.makePresetBuildFromJSON('Phase 7', Spec.SpecShadowPriest, Phase7BuildJSON);
 export const PresetBuildPhase8 = PresetUtils.makePresetBuildFromJSON('Phase 8', Spec.SpecShadowPriest, Phase8BuildJSON);
@@ -74,8 +58,6 @@ export const GearPresets = {
 	[Phase.Phase7]: [PresetBuildPhase7.gear!],
 	[Phase.Phase8]: [PresetBuildPhase8.gear!],
 };
-
-export const DefaultGear = GearPresets[Phase.Phase8][0];
 
 ///////////////////////////////////////////////////////////////////////////
 //                                 APL Presets
@@ -135,92 +117,4 @@ export const TalentPresets = {
 	[Phase.Phase6]: [],
 	[Phase.Phase7]: [PresetBuildPhase7.talents!],
 	[Phase.Phase8]: [PresetBuildPhase8.talents!],
-};
-
-export const DefaultTalents = TalentPresets[Phase.Phase8][0];
-
-///////////////////////////////////////////////////////////////////////////
-//                                 Build Presets
-///////////////////////////////////////////////////////////////////////////
-
-export const PresetBuildPhase4 = PresetUtils.makePresetBuild('Phase 4', {
-	gear: GearPhase4,
-	talents: TalentsPhase4,
-	rotation: APLPhase4,
-});
-export const PresetBuildPhase5Draconic = PresetUtils.makePresetBuild('Phase 5 Draconic', {
-	gear: GearPhase5Draconic,
-	talents: TalentsPhase4,
-	rotation: APLPhase5,
-});
-export const PresetBuildPhase5CoreForged = PresetUtils.makePresetBuild('Phase 5 Core Forged', {
-	gear: GearPhase5CoreForged,
-	talents: TalentsPhase4,
-	rotation: APLPhase5,
-});
-export const PresetBuildPhase6 = PresetUtils.makePresetBuild('Phase 6', {
-	gear: GearPhase6,
-	talents: TalentsPhase4,
-	rotation: APLPhase6,
-});
-
-///////////////////////////////////////////////////////////////////////////
-//                                 Options
-///////////////////////////////////////////////////////////////////////////
-
-export const DefaultOptions = Options.create({
-});
-
-export const DefaultConsumes = Consumes.create({
-	defaultConjured: Conjured.ConjuredDemonicRune,
-	defaultPotion: Potions.MajorManaPotion,
-	enchantedSigil: EnchantedSigil.WrathOfTheStormSigil,
-	flask: Flask.FlaskOfAncientKnowledge,
-	food: Food.FoodDarkclawBisque,
-	mainHandImbue: WeaponImbue.EnchantedRepellent,
-	manaRegenElixir: ManaRegenElixir.MagebloodPotion,
-	mildlyIrradiatedRejuvPot: true,
-	shadowPowerBuff: ShadowPowerBuff.ElixirOfShadowPower,
-	spellPowerBuff: SpellPowerBuff.ElixirOfTheMageLord,
-	zanzaBuff: ZanzaBuff.CerebralCortexCompound,
-});
-
-export const DefaultRaidBuffs = RaidBuffs.create({
-	arcaneBrilliance: true,
-	aspectOfTheLion: true,
-	demonicPact: 120,
-	divineSpirit: true,
-	fireResistanceAura: true,
-	fireResistanceTotem: true,
-	giftOfTheWild: TristateEffect.TristateEffectImproved,
-	manaSpringTotem: TristateEffect.TristateEffectImproved,
-	moonkinAura: true,
-	powerWordFortitude: TristateEffect.TristateEffectImproved,
-});
-
-export const DefaultIndividualBuffs = IndividualBuffs.create({
-	blessingOfWisdom: TristateEffect.TristateEffectImproved,
-	mightOfStormwind: true,
-	rallyingCryOfTheDragonslayer: true,
-	saygesFortune: SaygesFortune.SaygesDamage,
-	slipkiksSavvy: true,
-	songflowerSerenade: true,
-	spiritOfZandalar: true,
-	valorOfAzeroth: true,
-	warchiefsBlessing: true,
-});
-
-export const DefaultDebuffs = Debuffs.create({
-	improvedShadowBolt: true,
-	judgementOfWisdom: true,
-	occultPoison: true,
-	markOfChaos: true,
-	wintersChill: true,
-});
-
-export const OtherDefaults = {
-	channelClipDelay: 100,
-	distanceFromTarget: 30,
-	profession1: Profession.Alchemy,
-	profession2: Profession.Enchanting,
 };

--- a/ui/shadow_priest/presets.ts
+++ b/ui/shadow_priest/presets.ts
@@ -1,5 +1,6 @@
 import { Phase } from '../core/constants/other.js';
 import * as PresetUtils from '../core/preset_utils.js';
+import { Spec } from '../core/proto/common';
 import {
 	Conjured,
 	Consumes,
@@ -21,12 +22,17 @@ import {
 } from '../core/proto/common.js';
 import { ShadowPriest_Options as Options } from '../core/proto/priest.js';
 import { SavedTalents } from '../core/proto/ui.js';
+// APLs
 import Phase1APL from './apls/phase_1.apl.json';
 import Phase2APL from './apls/phase_2.apl.json';
 import Phase3APL from './apls/phase_3.apl.json';
 import Phase4APL from './apls/phase_4.apl.json';
 import Phase5APL from './apls/phase_5.apl.json';
 import Phase6APL from './apls/phase_6.apl.json';
+// Builds
+import Phase7BuildJSON from './builds/phase_7.build.json';
+import Phase8BuildJSON from './builds/phase_8.build.json';
+// Gear
 import Phase1Gear from './gear_sets/phase_1.gear.json';
 import Phase2Gear from './gear_sets/phase_2.gear.json';
 import Phase3Gear from './gear_sets/phase_3.gear.json';
@@ -38,6 +44,11 @@ import Phase6Gear from './gear_sets/phase_6.gear.json';
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
+
+export const PresetBuildPhase7 = PresetUtils.makePresetBuildFromJSON('Phase 7', Spec.SpecShadowPriest, Phase7BuildJSON);
+export const PresetBuildPhase8 = PresetUtils.makePresetBuildFromJSON('Phase 8', Spec.SpecShadowPriest, Phase8BuildJSON);
+
+export const DefaultBuild = PresetBuildPhase8;
 
 ///////////////////////////////////////////////////////////////////////////
 //                                 Gear Presets
@@ -60,9 +71,11 @@ export const GearPresets = {
 	[Phase.Phase4]: [GearPhase4],
 	[Phase.Phase5]: [GearPhase5Draconic, GearPhase5CoreForged],
 	[Phase.Phase6]: [GearPhase6],
+	[Phase.Phase7]: [PresetBuildPhase7.gear!],
+	[Phase.Phase8]: [PresetBuildPhase8.gear!],
 };
 
-export const DefaultGear = GearPresets[Phase.Phase6][0];
+export const DefaultGear = GearPresets[Phase.Phase8][0];
 
 ///////////////////////////////////////////////////////////////////////////
 //                                 APL Presets
@@ -82,13 +95,15 @@ export const APLPresets = {
 	[Phase.Phase4]: [APLPhase4],
 	[Phase.Phase5]: [APLPhase5],
 	[Phase.Phase6]: [APLPhase6],
+	[Phase.Phase7]: [PresetBuildPhase7.rotation!],
+	[Phase.Phase8]: [PresetBuildPhase8.rotation!],
 };
 
 export const DefaultAPLs: Record<number, PresetUtils.PresetRotation> = {
 	25: APLPresets[Phase.Phase1][0],
 	40: APLPresets[Phase.Phase2][0],
 	50: APLPresets[Phase.Phase3][0],
-	60: APLPresets[Phase.Phase6][0],
+	60: APLPresets[Phase.Phase8][0],
 };
 
 ///////////////////////////////////////////////////////////////////////////
@@ -118,9 +133,11 @@ export const TalentPresets = {
 	[Phase.Phase4]: [TalentsPhase4],
 	[Phase.Phase5]: [],
 	[Phase.Phase6]: [],
+	[Phase.Phase7]: [PresetBuildPhase7.talents!],
+	[Phase.Phase8]: [PresetBuildPhase8.talents!],
 };
 
-export const DefaultTalents = TalentPresets[Phase.Phase4][0];
+export const DefaultTalents = TalentPresets[Phase.Phase8][0];
 
 ///////////////////////////////////////////////////////////////////////////
 //                                 Build Presets

--- a/ui/shadow_priest/sim.ts
+++ b/ui/shadow_priest/sim.ts
@@ -6,7 +6,7 @@ import { IndividualSimUI, registerSpecConfig } from '../core/individual_sim_ui.j
 import { Player } from '../core/player.js';
 import { Class, Faction, ItemSlot, PartyBuffs, PseudoStat, Race, Spec, Stat } from '../core/proto/common.js';
 import { Stats } from '../core/proto_utils/stats.js';
-import { getSpecIcon, specNames } from '../core/proto_utils/utils.js';
+import { getSpecIcon, specNames, SpecOptions } from '../core/proto_utils/utils.js';
 import * as ShadowPriestInputs from './inputs.js';
 import * as Presets from './presets.js';
 
@@ -61,7 +61,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.DefaultGear.gear,
+		gear: Presets.DefaultBuild.gear!.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Stats.fromMap(
 			{
@@ -81,21 +81,22 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			},
 		),
 		// Default consumes settings.
-		consumes: Presets.DefaultConsumes,
+		consumes: Presets.DefaultBuild.settings!.consumes!,
 		// Default talents.
-		talents: Presets.DefaultTalents.data,
+		talents: Presets.DefaultBuild.talents!.data,
 		// Default spec-specific settings.
-		specOptions: Presets.DefaultOptions,
+		specOptions: Presets.DefaultBuild.settings!.specOptions! as SpecOptions<Spec.SpecShadowPriest>,
+		other: {
+			// Default distance from target.
+			distanceFromTarget: Presets.DefaultBuild.settings?.playerOptions?.distanceFromTarget,
+			profession1: Presets.DefaultBuild.settings?.playerOptions?.profession1,
+			profession2: Presets.DefaultBuild.settings?.playerOptions?.profession2,
+		},
 		// Default raid/party buffs settings.
-		raidBuffs: Presets.DefaultRaidBuffs,
-
-		partyBuffs: PartyBuffs.create({}),
-
-		individualBuffs: Presets.DefaultIndividualBuffs,
-
-		debuffs: Presets.DefaultDebuffs,
-
-		other: Presets.OtherDefaults,
+		raidBuffs: Presets.DefaultBuild.settings!.raidBuffs!,
+		partyBuffs: Presets.DefaultBuild.settings!.partyBuffs!,
+		individualBuffs: Presets.DefaultBuild.settings!.buffs!,
+		debuffs: Presets.DefaultBuild.settings!.debuffs!,
 	},
 
 	// IconInputs to include in the 'Player' section on the settings tab.
@@ -149,7 +150,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			...Presets.GearPresets[Phase.Phase2],
 			...Presets.GearPresets[Phase.Phase1],
 		],
-		builds: [Presets.PresetBuildPhase8, Presets.PresetBuildPhase7, Presets.PresetBuildPhase6, Presets.PresetBuildPhase5Draconic, Presets.PresetBuildPhase5CoreForged, Presets.PresetBuildPhase4],
+		builds: [Presets.PresetBuildPhase8, Presets.PresetBuildPhase7],
 	},
 
 	autoRotation: player => {
@@ -163,9 +164,9 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			defaultName: 'Shadow',
 			iconUrl: getSpecIcon(Class.ClassPriest, 2),
 
-			talents: Presets.DefaultTalents.data,
-			specOptions: Presets.DefaultOptions,
-			consumes: Presets.DefaultConsumes,
+			talents: Presets.DefaultBuild.talents!.data,
+			specOptions: Presets.DefaultBuild.settings!.specOptions! as SpecOptions<Spec.SpecShadowPriest>,
+			consumes: Presets.DefaultBuild.settings!.consumes!,
 			defaultFactionRaces: {
 				[Faction.Unknown]: Race.RaceUnknown,
 				[Faction.Alliance]: Race.RaceDwarf,

--- a/ui/shadow_priest/sim.ts
+++ b/ui/shadow_priest/sim.ts
@@ -120,6 +120,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 
 	presets: {
 		talents: [
+			...Presets.TalentPresets[Phase.Phase8],
+			...Presets.TalentPresets[Phase.Phase7],
 			...Presets.TalentPresets[Phase.Phase6],
 			...Presets.TalentPresets[Phase.Phase5],
 			...Presets.TalentPresets[Phase.Phase4],
@@ -128,6 +130,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			...Presets.TalentPresets[Phase.Phase1],
 		],
 		rotations: [
+			...Presets.APLPresets[Phase.Phase8],
+			...Presets.APLPresets[Phase.Phase7],
 			...Presets.APLPresets[Phase.Phase6],
 			...Presets.APLPresets[Phase.Phase5],
 			...Presets.APLPresets[Phase.Phase4],
@@ -136,6 +140,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			...Presets.APLPresets[Phase.Phase1],
 		],
 		gear: [
+			...Presets.GearPresets[Phase.Phase8],
+			...Presets.GearPresets[Phase.Phase7],
 			...Presets.GearPresets[Phase.Phase6],
 			...Presets.GearPresets[Phase.Phase5],
 			...Presets.GearPresets[Phase.Phase4],
@@ -143,7 +149,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			...Presets.GearPresets[Phase.Phase2],
 			...Presets.GearPresets[Phase.Phase1],
 		],
-		builds: [Presets.PresetBuildPhase6, Presets.PresetBuildPhase5Draconic, Presets.PresetBuildPhase5CoreForged, Presets.PresetBuildPhase4],
+		builds: [Presets.PresetBuildPhase8, Presets.PresetBuildPhase7, Presets.PresetBuildPhase6, Presets.PresetBuildPhase5Draconic, Presets.PresetBuildPhase5CoreForged, Presets.PresetBuildPhase4],
 	},
 
 	autoRotation: player => {


### PR DESCRIPTION
This PR adds BIS builds from @Shiromar1122 for Phase 7 + 8, and incorporates them into shadow_priest presets and sim.
Also sets Phase 8 as default selections.

Please let me know if I have misinterpreted some configuration here.