### PR TITLE
Ravagane fixes

### DIFF
--- a/sim/common/sod/item_effects/phase_8.go
+++ b/sim/common/sod/item_effects/phase_8.go
@@ -754,7 +754,7 @@ func init() {
 			SpellSchool: core.SpellSchoolPhysical,
 			DefenseType: core.DefenseTypeMelee,
 			ProcMask:    core.ProcMaskMeleeMHSpecial,
-			Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell | core.SpellFlagSuppressEquipProcs,
+			Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
@@ -793,6 +793,21 @@ func init() {
 				Duration: time.Second * 8,
 			},
 			OnGain: func(aura *core.Aura, sim *core.Simulation) {
+				if !aura.Icd.IsReady(sim) {
+					return
+				}
+				aura.Icd.Use(sim)
+
+				character.AutoAttacks.CancelAutoSwing(sim)
+				whirlwindSpell.AOEDot().Apply(sim)
+			},
+			OnRefresh: func(aura *core.Aura, sim *core.Simulation) {
+				if !aura.Icd.IsReady(sim) {
+					return
+				}
+				aura.Icd.Use(sim)
+
+				whirlwindSpell.AOEDot().Cancel(sim)
 				character.AutoAttacks.CancelAutoSwing(sim)
 				whirlwindSpell.AOEDot().Apply(sim)
 			},

--- a/sim/common/sod/item_effects/phase_8.go
+++ b/sim/common/sod/item_effects/phase_8.go
@@ -754,7 +754,7 @@ func init() {
 			SpellSchool: core.SpellSchoolPhysical,
 			DefenseType: core.DefenseTypeMelee,
 			ProcMask:    core.ProcMaskMeleeMHSpecial,
-			Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
+			Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell | core.SpellFlagSuppressEquipProcs,
 
 			DamageMultiplier: 1,
 			ThreatMultiplier: 1,
@@ -772,13 +772,12 @@ func init() {
 			ActionID:    core.ActionID{SpellID: 1231547},
 			SpellSchool: core.SpellSchoolPhysical,
 			ProcMask:    core.ProcMaskMeleeMHSpecial,
-			Flags:       core.SpellFlagChanneled,
 			Dot: core.DotConfig{
 				Aura: core.Aura{
 					Label: "Ravagane Whirlwind",
 				},
-				NumberOfTicks: 3,
-				TickLength:    time.Second * 3,
+				NumberOfTicks: 6,
+				TickLength:    time.Millisecond * 1500,
 				IsAOE:         true,
 				OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 					tickSpell.Cast(sim, target)
@@ -795,7 +794,6 @@ func init() {
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 				character.AutoAttacks.EnableAutoSwing(sim)
-				channelSpell.AOEDot().Cancel(sim)
 			},
 		})
 	})

--- a/sim/common/sod/item_effects/phase_8.go
+++ b/sim/common/sod/item_effects/phase_8.go
@@ -768,7 +768,7 @@ func init() {
 			},
 		})
 
-		channelSpell := character.RegisterSpell(core.SpellConfig{
+		whirlwindSpell := character.RegisterSpell(core.SpellConfig{
 			ActionID:    core.ActionID{SpellID: 1231547},
 			SpellSchool: core.SpellSchoolPhysical,
 			ProcMask:    core.ProcMaskMeleeMHSpecial,
@@ -788,12 +788,17 @@ func init() {
 		return character.RegisterAura(core.Aura{
 			Label:    "Ravagane Bladestorm",
 			Duration: time.Second * 9,
+			Icd: &core.Cooldown{
+				Timer:    character.NewTimer(),
+				Duration: time.Second * 8,
+			},
 			OnGain: func(aura *core.Aura, sim *core.Simulation) {
 				character.AutoAttacks.CancelAutoSwing(sim)
-				channelSpell.AOEDot().Apply(sim)
+				whirlwindSpell.AOEDot().Apply(sim)
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 				character.AutoAttacks.EnableAutoSwing(sim)
+				whirlwindSpell.AOEDot().Cancel(sim)
 			},
 		})
 	})

--- a/sim/common/sod/item_effects/phase_8.go
+++ b/sim/common/sod/item_effects/phase_8.go
@@ -798,8 +798,8 @@ func init() {
 				}
 				aura.Icd.Use(sim)
 
-				character.AutoAttacks.CancelAutoSwing(sim)
 				whirlwindSpell.AOEDot().Apply(sim)
+				character.AutoAttacks.CancelAutoSwing(sim)
 			},
 			OnRefresh: func(aura *core.Aura, sim *core.Simulation) {
 				if !aura.Icd.IsReady(sim) {
@@ -807,13 +807,12 @@ func init() {
 				}
 				aura.Icd.Use(sim)
 
-				whirlwindSpell.AOEDot().Cancel(sim)
+				whirlwindSpell.AOEDot().ApplyOrReset(sim)
 				character.AutoAttacks.CancelAutoSwing(sim)
-				whirlwindSpell.AOEDot().Apply(sim)
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-				character.AutoAttacks.EnableAutoSwing(sim)
 				whirlwindSpell.AOEDot().Cancel(sim)
+				character.AutoAttacks.EnableAutoSwing(sim)
 			},
 		})
 	})

--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -160,8 +160,11 @@ func (dot *Dot) ApplyOrReset(sim *Simulation) {
 	dot.TickCount = 0
 
 	oldTickAction := dot.tickAction
-	dot.tickAction = nil      // prevent tickAction.CleanUp() from adding an extra tick
-	oldTickAction.Cancel(sim) // remove old PA ticker
+	dot.tickAction = nil // prevent tickAction.CleanUp() from adding an extra tick
+
+	if oldTickAction != nil {
+		oldTickAction.Cancel(sim)
+	}
 
 	// recreate with new period, resetting the next tick.
 	periodicOptions := dot.basePeriodicOptions()


### PR DESCRIPTION
[Logs](https://sod.warcraftlogs.com/reports/GZ6DKxjVQcHB7nad?fight=last&type=damage-done&source=1) confirm:
- 9 second buff duration, AoE every 1.5 seconds (First tick is 1.5 seconds after buff is obtained)
- Can use abilities during it
- Can proc Weapon Enchants (03:12.533 Bladestorm hit, 03:12.533 Righteous Inquisition Refresh, no other hits)
- Can proc itself on last Bladestorm tick after 8 sec ICD (03:12.533 Bladestorm hit, 03:12.532 Bladestorm Buff is removed and Applied)
- If Bladestorm buff is refreshed while active, the next tick is still 1.5 seconds after refresh (03:03.525 Bladestorm is refreshed, 03:02.437 -> 03:05.084 for next Bladestorm tick)
- Can store + proc extra attacks (00:34.322 Bladestorm fades, 0.34.953 Double Melee removing 2 Wild Strike stacks), maybe there is retry timer? Need to also set max stored attacks for Hunter at 2.

There is currently a bug with this implementation where sometimes AutoAttack does not turn back on after Bladestorm fades. Not sure where it is.
