### PR TITLE
Add missing poison procs to Poisoned Knife

### DIFF
--- a/sim/rogue/poisoned_knife.go
+++ b/sim/rogue/poisoned_knife.go
@@ -81,6 +81,10 @@ func (rogue *Rogue) registerPoisonedKnife() {
 					rogue.OccultPoison[ShivProc].Cast(sim, target)
 				case proto.WeaponImbue_SebaciousPoison:
 					rogue.SebaciousPoison[ShivProc].Cast(sim, target)
+				case proto.WeaponImbue_AtrophicPoison:
+					rogue.AtrophicPoison[ShivProc].Cast(sim, target)
+				case proto.WeaponImbue_NumbingPoison:
+					rogue.NumbingPoison[ShivProc].Cast(sim, target)
 				// Add new alternative poisons as they are implemented
 				default:
 					if hasDeadlyBrew {

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -319,11 +319,26 @@ export class ActionId {
 			case 'Wound Poison':
 			case 'Occult Poison II':
 				if (this.tag === 1) {
-					name += ' (Shiv)';
+					name += ' (Poisoned Knife)';
 				} else if (this.tag === 2) {
 					name += ' (Deadly Brew)';
 				} else if (this.tag === 100) {
 					name += ' (Tick)';
+				}
+				break;
+			case 'Sebacious Poison':
+				if (this.tag === 1) {
+					name += ' (Poisoned Knife)';
+				}
+				break;
+			case 'Atrophic Poison':
+				if (this.tag === 1) {
+					name += ' (Poisoned Knife)';
+				}
+				break;
+			case 'Numbing Poison':
+				if (this.tag === 1) {
+					name += ' (Poisoned Knife)';
 				}
 				break;
 			case 'Saber Slash':

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -317,6 +317,9 @@ export class ActionId {
 			case 'Instant Poison V':
 			case 'Instant Poison VI':
 			case 'Wound Poison':
+			case 'Sebacious Poison':
+			case 'Atrophic Poison':
+			case 'Numbing Poison':
 			case 'Occult Poison II':
 				if (this.tag === 1) {
 					name += ' (Poisoned Knife)';
@@ -324,21 +327,6 @@ export class ActionId {
 					name += ' (Deadly Brew)';
 				} else if (this.tag === 100) {
 					name += ' (Tick)';
-				}
-				break;
-			case 'Sebacious Poison':
-				if (this.tag === 1) {
-					name += ' (Poisoned Knife)';
-				}
-				break;
-			case 'Atrophic Poison':
-				if (this.tag === 1) {
-					name += ' (Poisoned Knife)';
-				}
-				break;
-			case 'Numbing Poison':
-				if (this.tag === 1) {
-					name += ' (Poisoned Knife)';
 				}
 				break;
 			case 'Saber Slash':


### PR DESCRIPTION
Implement missing Poisoned Knife application trigger for the following poisons
- Atrophic Poison
- Numbing Poison

Useful for the new t4 2p set bonus.

Timeline before:
![image](https://github.com/user-attachments/assets/ff018e56-d485-4d21-a2e9-4dc3f87b5090)

Timeline after: 
![image](https://github.com/user-attachments/assets/df5fb27b-4a49-4e4c-aaa1-6d72bf96cdb8)

