### PR TITLE
Update Mirage, Rod of Illusion proc to 30s

### DIFF
--- a/sim/common/sod/item_effects/phase_8.go
+++ b/sim/common/sod/item_effects/phase_8.go
@@ -665,7 +665,7 @@ func init() {
 				Aura: core.Aura{
 					Label: "Mirage",
 				},
-				NumberOfTicks: 10,
+				NumberOfTicks: 20,
 				TickLength:    core.GCDDefault,
 				OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 					explosionSpell.Cast(sim, target)


### PR DESCRIPTION
Update number of ticks to 20 from 10, 1.5 each. The proc lasts for 30 seconds in the game - as proven both by logs & the item tooltip.