### PR TITLE
[Prot] Holy Shield fixes

### DIFF
--- a/sim/paladin/holy_shield.go
+++ b/sim/paladin/holy_shield.go
@@ -47,6 +47,7 @@ func (paladin *Paladin) registerHolyShield() {
 			SpellSchool:    core.SpellSchoolHoly,
 			DefenseType:    core.DefenseTypeMagic,
 			ProcMask:       core.ProcMaskSpellDamage,
+			Flags:          core.SpellFlagBinary, // By default HS is binary, unless T1 6pc (Radiant Defender) is equipped
 
 			RequiredLevel: int(level),
 			Rank:          rank,
@@ -56,8 +57,8 @@ func (paladin *Paladin) registerHolyShield() {
 			BonusCoefficient: 0.05,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				// Spell damage from Holy Shield can crit, but does not miss.
-				spell.CalcAndDealDamage(sim, target, paladin.getHolyShieldDamage(sim, damage), spell.OutcomeMagicCrit)
+				outcome := core.Ternary(paladin.holyShieldCanCrit, spell.OutcomeMagicHitAndCrit, spell.OutcomeMagicHit)
+				spell.CalcAndDealDamage(sim, target, paladin.getHolyShieldDamage(sim, damage), outcome)
 			},
 		})
 

--- a/sim/paladin/item_sets_pve.go
+++ b/sim/paladin/item_sets_pve.go
@@ -369,6 +369,11 @@ func (paladin *Paladin) applyPaladinT1Prot6P() {
 				// Holy Shield aura no longer has stacks and does not set stacks on gain or remove stacks on block.
 				// Setting MaxStacks to 0 disables this behavior in holy_shield.go
 				paladin.holyShieldAura[i].MaxStacks = 0
+
+				// With this bonus, the proc can partial resist and crit
+				paladin.holyShieldProc[i].ActionID.SpellID = 456544
+				paladin.holyShieldProc[i].Flags ^= core.SpellFlagBinary
+				paladin.holyShieldCanCrit = true
 			}
 		},
 	}))

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -114,6 +114,7 @@ type Paladin struct {
 	onHolyPowerSpent               func(sim *core.Simulation, holyPower int32)
 	holyShieldExtraDamage          func(sim *core.Simulation, paladin *Paladin) float64
 	bypassAvengingWrathForbearance bool
+	holyShieldCanCrit              bool
 
 	enableMultiJudge    bool
 	lingerDuration      time.Duration

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -51,38 +51,38 @@ stat_weights_results: {
  key: "TestProtection-Phase4-Lvl60-StatWeights-Default"
  value: {
   weights: 0.94763
-  weights: 0.7863
+  weights: 0.71525
   weights: 0
-  weights: 0.23688
+  weights: -0.1323
   weights: 0
-  weights: 0.18971
-  weights: 0
-  weights: 0
-  weights: 0
-  weights: 0.10504
+  weights: 0.18883
   weights: 0
   weights: 0
   weights: 0
-  weights: 4.27199
-  weights: 2.23259
+  weights: 0.10453
   weights: 0
   weights: 0
-  weights: 0.41331
   weights: 0
-  weights: 14.38904
+  weights: 3.58275
+  weights: 1.49198
   weights: 0
   weights: 0
+  weights: 0.41361
+  weights: 0
+  weights: 14.95314
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
   weights: 0
-  weights: 1.75188
-  weights: -0.23798
-  weights: 1.11579
-  weights: -4.73602
-  weights: -2.76022
+  weights: 0
+  weights: 0
+  weights: 1.91042
+  weights: 0.04632
+  weights: 1.09649
+  weights: -2.30515
+  weights: -0.50859
   weights: 0
   weights: 0
   weights: 0
@@ -139,10 +139,10 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-Average-Default"
  value: {
-  dps: 1882.6172
-  tps: 4577.88087
-  dtps: 431.23099
-  hps: 105.56614
+  dps: 1876.20909
+  tps: 4555.65527
+  dtps: 431.25301
+  hps: 105.61709
  }
 }
 dps_results: {
@@ -238,9 +238,9 @@ dps_results: {
 dps_results: {
  key: "TestProtection-Phase4-Lvl60-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1623.04164
-  tps: 3940.51183
-  dtps: 534.06876
-  hps: 95.83329
+  dps: 1612.7989
+  tps: 3918.62187
+  dtps: 533.66711
+  hps: 95.54016
  }
 }


### PR DESCRIPTION
* Regular Holy Shield should be binary (hit / resist) and not able to crit
* Radiant Defender (6pc T1) should make HS able to crit but also partial resist
  * This version also uses a separate spellID