### PR TITLE
explo shot fixes

### DIFF
--- a/sim/hunter/explosive_shot.go
+++ b/sim/hunter/explosive_shot.go
@@ -26,7 +26,7 @@ func (hunter *Hunter) registerExplosiveShotSpell() {
 		CastType:       proto.CastType_CastTypeRanged,
 		DefenseType:    core.DefenseTypeRanged,
 		ProcMask:       core.ProcMaskRangedSpecial,
-		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagIgnoreResists | core.SpellFlagAPL,
+		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
 
 		MinRange:     core.MinRangedAttackRange,
 		MaxRange:     core.MaxRangedAttackRange,
@@ -62,7 +62,7 @@ func (hunter *Hunter) registerExplosiveShotSpell() {
 				dot.Snapshot(target, baseDamage, isRollover)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickPhysicalCrit)
 			},
 		},
 


### PR DESCRIPTION
explosive shot can partial resist so removed that flag

the dot ticks are currently rolling off of spell crit instead of phys crit, snapshot dot is not letting me use phys crit for a spellschoolfire so I am cheating and using the non snapshot version of crit for each tick. if the desired behavior is to change snapshot crit to check defensetype instead of spellschool i can do that instead