### PR TITLE
BUGFIX - Sebacious Poison Applied In Settings > Debuffs Counts Towards P8 Rogue DPS Tier 2pc Bonus

### DIFF
--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -22,7 +22,6 @@ type OnRefresh func(aura *Aura, sim *Simulation)
 type OnExpire func(aura *Aura, sim *Simulation)
 type OnStacksChange func(aura *Aura, sim *Simulation, oldStacks int32, newStacks int32)
 type OnStatsChange func(aura *Aura, sim *Simulation, oldStats stats.Stats, newStats stats.Stats)
-type IsEnabledInSettings func(aura *Aura, sim *Simulation)
 
 // Callback for after a spell hits the target and after damage is calculated. Use it for proc effects
 // or anything that comes from the final result of the spell.
@@ -123,7 +122,7 @@ type Aura struct {
 	initialized bool
 
 	// P8 Sebacious Poison fix
-	IsEnabledInSettings IsEnabledInSettings
+	IsEnabledInSettings bool
 }
 
 func (aura *Aura) init(sim *Simulation) {
@@ -439,6 +438,13 @@ func (aura *Aura) ApplyOnPeriodicDamageDealt(newOnPeriodicDamageDealt OnPeriodic
 			newOnPeriodicDamageDealt(aura, sim, spell, result)
 		}
 	}
+
+	return aura
+}
+
+// TODO: working on fixing p8 bonus applying to Sebacious in Settings>Debuffs
+func (aura *Aura) ApplyIsEnabledInSettings() *Aura {
+	aura.IsEnabledInSettings = true
 
 	return aura
 }

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -22,6 +22,7 @@ type OnRefresh func(aura *Aura, sim *Simulation)
 type OnExpire func(aura *Aura, sim *Simulation)
 type OnStacksChange func(aura *Aura, sim *Simulation, oldStacks int32, newStacks int32)
 type OnStatsChange func(aura *Aura, sim *Simulation, oldStats stats.Stats, newStats stats.Stats)
+type IsEnabledInSettings func(aura *Aura, sim *Simulation)
 
 // Callback for after a spell hits the target and after damage is calculated. Use it for proc effects
 // or anything that comes from the final result of the spell.
@@ -120,6 +121,9 @@ type Aura struct {
 	metrics AuraMetrics
 
 	initialized bool
+
+	// P8 Sebacious Poison fix
+	IsEnabledInSettings IsEnabledInSettings
 }
 
 func (aura *Aura) init(sim *Simulation) {

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -178,6 +178,7 @@ func applyDebuffEffects(target *Unit, targetIdx int, debuffs *proto.Debuffs, lev
 
 		if debuffs.SebaciousPoison != proto.TristateEffect_TristateEffectMissing {
 			aura := SebaciousPoisonAura(target, TernaryInt32(debuffs.SebaciousPoison == proto.TristateEffect_TristateEffectRegular, 0, 2), level)
+			aura.ApplyIsEnabledInSettings()
 			SchedulePeriodicDebuffApplication(aura, PeriodicActionOptions{
 				Period:   time.Second * 0,
 				NumTicks: 1,

--- a/sim/rogue/item_sets_phase_8.go
+++ b/sim/rogue/item_sets_phase_8.go
@@ -1,6 +1,7 @@
 package rogue
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/wowsims/sod/sim/core"
@@ -54,6 +55,7 @@ func (rogue *Rogue) applyScarletEnclaveDamage2PBonus() {
 		Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			totalBleedsAndPoisons := rogue.PoisonsActive[rogue.CurrentTarget.UnitIndex] + rogue.BleedsActive[rogue.CurrentTarget.UnitIndex]
 
+			fmt.Println("Stack Count: ", totalBleedsAndPoisons)
 			// Only apply the damage mod up to 3 times for the 60% bonus maximum
 			damageMod.UpdateFloatValue(1 + 0.20*float64(min(3, totalBleedsAndPoisons)))
 			damageMod.Activate()

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -1,6 +1,7 @@
 package rogue
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -69,11 +70,14 @@ func (rogue *Rogue) improvedPoisonsBonusProcChance() float64 {
 
 // p8 DPS tier bonus helper function
 func trackTotalUniquePoisons(aura *core.Aura, rogue *Rogue) {
-	aura.ApplyOnGain(func(aura *core.Aura, sim *core.Simulation) {
-		rogue.PoisonsActive[aura.Unit.UnitIndex]++
-	}).ApplyOnExpire(func(aura *core.Aura, sim *core.Simulation) {
-		rogue.PoisonsActive[aura.Unit.UnitIndex]--
-	})
+	fmt.Println("AuraIsFromSettings: ", aura.IsEnabledInSettings)
+	if !aura.IsEnabledInSettings {
+		aura.ApplyOnGain(func(aura *core.Aura, sim *core.Simulation) {
+			rogue.PoisonsActive[aura.Unit.UnitIndex]++
+		}).ApplyOnExpire(func(aura *core.Aura, sim *core.Simulation) {
+			rogue.PoisonsActive[aura.Unit.UnitIndex]--
+		})
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
WIP but I am attempting to add a new callback to Auras to differentiate whether or not they "come from" the Settings UI in the sim. This should fix the interaction where if Sebacious Poison is turned on in Settings > Debuffs, it counts towards the Rogue P8 DPS Tier 2pc bonus when it shouldn't.

This has some ramifications when it does get fixed, as the SSL APL that Comfy currently has set up is relying on this bug to make the "pk swap macro" work.