### PR TITLE
Add TMI EP and COD EP columns to stat weights for tank specs

### DIFF
--- a/ui/core/components/stat_weights_action.ts
+++ b/ui/core/components/stat_weights_action.ts
@@ -178,7 +178,7 @@ class EpWeightsMenu extends BaseModal {
 				</div>
 				<div class="show-all-stats-container col col-sm-3"></div>
 			</div>
-			<div class="ep-reference-options row experimental">
+			<div class="ep-reference-options row">
 				<div class="col col-sm-4 damage-metrics">
 					<span>DPS/TPS reference:</span>
 					<select class="ref-stat-select form-select damage-metrics">
@@ -253,25 +253,25 @@ class EpWeightsMenu extends BaseModal {
 									<i class="fa fa-copy"></i>
 								</a>
 							</th>
-							<th class="threat-metrics type-weight experimental">
+							<th class="threat-metrics type-weight">
 								<span>TMI Weight</span>
 								<a href="javascript:void(0)" role="button" class="col-action">
 									<i class="fa fa-copy"></i>
 								</a>
 							</th>
-							<th class="threat-metrics type-ep experimental">
+							<th class="threat-metrics type-ep">
 								<span>TMI EP</span>
 								<a href="javascript:void(0)" role="button" class="col-action">
 									<i class="fa fa-copy"></i>
 								</a>
 							</th>
-							<th class="threat-metrics type-weight experimental">
+							<th class="threat-metrics type-weight">
 								<span>Death Weight</span>
 								<a href="javascript:void(0)" role="button" class="col-action">
 									<i class="fa fa-copy"></i>
 								</a>
 							</th>
-							<th class="threat-metrics type-ep experimental">
+							<th class="threat-metrics type-ep">
 								<span>Death EP</span>
 								<a href="javascript:void(0)" role="button" class="col-action">
 									<i class="fa fa-copy"></i>
@@ -303,13 +303,13 @@ class EpWeightsMenu extends BaseModal {
 							</td>
 							<td class="threat-metrics type-ratio type-ep">
 							</td>
-							<td class="threat-metrics type-ratio type-weight experimental">
+							<td class="threat-metrics type-ratio type-weight">
 							</td>
-							<td class="threat-metrics type-ratio type-ep experimental">
+							<td class="threat-metrics type-ratio type-ep">
 							</td>
-							<td class="threat-metrics type-ratio type-weight experimental">
+							<td class="threat-metrics type-ratio type-weight">
 							</td>
-							<td class="threat-metrics type-ratio type-ep experimental">
+							<td class="threat-metrics type-ratio type-ep">
 							</td>
 							<td style="text-align: center; vertical-align: middle;">
 								<button class="btn btn-primary compute-ep">
@@ -720,8 +720,8 @@ class EpWeightsMenu extends BaseModal {
 			${this.makeTableRowCells(stat, result?.hps, 'healing-metrics', rowTotalEp, epRatios[1])}
 			${this.makeTableRowCells(stat, result?.tps, 'threat-metrics', rowTotalEp, epRatios[2])}
 			${this.makeTableRowCells(stat, result?.dtps, 'threat-metrics', rowTotalEp, epRatios[3])}
-			${this.makeTableRowCells(stat, result?.tmi, 'threat-metrics experimental', rowTotalEp, epRatios[4])}
-			${this.makeTableRowCells(stat, result?.pDeath, 'threat-metrics experimental', rowTotalEp, epRatios[5])}
+			${this.makeTableRowCells(stat, result?.tmi, 'threat-metrics', rowTotalEp, epRatios[4])}
+			${this.makeTableRowCells(stat, result?.pDeath, 'threat-metrics', rowTotalEp, epRatios[5])}
 			<td class="current-ep"></td>
 		`;
 

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -460,8 +460,10 @@ export class Player<SpecType extends Spec> {
 			defaultRatios[1] = 1;
 		} else if (isTankSpec) {
 			// By default value TPS and DTPS EP equally for tanking spec
-			defaultRatios[2] = 1;
-			defaultRatios[3] = 1;
+			defaultRatios[2] = 1; // TPS
+			defaultRatios[3] = 1; // DTPS
+			defaultRatios[4] = 0; // TMI
+			defaultRatios[5] = 0; // COD
 		} else {
 			// By default only value DPS EP
 			defaultRatios[0] = 1;

--- a/ui/scss/core/components/_stat_weights_action.scss
+++ b/ui/scss/core/components/_stat_weights_action.scss
@@ -194,20 +194,18 @@
 		}
 	}
 
-	// Style overrides for the expanded/experimental EP UI in tank mode
-	&:not(.hide-experimental) {
-		@include media-breakpoint-down(lg) {
-			@include compact-button;
-			@include compact-table;
-			.results-ep-table {
-				@include compact-input;
-			}
+	// Apply compact styles when there are many columns shown
+	@include media-breakpoint-down(lg) {
+		@include compact-button;
+		@include compact-table;
+		.results-ep-table {
+			@include compact-input;
 		}
-		@include media-breakpoint-only(lg) {
-			.results-ep-table {
-				th {
-					padding-right: 0;
-				}
+	}
+	@include media-breakpoint-only(lg) {
+		.results-ep-table {
+			th {
+				padding-right: 0;
 			}
 		}
 	}


### PR DESCRIPTION
# Add TMI EP and COD EP columns to stat weights for tank specs

This PR adds TMI EP (Theck-Meloree Index) and COD EP (Chance of Death) columns to the stat weights UI for tank specs, similar to how DTPS EP is currently displayed and used.

## Changes
1. Removed the "experimental" class from TMI and COD EP columns to make them visible by default
2. Updated the CSS to handle the columns being shown by default
3. Updated the default epRatios for tank specs to include TMI and COD EP ratios (set to 0 by default)
4. Made the EP reference options row visible by default

## Benefits
These changes allow tank players to evaluate their gear based on different survivability metrics beyond just DTPS. While the default ratios are set to 0 (meaning they don't affect calculations by default), users can manually adjust these ratios if they want to include TMI and COD in their stat weight calculations.

## Note
This change was generated with the assistance of Cursor AI and may require further review to ensure it meets code quality standards and correctly implements the desired functionality.